### PR TITLE
style: modernize auth & onboarding pages

### DIFF
--- a/frontend/src/app/auth/forgot-password/page.tsx
+++ b/frontend/src/app/auth/forgot-password/page.tsx
@@ -3,6 +3,8 @@
 import { useState } from 'react';
 import Link from 'next/link';
 import { Card, CardContent } from '@/components/ui/card';
+import { Input } from '@/components/ui/input';
+import { Button } from '@/components/ui/button';
 import { EnvelopeIcon, CheckCircleIcon, ExclamationCircleIcon } from '@heroicons/react/24/outline';
 import { AppIcon } from '@/components/app-icon';
 import { apiClient } from '@/lib/api-client';
@@ -40,7 +42,7 @@ export default function ForgotPasswordPage() {
   // Success state after submission
   if (isSubmitted) {
     return (
-      <div className="min-h-screen bg-gradient-to-br from-primary-100 via-purple-50 to-primary-200 flex items-center justify-center py-12 px-4 sm:px-6 lg:px-8">
+      <div className="min-h-screen bg-gradient-to-br from-primary-50 to-primary-100 flex items-center justify-center py-12 px-4 sm:px-6 lg:px-8">
         <div className="max-w-md w-full space-y-8">
           <div className="text-center">
             <div className="flex justify-center mb-6">
@@ -48,7 +50,7 @@ export default function ForgotPasswordPage() {
                 <CheckCircleIcon className="w-12 h-12 text-white" />
               </div>
             </div>
-            <h2 className="text-h1 text-gray-900">{t('checkYourEmail')}</h2>
+            <h2 className="text-h1 text-slate-900">{t('checkYourEmail')}</h2>
           </div>
 
           <Card>
@@ -58,31 +60,32 @@ export default function ForgotPasswordPage() {
                   <EnvelopeIcon className="w-8 h-8 text-green-600" />
                 </div>
 
-                <p className="text-gray-700">
+                <p className="text-slate-700">
                   {t('forgotPasswordSentDescription')}
                 </p>
 
-                <p className="text-sm text-gray-500">
+                <p className="text-sm text-slate-500">
                   {t('forgotPasswordSpamNote')}
                 </p>
 
                 <div className="pt-4 space-y-3">
                   <Link
                     href="/auth/login"
-                    className="inline-block w-full px-4 py-2 bg-primary text-white rounded-lg hover:bg-primary-600 transition-colors text-center"
+                    className="btn btn-primary w-full justify-center"
                   >
                     {t('backToSignIn')}
                   </Link>
 
-                  <button
+                  <Button
+                    variant="outline"
+                    className="w-full"
                     onClick={() => {
                       setIsSubmitted(false);
                       setEmail('');
                     }}
-                    className="inline-block w-full px-4 py-2 border border-gray-300 text-gray-700 rounded-lg hover:bg-gray-50 transition-colors"
                   >
                     {t('tryDifferentEmail')}
-                  </button>
+                  </Button>
                 </div>
               </div>
             </CardContent>
@@ -94,7 +97,7 @@ export default function ForgotPasswordPage() {
 
   // Initial form state
   return (
-    <div className="min-h-screen bg-gradient-to-br from-primary-100 via-purple-50 to-primary-200 flex items-center justify-center py-12 px-4 sm:px-6 lg:px-8">
+    <div className="min-h-screen bg-gradient-to-br from-primary-50 to-primary-100 flex items-center justify-center py-12 px-4 sm:px-6 lg:px-8">
       <div className="max-w-md w-full space-y-8">
         <div className="text-center">
           <div className="flex justify-center mb-6">
@@ -102,8 +105,8 @@ export default function ForgotPasswordPage() {
               <AppIcon size={80} />
             </div>
           </div>
-          <h2 className="text-h1 text-gray-900">{t('forgotPassword')}</h2>
-          <p className="mt-2 text-gray-600">
+          <h2 className="text-h1 text-slate-900">{t('forgotPassword')}</h2>
+          <p className="mt-2 text-slate-600">
             {t('forgotPasswordHelper')}
           </p>
         </div>
@@ -112,46 +115,32 @@ export default function ForgotPasswordPage() {
           <CardContent className="p-8">
             <form onSubmit={handleSubmit} className="space-y-6">
               {error && (
-                <div className="bg-red-50 border border-red-200 rounded-lg p-4 flex items-start gap-3">
-                  <ExclamationCircleIcon className="w-5 h-5 text-red-500 flex-shrink-0 mt-0.5" />
-                  <p className="text-sm text-red-700">{error}</p>
+                <div className="bg-danger-50 border border-danger-200 rounded-card p-4 flex items-start gap-3">
+                  <ExclamationCircleIcon className="w-5 h-5 text-danger-500 flex-shrink-0 mt-0.5" />
+                  <p className="text-sm text-danger-700">{error}</p>
                 </div>
               )}
 
-              <div>
-                <label htmlFor="email" className="block text-sm font-medium text-gray-700 mb-1">
-                  {t('email')}
-                </label>
-                <input
-                  id="email"
-                  name="email"
-                  type="email"
-                  autoComplete="email"
-                  required
-                  value={email}
-                  onChange={(e) => setEmail(e.target.value)}
-                  className="w-full px-4 py-2 border border-gray-300 rounded-lg focus:ring-2 focus:ring-primary focus:border-transparent"
-                  placeholder={t('emailExample')}
-                />
-              </div>
+              <Input
+                id="email"
+                name="email"
+                type="email"
+                autoComplete="email"
+                required
+                value={email}
+                onChange={(e) => setEmail(e.target.value)}
+                label={t('email')}
+                placeholder={t('emailExample')}
+              />
 
-              <button
+              <Button
                 type="submit"
+                className="w-full"
+                loading={isLoading}
                 disabled={isLoading || !email}
-                className="w-full px-4 py-2 bg-primary text-white rounded-lg hover:bg-primary-600 transition-colors disabled:opacity-50 disabled:cursor-not-allowed flex items-center justify-center"
               >
-                {isLoading ? (
-                  <>
-                    <svg className="animate-spin -ml-1 mr-3 h-5 w-5 text-white" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24">
-                      <circle className="opacity-25" cx="12" cy="12" r="10" stroke="currentColor" strokeWidth="4"></circle>
-                      <path className="opacity-75" fill="currentColor" d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4zm2 5.291A7.962 7.962 0 014 12H0c0 3.042 1.135 5.824 3 7.938l3-2.647z"></path>
-                    </svg>
-                    {t('sending')}
-                  </>
-                ) : (
-                  t('sendResetLink')
-                )}
-              </button>
+                {t('sendResetLink')}
+              </Button>
 
               <div className="text-center">
                 <Link

--- a/frontend/src/app/auth/login/page.tsx
+++ b/frontend/src/app/auth/login/page.tsx
@@ -135,10 +135,10 @@ export default function LoginPage() {
               <AppIcon size={80} />
             </div>
           </div>
-          <h2 className="text-h1 text-gray-900">
+          <h2 className="text-h1 text-slate-900">
             {t('signInTitle')}
           </h2>
-          <p className="mt-2 text-gray-600">
+          <p className="mt-2 text-slate-600">
             {t('signInSubtitle')}
           </p>
         </div>
@@ -230,9 +230,9 @@ export default function LoginPage() {
                     type="checkbox"
                     checked={formData.rememberMe}
                     onChange={handleInputChange}
-                    className="h-4 w-4 text-primary border-gray-300 rounded-sm focus:ring-primary"
+                    className="h-4 w-4 text-primary border-slate-300 rounded-sm focus:ring-primary"
                   />
-                  <label htmlFor="rememberMe" className="ml-2 block text-sm text-gray-900">
+                  <label htmlFor="rememberMe" className="ml-2 block text-sm text-slate-700">
                     {t('rememberMe')}
                   </label>
                 </div>
@@ -257,10 +257,10 @@ export default function LoginPage() {
                 <>
                   <div className="relative">
                     <div className="absolute inset-0 flex items-center">
-                      <div className="w-full border-t border-gray-300"></div>
+                      <div className="w-full border-t border-slate-200"></div>
                     </div>
                     <div className="relative flex justify-center text-sm">
-                      <span className="px-2 bg-white text-gray-500">{t('orContinueWith')}</span>
+                      <span className="px-2 bg-white text-slate-500">{t('orContinueWith')}</span>
                     </div>
                   </div>
 
@@ -271,7 +271,7 @@ export default function LoginPage() {
               )}
 
               <div className="text-center">
-                <span className="text-sm text-gray-600">
+                <span className="text-sm text-slate-600">
                   {t('noAccount')}{' '}
                   <Link href="/auth/register" className="font-medium text-primary hover:text-primary-600">
                     {t('signUp')}
@@ -282,10 +282,10 @@ export default function LoginPage() {
           </CardContent>
         </Card>
 
-        <div className="text-center text-xs text-gray-500">
-          <Link href="/terms" className="hover:text-gray-700 underline">{t('termsLink')}</Link>
+        <div className="text-center text-xs text-slate-500">
+          <Link href="/terms" className="hover:text-slate-700 underline">{t('termsLink')}</Link>
           {' · '}
-          <Link href="/privacy" className="hover:text-gray-700 underline">{t('privacyLink')}</Link>
+          <Link href="/privacy" className="hover:text-slate-700 underline">{t('privacyLink')}</Link>
         </div>
       </div>
     </div>

--- a/frontend/src/app/auth/register/page.tsx
+++ b/frontend/src/app/auth/register/page.tsx
@@ -187,7 +187,7 @@ export default function RegisterPage() {
   // Show verification email sent success screen
   if (verificationSent) {
     return (
-      <div className="min-h-screen bg-gradient-to-br from-primary-100 via-purple-50 to-primary-200 flex items-center justify-center py-12 px-4 sm:px-6 lg:px-8">
+      <div className="min-h-screen bg-gradient-to-br from-primary-50 to-primary-100 flex items-center justify-center py-12 px-4 sm:px-6 lg:px-8">
         <div className="max-w-md w-full space-y-8">
           <div className="text-center">
             <div className="flex justify-center mb-6">
@@ -203,19 +203,19 @@ export default function RegisterPage() {
                 <div className="w-16 h-16 bg-gradient-to-br from-green-500 to-green-700 rounded-2xl shadow-2xl flex items-center justify-center mx-auto mb-6">
                   <CheckCircleIcon className="w-8 h-8 text-white" />
                 </div>
-                <h2 className="text-2xl font-bold text-gray-900 mb-2">
+                <h2 className="text-2xl font-bold text-slate-900 mb-2">
                   {tVerify('registrationSuccess')}
                 </h2>
-                <p className="text-gray-600 mb-4">
+                <p className="text-slate-600 mb-4">
                   {tVerify('checkEmailMessage')}
                 </p>
-                <div className="bg-gray-50 rounded-lg p-4 mb-6">
-                  <div className="flex items-center justify-center gap-2 text-gray-700">
+                <div className="bg-slate-50 rounded-lg p-4 mb-6">
+                  <div className="flex items-center justify-center gap-2 text-slate-700">
                     <EnvelopeIcon className="w-5 h-5" />
                     <span className="font-medium">{registeredEmail}</span>
                   </div>
                 </div>
-                <p className="text-sm text-gray-500 mb-6">
+                <p className="text-sm text-slate-500 mb-6">
                   {tVerify('checkSpamFolder')}
                 </p>
                 <Link
@@ -233,7 +233,7 @@ export default function RegisterPage() {
   }
 
   return (
-    <div className="min-h-screen bg-gradient-to-br from-primary-100 via-purple-50 to-primary-200 flex items-center justify-center py-12 px-4 sm:px-6 lg:px-8">
+    <div className="min-h-screen bg-gradient-to-br from-primary-50 to-primary-100 flex items-center justify-center py-12 px-4 sm:px-6 lg:px-8">
       <div className="max-w-md w-full space-y-8">
         <div className="text-center">
           <div className="flex justify-center mb-6">
@@ -241,10 +241,10 @@ export default function RegisterPage() {
               <AppIcon size={80} />
             </div>
           </div>
-          <h2 className="text-h1 text-gray-900">
+          <h2 className="text-h1 text-slate-900">
             {t('signUpTitle')}
           </h2>
-          <p className="mt-2 text-gray-600">
+          <p className="mt-2 text-slate-600">
             {t('signUpSubtitle')}
           </p>
         </div>
@@ -351,9 +351,9 @@ export default function RegisterPage() {
                         });
                       }
                     }}
-                    className="h-4 w-4 mt-0.5 text-primary border-gray-300 rounded-sm focus:ring-primary"
+                    className="h-4 w-4 mt-0.5 text-primary border-slate-200 rounded-sm focus:ring-primary"
                   />
-                  <span className="text-sm text-gray-600">
+                  <span className="text-sm text-slate-600">
                     {t.rich('acceptTerms', {
                       terms: (chunks) => (
                         <Link href="/terms" className="font-medium text-primary hover:text-primary-600 underline" target="_blank">
@@ -386,10 +386,10 @@ export default function RegisterPage() {
                 <>
                   <div className="relative">
                     <div className="absolute inset-0 flex items-center">
-                      <div className="w-full border-t border-gray-300"></div>
+                      <div className="w-full border-t border-slate-200"></div>
                     </div>
                     <div className="relative flex justify-center text-sm">
-                      <span className="px-2 bg-white text-gray-500">{t('orContinueWith')}</span>
+                      <span className="px-2 bg-white text-slate-500">{t('orContinueWith')}</span>
                     </div>
                   </div>
 
@@ -401,7 +401,7 @@ export default function RegisterPage() {
               )}
 
               <div className="text-center">
-                <span className="text-sm text-gray-600">
+                <span className="text-sm text-slate-600">
                   {t('hasAccount')}{' '}
                   <Link href="/auth/login" className="font-medium text-primary hover:text-primary-600">
                     {t('signIn')}
@@ -412,10 +412,10 @@ export default function RegisterPage() {
           </CardContent>
         </Card>
 
-        <div className="text-center text-xs text-gray-500">
-          <Link href="/terms" className="hover:text-gray-700 underline">{t('termsLink')}</Link>
+        <div className="text-center text-xs text-slate-500">
+          <Link href="/terms" className="hover:text-slate-700 underline">{t('termsLink')}</Link>
           {' · '}
-          <Link href="/privacy" className="hover:text-gray-700 underline">{t('privacyLink')}</Link>
+          <Link href="/privacy" className="hover:text-slate-700 underline">{t('privacyLink')}</Link>
         </div>
       </div>
     </div>

--- a/frontend/src/app/auth/reset-password/page.tsx
+++ b/frontend/src/app/auth/reset-password/page.tsx
@@ -4,10 +4,12 @@ import { useState, useEffect, Suspense } from 'react';
 import { useSearchParams } from 'next/navigation';
 import Link from 'next/link';
 import { Card, CardContent } from '@/components/ui/card';
+import { Button } from '@/components/ui/button';
 import { CheckCircleIcon, ExclamationCircleIcon, EyeIcon, EyeSlashIcon, XCircleIcon } from '@heroicons/react/24/outline';
 import { AppIcon } from '@/components/app-icon';
 import { apiClient } from '@/lib/api-client';
 import { useTranslations } from 'next-intl';
+import { cn } from '@/lib/utils';
 
 function ResetPasswordForm() {
   const searchParams = useSearchParams();
@@ -112,7 +114,7 @@ function ResetPasswordForm() {
   // Success state
   if (isSuccess) {
     return (
-      <div className="min-h-screen bg-gradient-to-br from-primary-100 via-purple-50 to-primary-200 flex items-center justify-center py-12 px-4 sm:px-6 lg:px-8">
+      <div className="min-h-screen bg-gradient-to-br from-primary-50 to-primary-100 flex items-center justify-center py-12 px-4 sm:px-6 lg:px-8">
         <div className="max-w-md w-full space-y-8">
           <div className="text-center">
             <div className="flex justify-center mb-6">
@@ -120,24 +122,24 @@ function ResetPasswordForm() {
                 <CheckCircleIcon className="w-12 h-12 text-white" />
               </div>
             </div>
-            <h2 className="text-h1 text-gray-900">{t('passwordResetSuccessTitle')}</h2>
+            <h2 className="text-h1 text-slate-900">{t('passwordResetSuccessTitle')}</h2>
           </div>
 
           <Card>
             <CardContent className="p-8">
               <div className="text-center space-y-4">
-                <p className="text-gray-700">
+                <p className="text-slate-700">
                   {t('passwordResetSuccessDescription')}
                 </p>
 
-                <p className="text-sm text-gray-500">
+                <p className="text-sm text-slate-500">
                   {t('passwordResetSecurityNote')}
                 </p>
 
                 <div className="pt-4">
                   <Link
                     href="/auth/login"
-                    className="inline-block w-full px-4 py-2 bg-primary text-white rounded-lg hover:bg-primary-600 transition-colors text-center"
+                    className="btn btn-primary w-full justify-center"
                   >
                     {t('signInNow')}
                   </Link>
@@ -153,7 +155,7 @@ function ResetPasswordForm() {
   // Missing token/email state
   if (!formData.token || !formData.email) {
     return (
-      <div className="min-h-screen bg-gradient-to-br from-primary-100 via-purple-50 to-primary-200 flex items-center justify-center py-12 px-4 sm:px-6 lg:px-8">
+      <div className="min-h-screen bg-gradient-to-br from-primary-50 to-primary-100 flex items-center justify-center py-12 px-4 sm:px-6 lg:px-8">
         <div className="max-w-md w-full space-y-8">
           <div className="text-center">
             <div className="flex justify-center mb-6">
@@ -161,27 +163,27 @@ function ResetPasswordForm() {
                 <XCircleIcon className="w-12 h-12 text-white" />
               </div>
             </div>
-            <h2 className="text-h1 text-gray-900">{t('invalidResetLinkTitle')}</h2>
+            <h2 className="text-h1 text-slate-900">{t('invalidResetLinkTitle')}</h2>
           </div>
 
           <Card>
             <CardContent className="p-8">
               <div className="text-center space-y-4">
-                <p className="text-gray-700">
+                <p className="text-slate-700">
                   {t('invalidResetLinkDescription')}
                 </p>
 
                 <div className="pt-4 space-y-3">
                   <Link
                     href="/auth/forgot-password"
-                    className="inline-block w-full px-4 py-2 bg-primary text-white rounded-lg hover:bg-primary-600 transition-colors text-center"
+                    className="btn btn-primary w-full justify-center"
                   >
                     {t('requestNewResetLink')}
                   </Link>
 
                   <Link
                     href="/auth/login"
-                    className="inline-block w-full px-4 py-2 border border-gray-300 text-gray-700 rounded-lg hover:bg-gray-50 transition-colors text-center"
+                    className="btn btn-secondary w-full justify-center"
                   >
                     {t('backToSignIn')}
                   </Link>
@@ -196,7 +198,7 @@ function ResetPasswordForm() {
 
   // Form state
   return (
-    <div className="min-h-screen bg-gradient-to-br from-primary-100 via-purple-50 to-primary-200 flex items-center justify-center py-12 px-4 sm:px-6 lg:px-8">
+    <div className="min-h-screen bg-gradient-to-br from-primary-50 to-primary-100 flex items-center justify-center py-12 px-4 sm:px-6 lg:px-8">
       <div className="max-w-md w-full space-y-8">
         <div className="text-center">
           <div className="flex justify-center mb-6">
@@ -204,8 +206,8 @@ function ResetPasswordForm() {
               <AppIcon size={80} />
             </div>
           </div>
-          <h2 className="text-h1 text-gray-900">{t('resetPasswordTitle')}</h2>
-          <p className="mt-2 text-gray-600">
+          <h2 className="text-h1 text-slate-900">{t('resetPasswordTitle')}</h2>
+          <p className="mt-2 text-slate-600">
             {t('resetPasswordSubtitle')}
           </p>
         </div>
@@ -214,12 +216,12 @@ function ResetPasswordForm() {
           <CardContent className="p-8">
             <form onSubmit={handleSubmit} className="space-y-6">
               {errors.length > 0 && (
-                <div className="bg-red-50 border border-red-200 rounded-lg p-4">
+                <div className="bg-danger-50 border border-danger-200 rounded-card p-4">
                   <div className="flex items-start gap-3">
-                    <ExclamationCircleIcon className="w-5 h-5 text-red-500 flex-shrink-0 mt-0.5" />
+                    <ExclamationCircleIcon className="w-5 h-5 text-danger-500 flex-shrink-0 mt-0.5" />
                     <div>
                       {errors.map((error, index) => (
-                        <p key={index} className="text-sm text-red-700">{error}</p>
+                        <p key={index} className="text-sm text-danger-700">{error}</p>
                       ))}
                     </div>
                   </div>
@@ -227,7 +229,7 @@ function ResetPasswordForm() {
               )}
 
               <div>
-                <label htmlFor="email" className="block text-sm font-medium text-gray-700 mb-1">
+                <label htmlFor="email" className="block text-sm font-medium text-slate-700 mb-1">
                   {t('email')}
                 </label>
                 <input
@@ -236,15 +238,15 @@ function ResetPasswordForm() {
                   type="email"
                   value={formData.email}
                   disabled
-                  className="w-full px-4 py-2 border border-gray-300 rounded-lg bg-gray-50 text-gray-600"
+                  className="input"
                 />
                 {validationErrors.email && (
-                  <p className="mt-1 text-sm text-red-600">{validationErrors.email}</p>
+                  <p className="mt-1 text-sm text-danger-600">{validationErrors.email}</p>
                 )}
               </div>
 
               <div>
-                <label htmlFor="newPassword" className="block text-sm font-medium text-gray-700 mb-1">
+                <label htmlFor="newPassword" className="block text-sm font-medium text-slate-700 mb-1">
                   {t('newPassword')}
                 </label>
                 <div className="relative">
@@ -256,13 +258,16 @@ function ResetPasswordForm() {
                     required
                     value={formData.newPassword}
                     onChange={(e) => setFormData({ ...formData, newPassword: e.target.value })}
-                    className={`w-full px-4 py-2 pr-10 border rounded-lg focus:ring-2 focus:ring-primary focus:border-transparent ${validationErrors.newPassword ? 'border-red-300' : 'border-gray-300'}`}
+                    className={cn(
+                      'input pr-10',
+                      validationErrors.newPassword && 'border-danger focus:border-danger focus:ring-danger/20'
+                    )}
                     placeholder={t('newPasswordPlaceholder')}
                   />
                   <button
                     type="button"
                     onClick={() => setShowPassword(!showPassword)}
-                    className="absolute right-3 top-1/2 transform -translate-y-1/2 text-gray-400 hover:text-gray-600"
+                    className="absolute right-3 top-1/2 transform -translate-y-1/2 text-slate-400 hover:text-slate-600"
                   >
                     {showPassword ? (
                       <EyeSlashIcon className="w-5 h-5" />
@@ -272,26 +277,26 @@ function ResetPasswordForm() {
                   </button>
                 </div>
                 {validationErrors.newPassword && (
-                  <p className="mt-1 text-sm text-red-600">{validationErrors.newPassword}</p>
+                  <p className="mt-1 text-sm text-danger-600">{validationErrors.newPassword}</p>
                 )}
 
                 {/* Password requirements checklist */}
                 <div className="mt-3 space-y-1">
-                  <p className="text-xs font-medium text-gray-600">{t('passwordRequirementsTitle')}</p>
+                  <p className="text-xs font-medium text-slate-600">{t('passwordRequirementsTitle')}</p>
                   <ul className="text-xs space-y-1">
-                    <li className={passwordChecks.minLength ? 'text-green-600' : 'text-gray-500'}>
+                    <li className={passwordChecks.minLength ? 'text-green-600' : 'text-slate-500'}>
                       {passwordChecks.minLength ? '✓' : '○'} {t('passwordRequirements.minLength')}
                     </li>
-                    <li className={passwordChecks.hasUppercase ? 'text-green-600' : 'text-gray-500'}>
+                    <li className={passwordChecks.hasUppercase ? 'text-green-600' : 'text-slate-500'}>
                       {passwordChecks.hasUppercase ? '✓' : '○'} {t('passwordRequirements.uppercase')}
                     </li>
-                    <li className={passwordChecks.hasLowercase ? 'text-green-600' : 'text-gray-500'}>
+                    <li className={passwordChecks.hasLowercase ? 'text-green-600' : 'text-slate-500'}>
                       {passwordChecks.hasLowercase ? '✓' : '○'} {t('passwordRequirements.lowercase')}
                     </li>
-                    <li className={passwordChecks.hasNumber ? 'text-green-600' : 'text-gray-500'}>
+                    <li className={passwordChecks.hasNumber ? 'text-green-600' : 'text-slate-500'}>
                       {passwordChecks.hasNumber ? '✓' : '○'} {t('passwordRequirements.number')}
                     </li>
-                    <li className={passwordChecks.hasSpecial ? 'text-green-600' : 'text-gray-500'}>
+                    <li className={passwordChecks.hasSpecial ? 'text-green-600' : 'text-slate-500'}>
                       {passwordChecks.hasSpecial ? '✓' : '○'} {t('passwordRequirements.special')}
                     </li>
                   </ul>
@@ -299,7 +304,7 @@ function ResetPasswordForm() {
               </div>
 
               <div>
-                <label htmlFor="confirmPassword" className="block text-sm font-medium text-gray-700 mb-1">
+                <label htmlFor="confirmPassword" className="block text-sm font-medium text-slate-700 mb-1">
                   {t('confirmPassword')}
                 </label>
                 <div className="relative">
@@ -311,13 +316,16 @@ function ResetPasswordForm() {
                     required
                     value={formData.confirmPassword}
                     onChange={(e) => setFormData({ ...formData, confirmPassword: e.target.value })}
-                    className={`w-full px-4 py-2 pr-10 border rounded-lg focus:ring-2 focus:ring-primary focus:border-transparent ${validationErrors.confirmPassword ? 'border-red-300' : 'border-gray-300'}`}
+                    className={cn(
+                      'input pr-10',
+                      validationErrors.confirmPassword && 'border-danger focus:border-danger focus:ring-danger/20'
+                    )}
                     placeholder={t('confirmPasswordPlaceholder')}
                   />
                   <button
                     type="button"
                     onClick={() => setShowConfirmPassword(!showConfirmPassword)}
-                    className="absolute right-3 top-1/2 transform -translate-y-1/2 text-gray-400 hover:text-gray-600"
+                    className="absolute right-3 top-1/2 transform -translate-y-1/2 text-slate-400 hover:text-slate-600"
                   >
                     {showConfirmPassword ? (
                       <EyeSlashIcon className="w-5 h-5" />
@@ -327,32 +335,23 @@ function ResetPasswordForm() {
                   </button>
                 </div>
                 {validationErrors.confirmPassword && (
-                  <p className="mt-1 text-sm text-red-600">{validationErrors.confirmPassword}</p>
+                  <p className="mt-1 text-sm text-danger-600">{validationErrors.confirmPassword}</p>
                 )}
                 {formData.confirmPassword && (
-                  <p className={`mt-1 text-xs ${passwordsMatch ? 'text-green-600' : 'text-red-600'}`}>
+                  <p className={cn('mt-1 text-xs', passwordsMatch ? 'text-green-600' : 'text-danger-600')}>
                     {passwordsMatch ? t('passwordsMatch') : t('passwordsDoNotMatch')}
                   </p>
                 )}
               </div>
 
-              <button
+              <Button
                 type="submit"
+                className="w-full"
+                loading={isLoading}
                 disabled={isLoading || !allPasswordChecksPassing || !passwordsMatch}
-                className="w-full px-4 py-2 bg-primary text-white rounded-lg hover:bg-primary-600 transition-colors disabled:opacity-50 disabled:cursor-not-allowed flex items-center justify-center"
               >
-                {isLoading ? (
-                  <>
-                    <svg className="animate-spin -ml-1 mr-3 h-5 w-5 text-white" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24">
-                      <circle className="opacity-25" cx="12" cy="12" r="10" stroke="currentColor" strokeWidth="4"></circle>
-                      <path className="opacity-75" fill="currentColor" d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4zm2 5.291A7.962 7.962 0 014 12H0c0 3.042 1.135 5.824 3 7.938l3-2.647z"></path>
-                    </svg>
-                    {t('resettingPassword')}
-                  </>
-                ) : (
-                  t('resetPassword')
-                )}
-              </button>
+                {t('resetPassword')}
+              </Button>
 
               <div className="text-center">
                 <Link
@@ -374,10 +373,10 @@ export default function ResetPasswordPage() {
   const tCommon = useTranslations('common');
   return (
     <Suspense fallback={
-      <div className="min-h-screen bg-gradient-to-br from-primary-100 via-purple-50 to-primary-200 flex items-center justify-center">
+      <div className="min-h-screen bg-gradient-to-br from-primary-50 to-primary-100 flex items-center justify-center">
         <div className="text-center">
           <div className="animate-spin rounded-full h-12 w-12 border-b-2 border-primary mx-auto"></div>
-          <p className="mt-4 text-gray-600">{tCommon('loading')}</p>
+          <p className="mt-4 text-slate-600">{tCommon('loading')}</p>
         </div>
       </div>
     }>

--- a/frontend/src/app/auth/verify-email/page.tsx
+++ b/frontend/src/app/auth/verify-email/page.tsx
@@ -74,8 +74,8 @@ export default function VerifyEmailPage() {
             <div className="w-16 h-16 bg-gradient-to-br from-primary-500 to-primary-700 rounded-2xl shadow-2xl flex items-center justify-center animate-pulse mx-auto mb-6">
               <EnvelopeIcon className="w-8 h-8 text-white" />
             </div>
-            <h2 className="text-2xl font-bold text-gray-900 mb-2">{t('verifying')}</h2>
-            <p className="text-gray-600">{t('pleaseWait')}</p>
+            <h2 className="text-2xl font-bold text-slate-900 mb-2">{t('verifying')}</h2>
+            <p className="text-slate-600">{t('pleaseWait')}</p>
           </div>
         );
 
@@ -85,8 +85,8 @@ export default function VerifyEmailPage() {
             <div className="w-16 h-16 bg-gradient-to-br from-green-500 to-green-700 rounded-2xl shadow-2xl flex items-center justify-center mx-auto mb-6">
               <CheckCircleIcon className="w-8 h-8 text-white" />
             </div>
-            <h2 className="text-2xl font-bold text-gray-900 mb-2">{t('successTitle')}</h2>
-            <p className="text-gray-600 mb-6">{message}</p>
+            <h2 className="text-2xl font-bold text-slate-900 mb-2">{t('successTitle')}</h2>
+            <p className="text-slate-600 mb-6">{message}</p>
             <Button onClick={() => router.push('/auth/login')} className="w-full">
               {t('proceedToLogin')}
             </Button>
@@ -99,11 +99,11 @@ export default function VerifyEmailPage() {
             <div className="w-16 h-16 bg-gradient-to-br from-red-500 to-red-700 rounded-2xl shadow-2xl flex items-center justify-center mx-auto mb-6">
               <ExclamationCircleIcon className="w-8 h-8 text-white" />
             </div>
-            <h2 className="text-2xl font-bold text-gray-900 mb-2">{t('errorTitle')}</h2>
-            <p className="text-gray-600 mb-6">{message}</p>
+            <h2 className="text-2xl font-bold text-slate-900 mb-2">{t('errorTitle')}</h2>
+            <p className="text-slate-600 mb-6">{message}</p>
 
             <div className="space-y-4">
-              <p className="text-sm text-gray-500">{t('needNewLink')}</p>
+              <p className="text-sm text-slate-500">{t('needNewLink')}</p>
               <Input
                 type="email"
                 placeholder={t('emailPlaceholder')}
@@ -137,8 +137,8 @@ export default function VerifyEmailPage() {
             <div className="w-16 h-16 bg-gradient-to-br from-primary-500 to-primary-700 rounded-2xl shadow-2xl flex items-center justify-center mx-auto mb-6">
               <EnvelopeIcon className="w-8 h-8 text-white" />
             </div>
-            <h2 className="text-2xl font-bold text-gray-900 mb-2">{t('resendTitle')}</h2>
-            <p className="text-gray-600 mb-6">{message}</p>
+            <h2 className="text-2xl font-bold text-slate-900 mb-2">{t('resendTitle')}</h2>
+            <p className="text-slate-600 mb-6">{message}</p>
 
             <div className="space-y-4">
               <Input
@@ -171,7 +171,7 @@ export default function VerifyEmailPage() {
   };
 
   return (
-    <div className="min-h-screen bg-gradient-to-br from-primary-100 via-purple-50 to-primary-200 flex items-center justify-center py-12 px-4 sm:px-6 lg:px-8">
+    <div className="min-h-screen bg-gradient-to-br from-primary-50 to-primary-100 flex items-center justify-center py-12 px-4 sm:px-6 lg:px-8">
       <div className="max-w-md w-full space-y-8">
         <div className="text-center">
           <div className="flex justify-center mb-6">


### PR DESCRIPTION
## Summary

- **Consistent violet gradient background** across all auth pages — standardized from the login page's `from-primary-50 to-primary-100` (register, forgot-password, reset-password, verify-email all updated)
- **slate-\* colors** replace gray-\* throughout for refined text hierarchy and better visual coherence with the violet design language
- **Design system components** — forgot-password and reset-password upgraded from raw `<input>`/`<button>` HTML to `<Input>` and `<Button>` components
- **Danger tokens** for error states replace raw `red-*` utility classes
- **cn()** used for conditional classes in password field validation states
- No functionality changes — all validation, redirects, and auth logic unchanged

## Screenshots

### Login
![Login](https://raw.githubusercontent.com/digaomatias/mymascada/feat/modernize-auth-pages/screenshot-login.png)

### Register
![Register](https://raw.githubusercontent.com/digaomatias/mymascada/feat/modernize-auth-pages/screenshot-register.png)

### Forgot Password
![Forgot Password](https://raw.githubusercontent.com/digaomatias/mymascada/feat/modernize-auth-pages/screenshot-forgot-password.png)

## Test plan

- [ ] Visit `/auth/login` — consistent violet gradient, card glassmorphism, slate text
- [ ] Visit `/auth/register` — same gradient/card, slate text, sign up flow works
- [ ] Visit `/auth/forgot-password` — `<Input>` / `<Button>` components render correctly, submit disabled until email entered
- [ ] Visit `/auth/reset-password?token=x&email=y` — password fields with eye toggles, checklist, `cn()`-based error classes
- [ ] Visit `/auth/verify-email` — slate text, consistent gradient
- [ ] `npm run build` passes with no new errors ✅

🤖 Generated with [Claude Code](https://claude.com/claude-code)