### PR TITLE
Show decimal months in Financial Runway card

### DIFF
--- a/frontend/src/components/dashboard/cards/financial-runway-card.tsx
+++ b/frontend/src/components/dashboard/cards/financial-runway-card.tsx
@@ -60,7 +60,7 @@ export function FinancialRunwayCard() {
         const monthlyExpenses = period === 'quarter' ? expenses / 3 : expenses;
         const runwayMonths =
           monthlyExpenses > 0
-            ? Math.floor(totalBalance / monthlyExpenses)
+            ? Math.round((totalBalance / monthlyExpenses) * 10) / 10
             : 0;
         const netSaved = income - expenses;
         const savingsRate = income > 0 ? Math.round((netSaved / income) * 100) : 0;
@@ -97,12 +97,12 @@ export function FinancialRunwayCard() {
                 <p className="text-sm font-semibold text-slate-500">{t('title')}</p>
                 <div className="mt-2 flex items-baseline gap-3">
                   <p className="font-[var(--font-dash-mono)] text-5xl font-semibold tracking-[-0.02em] text-slate-900 sm:text-[3.2rem]">
-                    {data.runwayMonths}
+                    {data.runwayMonths === 0 ? '0' : data.runwayMonths.toFixed(1)}
                   </p>
                   <p className="text-xl font-medium text-slate-400">{t('months')}</p>
                 </div>
                 <p className="mt-1.5 max-w-sm text-[15px] leading-relaxed text-slate-500">
-                  {t('description', { months: data.runwayMonths })}
+                  {t('description', { months: data.runwayMonths === 0 ? '0' : data.runwayMonths.toFixed(1) })}
                 </p>
               </div>
               {/* Inline period toggle */}


### PR DESCRIPTION
## Summary
Show fractional months (1 decimal place) instead of integer in the Financial Runway dashboard card.

**Before:** Users see '0 months' until they accumulate a full month of savings — discouraging.
**After:** Users see '0.7 months' etc., giving visible progress even with partial savings.

## Changes
- `Math.floor()` → `Math.round(x * 10) / 10` for 1 decimal precision
- Display uses `toFixed(1)` for non-zero values, clean '0' for zero
- Description text also shows decimal value
- Progress bar unaffected (already used raw ratio)

Co-Authored-By: Claude Opus 4.5 <noreply@anthropic.com>