### PR TITLE
UI refinements: transaction details hero + button consistency

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -223,3 +223,4 @@ saas-beta-checklist.md
 to-localize.md
 # Agent swarm
 .clawdbot/
+src/qemu_dotnet_20260224-224113_1.core

--- a/frontend/src/app/transactions/[id]/page.tsx
+++ b/frontend/src/app/transactions/[id]/page.tsx
@@ -261,10 +261,6 @@ export default function TransactionDetailsPage() {
         <TransactionBackButton />
 
         <div className="flex items-center gap-2">
-          <EditTransactionButton
-            transactionId={transaction.id.toString()}
-            onSuccess={loadTransaction}
-          />
           <Button
             variant="secondary"
             size="sm"
@@ -274,6 +270,12 @@ export default function TransactionDetailsPage() {
             <TrashIcon className="w-4 h-4" />
             <span className="hidden sm:inline">{t('deleteTransaction')}</span>
           </Button>
+          <EditTransactionButton
+            transactionId={transaction.id.toString()}
+            onSuccess={loadTransaction}
+            variant="secondary"
+            size="sm"
+          />
         </div>
       </header>
 

--- a/frontend/src/components/buttons/edit-transaction-button.tsx
+++ b/frontend/src/components/buttons/edit-transaction-button.tsx
@@ -12,13 +12,17 @@ interface EditTransactionButtonProps {
   onSuccess?: () => void;
   className?: string;
   children?: React.ReactNode;
+  variant?: 'primary' | 'secondary' | 'danger' | 'ghost' | 'outline';
+  size?: 'sm' | 'md' | 'lg' | 'icon';
 }
 
 export function EditTransactionButton({ 
   transactionId, 
   onSuccess,
   className = '',
-  children
+  children,
+  variant,
+  size,
 }: EditTransactionButtonProps) {
   const [showModal, setShowModal] = useState(false);
   const { isMobile } = useDeviceDetect();
@@ -45,6 +49,8 @@ export function EditTransactionButton({
     <>
       <Button 
         onClick={handleClick}
+        variant={variant}
+        size={size}
         className={className}
       >
         <PencilIcon className="w-5 h-5 mr-2" />


### PR DESCRIPTION
Follow-up to #32. Minor refinements:

- Simplified Transaction Details hero (removed icon square, better spacing)
- Delete button on left, Edit on right (consistent with Account Details page)
- EditTransactionButton now accepts variant/size props
- Edit Transaction rendered as secondary button (not primary)