### PR TITLE
style: modernize category, budget & goal form pages

### DIFF
--- a/frontend/src/app/budgets/[id]/edit/page.tsx
+++ b/frontend/src/app/budgets/[id]/edit/page.tsx
@@ -508,7 +508,7 @@ export default function EditBudgetPage() {
           </div>
           <div className="flex items-center gap-2">
             <Link href={`${BUDGET_BASE}/${budget.id}`}>
-              <Button variant="outline">{tCommon('cancel')}</Button>
+              <Button variant="secondary">{tCommon('cancel')}</Button>
             </Link>
             <Button onClick={handleSave} disabled={saving || !name.trim()} loading={saving}>
               {tCommon('save')}

--- a/frontend/src/app/budgets/new/page.tsx
+++ b/frontend/src/app/budgets/new/page.tsx
@@ -184,8 +184,8 @@ export default function CreateBudgetPage() {
       <div className="space-y-5">
         <div className="flex items-center justify-between">
           <Link href={BUDGET_BASE}>
-            <Button variant="outline">
-              <ArrowLeftIcon className="mr-1.5 h-4 w-4" />
+            <Button variant="secondary" size="sm" className="flex items-center gap-2">
+              <ArrowLeftIcon className="h-4 w-4" />
               {t('backToBudgets')}
             </Button>
           </Link>

--- a/frontend/src/app/categories/[id]/edit/page.tsx
+++ b/frontend/src/app/categories/[id]/edit/page.tsx
@@ -178,7 +178,7 @@ export default function EditCategoryPage() {
           <div className="w-16 h-16 bg-gradient-to-br from-violet-500 to-fuchsia-500 rounded-2xl shadow-2xl flex items-center justify-center animate-pulse mx-auto">
             <TagIcon className="w-8 h-8 text-white" />
           </div>
-          <div className="mt-6 text-gray-700 font-medium">{t('details.loadingCategory')}</div>
+          <div className="mt-6 text-slate-700 font-medium">{t('details.loadingCategory')}</div>
         </div>
       </div>
     );
@@ -192,8 +192,8 @@ export default function EditCategoryPage() {
     return (
       <AppLayout>
           <div className="text-center">
-            <h1 className="text-2xl font-bold text-gray-900 mb-4">{t('edit.cannotEditSystem')}</h1>
-            <p className="text-gray-600 mb-6">{t('edit.systemCategoriesCannotBeModified')}</p>
+            <h1 className="font-[var(--font-dash-sans)] text-2xl font-semibold text-slate-900 mb-4">{t('edit.cannotEditSystem')}</h1>
+            <p className="text-slate-600 mb-6">{t('edit.systemCategoriesCannotBeModified')}</p>
             <Link href={`/categories/${categoryId}`}>
               <Button>{t('edit.backToCategory')}</Button>
             </Link>
@@ -224,21 +224,21 @@ export default function EditCategoryPage() {
           </div>
 
           {/* Page Title */}
-          <div className="text-center mb-8">
-            <h1 className="text-2xl sm:text-3xl lg:text-4xl font-bold text-gray-900 mb-2">
+          <div className="mb-6">
+            <h1 className="font-[var(--font-dash-sans)] text-3xl font-semibold tracking-[-0.03em] text-slate-900 sm:text-[2.1rem]">
               {t('edit.title')}
             </h1>
-            <p className="text-gray-600 text-sm sm:text-base">
+            <p className="text-[15px] text-slate-500 mt-1.5">
               {t('edit.subtitle')}
             </p>
           </div>
         </div>
 
         <div className="max-w-2xl mx-auto">
-          <Card className="bg-white/90 backdrop-blur-xs border-0 shadow-lg">
+          <Card className="rounded-[26px] border border-violet-100/70 shadow-[0_20px_46px_-30px_rgba(76,29,149,0.45)] backdrop-blur-xs bg-white/92">
             <CardHeader>
-              <CardTitle className="text-xl font-bold text-gray-900 flex items-center gap-2">
-                <TagIcon className="w-6 h-6 text-primary-600" />
+              <CardTitle className="font-[var(--font-dash-sans)] text-lg font-semibold text-slate-900 flex items-center gap-2">
+                <TagIcon className="w-5 h-5 text-violet-600" />
                 {t('categoryDetails')}
               </CardTitle>
             </CardHeader>
@@ -246,24 +246,24 @@ export default function EditCategoryPage() {
             <CardContent>
               <form onSubmit={handleSubmit} className="space-y-6">
                 {/* Preview */}
-                <div className="text-center p-6 bg-gray-50 rounded-lg">
-                  <div 
+                <div className="text-center p-6 bg-slate-50/50 rounded-[16px]">
+                  <div
                     className="w-16 h-16 rounded-2xl shadow-lg flex items-center justify-center mx-auto mb-3 transition-colors"
                     style={{ backgroundColor: formData.color }}
                   >
                     {renderCategoryIcon(category.icon, "w-8 h-8 text-white")}
                   </div>
-                  <h3 className="text-lg font-semibold text-gray-900">
+                  <h3 className="font-[var(--font-dash-sans)] text-lg font-semibold text-slate-900">
                     {formData.name || 'Category Name'}
                   </h3>
                   {formData.description && (
-                    <p className="text-sm text-gray-600 mt-1">{formData.description}</p>
+                    <p className="text-sm text-slate-600 mt-1">{formData.description}</p>
                   )}
                 </div>
 
                 {/* Name */}
                 <div>
-                  <label className="block text-sm font-medium text-gray-700 mb-2">
+                  <label className="block text-xs font-semibold uppercase tracking-[0.08em] text-slate-500 mb-2">
                     {t('edit.categoryName')}
                   </label>
                   <Input
@@ -280,7 +280,7 @@ export default function EditCategoryPage() {
 
                 {/* Description */}
                 <div>
-                  <label className="block text-sm font-medium text-gray-700 mb-2">
+                  <label className="block text-xs font-semibold uppercase tracking-[0.08em] text-slate-500 mb-2">
                     {t('edit.description')}
                   </label>
                   <Input
@@ -293,7 +293,7 @@ export default function EditCategoryPage() {
 
                 {/* Parent Category */}
                 <div>
-                  <label className="block text-sm font-medium text-gray-700 mb-2">
+                  <label className="block text-xs font-semibold uppercase tracking-[0.08em] text-slate-500 mb-2">
                     {t('edit.parentCategory')}
                   </label>
                   <select
@@ -315,7 +315,7 @@ export default function EditCategoryPage() {
 
                 {/* Color */}
                 <div>
-                  <label className="block text-sm font-medium text-gray-700 mb-2">
+                  <label className="block text-xs font-semibold uppercase tracking-[0.08em] text-slate-500 mb-2">
                     {t('edit.color')}
                   </label>
                   <div className="flex items-center gap-3 mb-3">
@@ -323,7 +323,7 @@ export default function EditCategoryPage() {
                       type="color"
                       value={formData.color}
                       onChange={(e) => handleInputChange('color', e.target.value)}
-                      className="w-12 h-12 rounded-lg border border-gray-300 cursor-pointer"
+                      className="w-12 h-12 rounded-lg border border-slate-300 cursor-pointer"
                     />
                     <Input
                       type="text"
@@ -342,9 +342,9 @@ export default function EditCategoryPage() {
                         type="button"
                         onClick={() => handleInputChange('color', color)}
                         className={`w-8 h-8 rounded-lg border-2 transition-all ${
-                          formData.color === color 
-                            ? 'border-gray-900 scale-110' 
-                            : 'border-gray-300 hover:border-gray-400'
+                          formData.color === color
+                            ? 'border-slate-900 scale-110'
+                            : 'border-slate-300 hover:border-slate-400'
                         }`}
                         style={{ backgroundColor: color }}
                       />

--- a/frontend/src/app/categories/new/page.tsx
+++ b/frontend/src/app/categories/new/page.tsx
@@ -139,7 +139,7 @@ export default function NewCategoryPage() {
           <div className="w-16 h-16 bg-gradient-to-br from-violet-500 to-fuchsia-500 rounded-2xl shadow-2xl flex items-center justify-center animate-pulse mx-auto">
             <TagIcon className="w-8 h-8 text-white" />
           </div>
-          <div className="mt-6 text-gray-700 font-medium">{tCommon('loading')}</div>
+          <div className="mt-6 text-slate-700 font-medium">{tCommon('loading')}</div>
         </div>
       </div>
     );
@@ -152,14 +152,14 @@ export default function NewCategoryPage() {
   if (success) {
     return (
       <div className="min-h-screen bg-[#faf8ff] flex items-center justify-center">
-        <Card className="mx-4 max-w-md w-full bg-white/90 backdrop-blur-xs border-0 shadow-2xl">
+        <Card className="mx-4 max-w-md w-full rounded-[26px] border border-violet-100/70 shadow-[0_20px_46px_-30px_rgba(76,29,149,0.45)] backdrop-blur-xs bg-white/92">
           <CardContent className="p-8 text-center">
-            <div className="w-16 h-16 bg-gradient-to-br from-success-500 to-success-600 rounded-2xl shadow-2xl flex items-center justify-center mx-auto mb-6">
+            <div className="w-16 h-16 bg-gradient-to-br from-emerald-500 to-emerald-600 rounded-2xl shadow-2xl flex items-center justify-center mx-auto mb-6">
               <CheckIcon className="w-8 h-8 text-white" />
             </div>
-            <h2 className="text-2xl font-bold text-gray-900 mb-2">{t('new.categoryCreated')}</h2>
-            <p className="text-gray-600 mb-6">{t('new.categoryCreatedDesc')}</p>
-            <div className="text-sm text-gray-500">{t('new.redirectingToCategories')}</div>
+            <h2 className="font-[var(--font-dash-sans)] text-2xl font-semibold text-slate-900 mb-2">{t('new.categoryCreated')}</h2>
+            <p className="text-slate-600 mb-6">{t('new.categoryCreatedDesc')}</p>
+            <div className="text-sm text-slate-500">{t('new.redirectingToCategories')}</div>
           </CardContent>
         </Card>
       </div>
@@ -185,11 +185,11 @@ export default function NewCategoryPage() {
           </div>
 
           {/* Page Title */}
-          <div className="text-center mb-8">
-            <h1 className="text-2xl sm:text-3xl lg:text-4xl font-bold text-gray-900 mb-2">
+          <div className="mb-6">
+            <h1 className="font-[var(--font-dash-sans)] text-3xl font-semibold tracking-[-0.03em] text-slate-900 sm:text-[2.1rem]">
               {t('new.title')}
             </h1>
-            <p className="text-gray-600 text-sm sm:text-base">
+            <p className="text-[15px] text-slate-500 mt-1.5">
               {t('new.subtitle')}
             </p>
           </div>
@@ -197,10 +197,10 @@ export default function NewCategoryPage() {
 
         {/* Category Form */}
         <div className="max-w-2xl mx-auto">
-          <Card className="bg-white/90 backdrop-blur-xs border-0 shadow-lg">
+          <Card className="rounded-[26px] border border-violet-100/70 shadow-[0_20px_46px_-30px_rgba(76,29,149,0.45)] backdrop-blur-xs bg-white/92">
             <CardHeader>
-              <CardTitle className="flex items-center gap-2">
-                <TagIcon className="w-6 h-6 text-primary-600" />
+              <CardTitle className="font-[var(--font-dash-sans)] text-lg font-semibold text-slate-900 flex items-center gap-2">
+                <TagIcon className="w-5 h-5 text-violet-600" />
                 {t('categoryDetails')}
               </CardTitle>
             </CardHeader>
@@ -209,7 +209,7 @@ export default function NewCategoryPage() {
               <form onSubmit={handleSubmit} className="space-y-6">
                 {/* General Error */}
                 {errors.submit && (
-                  <div className="bg-red-50 border border-red-200 rounded-lg p-4 flex items-start gap-3">
+                  <div className="bg-red-50 border border-red-200/80 rounded-[16px] p-4 flex items-start gap-3">
                     <ExclamationTriangleIcon className="w-5 h-5 text-red-500 flex-shrink-0 mt-0.5" />
                     <div>
                       <h4 className="text-sm font-medium text-red-800">{tCommon('error')}</h4>
@@ -220,7 +220,7 @@ export default function NewCategoryPage() {
 
                 {/* Name Field */}
                 <div>
-                  <label htmlFor="name" className="block text-sm font-medium text-gray-700 mb-2">
+                  <label htmlFor="name" className="block text-xs font-semibold uppercase tracking-[0.08em] text-slate-500 mb-2">
                     {t('edit.categoryName')}
                   </label>
                   <Input
@@ -239,7 +239,7 @@ export default function NewCategoryPage() {
                 {/* Parent Category Field */}
                 {parentCategoryOptions.length > 0 && (
                   <div>
-                    <label htmlFor="parentCategoryId" className="block text-sm font-medium text-gray-700 mb-2">
+                    <label htmlFor="parentCategoryId" className="block text-xs font-semibold uppercase tracking-[0.08em] text-slate-500 mb-2">
                       {t('new.parentCategoryOptional')}
                     </label>
                     <select
@@ -255,7 +255,7 @@ export default function NewCategoryPage() {
                         </option>
                       ))}
                     </select>
-                    <p className="mt-1 text-xs text-gray-500">
+                    <p className="mt-1 text-xs text-slate-500">
                       {t('new.parentHelp')}
                     </p>
                   </div>
@@ -263,7 +263,7 @@ export default function NewCategoryPage() {
 
                 {/* Color Field */}
                 <div>
-                  <label htmlFor="color" className="block text-sm font-medium text-gray-700 mb-2">
+                  <label htmlFor="color" className="block text-xs font-semibold uppercase tracking-[0.08em] text-slate-500 mb-2">
                     {t('edit.color')}
                   </label>
                   <div className="flex gap-2 flex-wrap">
@@ -273,7 +273,7 @@ export default function NewCategoryPage() {
                         type="button"
                         onClick={() => handleInputChange('color', color)}
                         className={`w-8 h-8 rounded-full border-2 ${
-                          formData.color === color ? 'border-gray-800' : 'border-gray-300'
+                          formData.color === color ? 'border-slate-800' : 'border-slate-300'
                         }`}
                         style={{ backgroundColor: color }}
                         aria-label={`Select color ${color}`}
@@ -292,7 +292,7 @@ export default function NewCategoryPage() {
 
                 {/* Description Field */}
                 <div>
-                  <label htmlFor="description" className="block text-sm font-medium text-gray-700 mb-2">
+                  <label htmlFor="description" className="block text-xs font-semibold uppercase tracking-[0.08em] text-slate-500 mb-2">
                     {t('new.descriptionLabel')}
                   </label>
                   <textarea
@@ -301,7 +301,7 @@ export default function NewCategoryPage() {
                     placeholder={t('new.descriptionPlaceholder')}
                     value={formData.description}
                     onChange={(e) => handleInputChange('description', e.target.value)}
-                    className="w-full rounded-md border-gray-300 shadow-sm focus:border-primary-500 focus:ring-primary-500 resize-none"
+                    className="input w-full resize-none"
                   />
                 </div>
 

--- a/frontend/src/app/goals/[id]/edit/page.tsx
+++ b/frontend/src/app/goals/[id]/edit/page.tsx
@@ -112,8 +112,10 @@ export default function EditGoalPage() {
   if (isLoading) {
     return (
       <AppLayout>
-          <Skeleton className="h-8 w-64" />
-          <Skeleton className="h-96" />
+        <div className="space-y-4">
+          <Skeleton className="h-8 w-64 rounded-2xl" />
+          <Skeleton className="h-96 rounded-[26px]" />
+        </div>
       </AppLayout>
     );
   }
@@ -133,9 +135,9 @@ export default function EditGoalPage() {
 
         {/* Form Card */}
         <div className="max-w-2xl mx-auto">
-          <Card className="bg-white/90 backdrop-blur-xs border-0 shadow-lg">
+          <Card className="rounded-[26px] border border-violet-100/70 shadow-[0_20px_46px_-30px_rgba(76,29,149,0.45)] backdrop-blur-xs bg-white/92">
             <CardHeader>
-              <CardTitle>{tCommon('edit')} - {name}</CardTitle>
+              <CardTitle className="font-[var(--font-dash-sans)] text-lg font-semibold text-slate-900">{tCommon('edit')} - {name}</CardTitle>
             </CardHeader>
             <CardContent>
               <form onSubmit={handleSubmit} className="space-y-6">
@@ -188,7 +190,7 @@ export default function EditGoalPage() {
                       disabled={!!linkedAccountId}
                     />
                     {linkedAccountId && (
-                      <p className="text-xs text-gray-500">{t('form.currentAmountLinkedHint')}</p>
+                      <p className="text-xs text-slate-500">{t('form.currentAmountLinkedHint')}</p>
                     )}
                   </div>
                 </div>
@@ -251,7 +253,7 @@ export default function EditGoalPage() {
                       </option>
                     ))}
                   </Select>
-                  <p className="text-xs text-gray-500">{t('form.linkedAccountHelp')}</p>
+                  <p className="text-xs text-slate-500">{t('form.linkedAccountHelp')}</p>
                 </div>
 
                 <div className="flex justify-end gap-3">

--- a/frontend/src/app/goals/new/page.tsx
+++ b/frontend/src/app/goals/new/page.tsx
@@ -96,9 +96,9 @@ export default function CreateGoalPage() {
 
         {/* Form Card */}
         <div className="max-w-2xl mx-auto">
-          <Card className="bg-white/90 backdrop-blur-xs border-0 shadow-lg">
+          <Card className="rounded-[26px] border border-violet-100/70 shadow-[0_20px_46px_-30px_rgba(76,29,149,0.45)] backdrop-blur-xs bg-white/92">
             <CardHeader>
-              <CardTitle>{t('createGoal')}</CardTitle>
+              <CardTitle className="font-[var(--font-dash-sans)] text-lg font-semibold text-slate-900">{t('createGoal')}</CardTitle>
             </CardHeader>
             <CardContent>
               <form onSubmit={handleSubmit} className="space-y-6">
@@ -179,7 +179,7 @@ export default function CreateGoalPage() {
                       </option>
                     ))}
                   </Select>
-                  <p className="text-xs text-gray-500">{t('form.linkedAccountHelp')}</p>
+                  <p className="text-xs text-slate-500">{t('form.linkedAccountHelp')}</p>
                 </div>
 
                 <div className="flex justify-end gap-3">


### PR DESCRIPTION
## Summary

- **Category forms** (`/categories/new`, `/categories/[id]/edit`): full overhaul — modern card (`rounded-[26px]`, violet border, shadow, `backdrop-blur-xs bg-white/92`), left-aligned page header with `font-[var(--font-dash-sans)]` h1, uppercase tracking labels replacing `text-gray-*` with `text-slate-*`, modern color-picker borders, textarea using `input` CSS class
- **Budget forms** (`/budgets/new`, `/budgets/[id]/edit`): back button changed from `variant="outline"` to `variant="secondary"`; cancel button in sticky footer also updated
- **Goal forms** (`/goals/new`, `/goals/[id]/edit`): card modernized to match design system (`rounded-[26px]` border, shadow, `bg-white/92`), CardTitle given `font-[var(--font-dash-sans)]` heading style, all `text-gray-*` → `text-slate-*`
- **Rules/new**: already used modern design tokens — no changes needed

All changes are **styling only** — zero functionality changes.

## Design tokens applied

| Token | Value |
|---|---|
| Card border-radius | `rounded-[26px]` |
| Card border | `border border-violet-100/70` |
| Card shadow | `shadow-[0_20px_46px_-30px_rgba(76,29,149,0.45)]` |
| Card bg | `backdrop-blur-xs bg-white/92` |
| Heading font | `font-[var(--font-dash-sans)] font-semibold tracking-[-0.03em]` |
| Label style | `text-xs font-semibold uppercase tracking-[0.08em] text-slate-500` |
| Color text | `text-slate-*` (no `text-gray-*`) |

## Test plan

- [x] `npm run build` passes with no errors
- [ ] Visual review: `/categories/new` — modern card, left-aligned header, uppercase labels, slate color pickers
- [ ] Visual review: `/categories/[id]/edit` — same as above + preview section uses `bg-slate-50/50`
- [ ] Visual review: `/budgets/new` — back button uses secondary variant
- [ ] Visual review: `/budgets/[id]/edit` — cancel button uses secondary variant
- [ ] Visual review: `/goals/new` — modern card, modern CardTitle
- [ ] Visual review: `/goals/[id]/edit` — same as above

> **Note:** Screenshots not included — dev environment (backend + DB) was unavailable at commit time.

🤖 Generated with [Claude Code](https://claude.com/claude-code)