### PR TITLE
feat: modernize settings & chat pages with violet design system

### DIFF
--- a/frontend/src/app/chat/page.tsx
+++ b/frontend/src/app/chat/page.tsx
@@ -28,17 +28,17 @@ const MAX_CHARS = 5000;
 const chatComponents: Partial<Components> = {
   // Headings render as compact section labels with a subtle separator
   h1: ({ children }) => (
-    <div className="text-xs font-semibold text-primary-700 mt-3 first:mt-0 mb-1 pb-0.5 border-b border-gray-100">
+    <div className="text-xs font-semibold text-violet-700 mt-3 first:mt-0 mb-1 pb-0.5 border-b border-slate-100">
       {children}
     </div>
   ),
   h2: ({ children }) => (
-    <div className="text-xs font-semibold text-primary-700 mt-3 first:mt-0 mb-1 pb-0.5 border-b border-gray-100">
+    <div className="text-xs font-semibold text-violet-700 mt-3 first:mt-0 mb-1 pb-0.5 border-b border-slate-100">
       {children}
     </div>
   ),
   h3: ({ children }) => (
-    <div className="text-xs font-semibold text-primary-700 mt-3 first:mt-0 mb-1 pb-0.5 border-b border-gray-100">
+    <div className="text-xs font-semibold text-violet-700 mt-3 first:mt-0 mb-1 pb-0.5 border-b border-slate-100">
       {children}
     </div>
   ),
@@ -51,10 +51,10 @@ const chatComponents: Partial<Components> = {
         ? 'text-red-600'
         : text.startsWith('+')
           ? 'text-emerald-600'
-          : 'text-primary-700';
+          : 'text-violet-700';
       return <strong className={`font-semibold ${color}`}>{children}</strong>;
     }
-    return <strong className="font-semibold text-gray-900">{children}</strong>;
+    return <strong className="font-semibold text-slate-900">{children}</strong>;
   },
 };
 
@@ -242,12 +242,12 @@ export default function ChatPage() {
 
   if (isLoading) {
     return (
-      <div className="min-h-screen bg-gray-50 flex items-center justify-center">
+      <div className="min-h-screen bg-[#faf8ff] flex items-center justify-center">
         <div className="text-center">
           <div className="w-16 h-16 bg-gradient-to-br from-violet-500 to-fuchsia-500 rounded-2xl shadow-2xl flex items-center justify-center animate-pulse mx-auto">
             <ChatBubbleLeftRightIcon className="w-8 h-8 text-white" />
           </div>
-          <div className="mt-6 text-gray-700 font-medium">{tCommon('loading')}</div>
+          <div className="mt-6 text-slate-700 font-medium">{tCommon('loading')}</div>
         </div>
       </div>
     );
@@ -261,14 +261,14 @@ export default function ChatPage() {
   if (chatConfigured === false) {
     return (
       <AppLayout mainClassName="relative z-10 flex-1 flex items-center justify-center p-4 pb-24 md:pb-4">
-          <div className="max-w-md w-full bg-white rounded-2xl shadow-lg p-8 text-center">
+          <div className="max-w-md w-full rounded-[26px] border border-violet-100/70 bg-white/92 shadow-[0_20px_46px_-30px_rgba(76,29,149,0.45)] backdrop-blur-xs p-8 text-center">
             <div className="w-16 h-16 bg-amber-100 rounded-2xl flex items-center justify-center mx-auto mb-4">
               <ExclamationCircleIcon className="w-8 h-8 text-amber-600" />
             </div>
-            <h2 className="text-xl font-semibold text-gray-900 mb-2">
+            <h2 className="text-xl font-semibold text-slate-900 mb-2">
               {t('notConfigured')}
             </h2>
-            <p className="text-gray-600 mb-6">
+            <p className="text-slate-500 mb-6">
               {t('notConfiguredDescription')}
             </p>
             <Link href="/settings/ai">
@@ -288,16 +288,16 @@ export default function ChatPage() {
     <AppLayout mainClassName="relative z-10 flex-1 flex flex-col max-w-4xl mx-auto w-full pb-24 md:pb-0" noBackground>
         {/* Header bar with clear button */}
         {hasMessages && (
-          <div className="flex items-center justify-between px-4 py-2 border-b border-gray-200 bg-white/80 backdrop-blur-xs">
+          <div className="flex items-center justify-between px-4 py-2 border-b border-slate-200 bg-white/90 backdrop-blur-xs">
             <div className="flex items-center gap-2">
-              <SparklesIcon className="w-5 h-5 text-primary-600" />
-              <h1 className="text-sm font-medium text-gray-700">{t('title')}</h1>
+              <SparklesIcon className="w-5 h-5 text-violet-600" />
+              <h1 className="text-sm font-medium text-slate-700">{t('title')}</h1>
             </div>
             <Button
               variant="ghost"
               size="sm"
               onClick={() => setShowClearConfirm(true)}
-              className="text-gray-500 hover:text-red-600"
+              className="text-slate-500 hover:text-red-600"
             >
               <TrashIcon className="w-4 h-4 mr-1" />
               {t('clearHistory')}
@@ -313,21 +313,21 @@ export default function ChatPage() {
           {loadingHistory ? (
             <div className="flex items-center justify-center py-12">
               <div className="text-center">
-                <div className="animate-spin w-8 h-8 border-2 border-primary-600 border-t-transparent rounded-full mx-auto mb-3" />
-                <p className="text-sm text-gray-500">{t('loading')}</p>
+                <div className="animate-spin w-8 h-8 border-2 border-violet-600 border-t-transparent rounded-full mx-auto mb-3" />
+                <p className="text-sm text-slate-500">{t('loading')}</p>
               </div>
             </div>
           ) : !hasMessages ? (
             /* Empty State */
             <div className="flex-1 flex items-center justify-center py-12">
               <div className="max-w-md w-full text-center">
-                <div className="w-20 h-20 bg-gradient-to-br from-primary-400 to-primary-600 rounded-2xl flex items-center justify-center mx-auto mb-6 shadow-lg">
+                <div className="w-20 h-20 bg-gradient-to-br from-violet-500 to-violet-600 rounded-2xl flex items-center justify-center mx-auto mb-6 shadow-lg">
                   <SparklesIcon className="w-10 h-10 text-white" />
                 </div>
-                <h2 className="text-2xl font-bold text-gray-900 mb-2">
+                <h2 className="text-2xl font-bold text-slate-900 mb-2">
                   {t('title')}
                 </h2>
-                <p className="text-gray-600 mb-8">
+                <p className="text-slate-500 mb-8">
                   {t('subtitle')}
                 </p>
                 <div className="flex flex-wrap gap-2 justify-center">
@@ -336,7 +336,7 @@ export default function ChatPage() {
                       key={key}
                       onClick={() => handleSuggestedPrompt(t(`suggestedPrompts.${key}`))}
                       disabled={sending}
-                      className="px-4 py-2 text-sm bg-white border border-gray-200 rounded-full text-gray-700 hover:bg-primary-50 hover:border-primary-200 hover:text-primary-700 transition-colors cursor-pointer disabled:opacity-50 disabled:cursor-not-allowed"
+                      className="px-4 py-2 text-sm bg-white border border-violet-200/60 rounded-full text-slate-700 hover:bg-violet-50 hover:border-violet-300 hover:text-violet-700 transition-colors cursor-pointer disabled:opacity-50 disabled:cursor-not-allowed"
                     >
                       {t(`suggestedPrompts.${key}`)}
                     </button>
@@ -370,14 +370,14 @@ export default function ChatPage() {
                   <div
                     className={`max-w-[85%] sm:max-w-[75%] rounded-2xl px-4 py-3 ${
                       message.role === 'user'
-                        ? 'bg-primary-600 text-white'
+                        ? 'bg-violet-600 text-white'
                         : message.id < 0 && !message.content
                           ? ''
-                          : 'bg-white border border-gray-200 text-gray-800'
+                          : 'bg-white border border-slate-200 text-slate-800'
                     }`}
                   >
                     {message.role === 'assistant' ? (
-                      <div className="prose prose-sm max-w-none break-words overflow-hidden prose-p:my-1 prose-ul:my-1 prose-ol:my-1 prose-li:my-0.5 prose-pre:my-2 prose-pre:overflow-x-auto prose-pre:max-w-full prose-table:overflow-x-auto prose-table:block prose-table:text-xs prose-code:text-primary-700 prose-code:bg-primary-50 prose-code:px-1 prose-code:rounded prose-code:break-all">
+                      <div className="prose prose-sm max-w-none break-words overflow-hidden prose-p:my-1 prose-ul:my-1 prose-ol:my-1 prose-li:my-0.5 prose-pre:my-2 prose-pre:overflow-x-auto prose-pre:max-w-full prose-table:overflow-x-auto prose-table:block prose-table:text-xs prose-code:text-violet-700 prose-code:bg-violet-50 prose-code:px-1 prose-code:rounded prose-code:break-all">
                         <ReactMarkdown components={chatComponents}>{message.content}</ReactMarkdown>
                       </div>
                     ) : (
@@ -385,7 +385,7 @@ export default function ChatPage() {
                     )}
                     <p
                       className={`text-xs mt-1.5 ${
-                        message.role === 'user' ? 'text-primary-200' : 'text-gray-400'
+                        message.role === 'user' ? 'text-violet-200' : 'text-slate-400'
                       }`}
                     >
                       {formatTimestamp(message.createdAt)}
@@ -397,11 +397,11 @@ export default function ChatPage() {
               {/* Typing indicator */}
               {sending && (
                 <div className="flex justify-start">
-                  <div className="bg-white border border-gray-200 rounded-2xl px-4 py-3">
+                  <div className="bg-white border border-slate-200 rounded-2xl px-4 py-3">
                     <div className="flex items-center gap-1.5">
-                      <div className="w-2 h-2 bg-gray-400 rounded-full animate-bounce" style={{ animationDelay: '0ms' }} />
-                      <div className="w-2 h-2 bg-gray-400 rounded-full animate-bounce" style={{ animationDelay: '150ms' }} />
-                      <div className="w-2 h-2 bg-gray-400 rounded-full animate-bounce" style={{ animationDelay: '300ms' }} />
+                      <div className="w-2 h-2 bg-slate-400 rounded-full animate-bounce" style={{ animationDelay: '0ms' }} />
+                      <div className="w-2 h-2 bg-slate-400 rounded-full animate-bounce" style={{ animationDelay: '150ms' }} />
+                      <div className="w-2 h-2 bg-slate-400 rounded-full animate-bounce" style={{ animationDelay: '300ms' }} />
                     </div>
                   </div>
                 </div>
@@ -412,7 +412,7 @@ export default function ChatPage() {
         </div>
 
         {/* Input area */}
-        <div className="border-t border-gray-200 bg-white px-4 py-3">
+        <div className="border-t border-slate-200 bg-white px-4 py-3">
           <div className="flex items-end gap-2">
             <div className="flex-1 relative">
               <textarea
@@ -427,13 +427,13 @@ export default function ChatPage() {
                 placeholder={t('inputPlaceholder')}
                 disabled={sending}
                 rows={1}
-                className="w-full resize-none rounded-xl border border-gray-300 px-4 py-2.5 text-sm focus:outline-none focus:ring-2 focus:ring-primary-500 focus:border-transparent disabled:opacity-50 disabled:cursor-not-allowed"
+                className="w-full resize-none rounded-xl border border-slate-300 px-4 py-2.5 text-sm focus:outline-none focus:ring-2 focus:ring-violet-500 focus:border-transparent disabled:opacity-50 disabled:cursor-not-allowed"
                 style={{ maxHeight: '150px' }}
               />
               {input.length > MAX_CHARS * 0.9 && (
                 <span
                   className={`absolute bottom-1 right-2 text-xs ${
-                    input.length >= MAX_CHARS ? 'text-red-500' : 'text-gray-400'
+                    input.length >= MAX_CHARS ? 'text-red-500' : 'text-slate-400'
                   }`}
                 >
                   {input.length}/{MAX_CHARS}

--- a/frontend/src/app/settings/ai/page.tsx
+++ b/frontend/src/app/settings/ai/page.tsx
@@ -271,7 +271,7 @@ export default function AiSettingsPage() {
           <div className="w-16 h-16 bg-gradient-to-br from-violet-500 to-fuchsia-500 rounded-2xl shadow-2xl flex items-center justify-center animate-pulse mx-auto">
             <SparklesIcon className="w-8 h-8 text-white" />
           </div>
-          <div className="mt-6 text-gray-700 font-medium">{tCommon('loading')}</div>
+          <div className="mt-6 text-slate-700 font-medium">{tCommon('loading')}</div>
         </div>
       </div>
     );
@@ -288,7 +288,7 @@ export default function AiSettingsPage() {
       {/* Back link */}
         <Link
           href="/settings"
-          className="inline-flex items-center gap-2 text-sm text-gray-600 hover:text-gray-900 mb-4"
+          className="inline-flex items-center gap-2 text-sm text-slate-600 hover:text-slate-900 mb-4"
         >
           <ArrowLeftIcon className="w-4 h-4" />
           {t('backToSettings')}
@@ -297,27 +297,27 @@ export default function AiSettingsPage() {
         {/* Header */}
         <div className="mb-6 lg:mb-8">
           <div className="flex items-center gap-3 mb-1">
-            <div className="w-10 h-10 bg-gradient-to-br from-primary-400 to-primary-600 rounded-xl flex items-center justify-center">
+            <div className="w-10 h-10 bg-gradient-to-br from-violet-500 to-violet-600 rounded-xl flex items-center justify-center">
               <SparklesIcon className="w-5 h-5 text-white" />
             </div>
             <div>
-              <h1 className="text-2xl sm:text-3xl lg:text-4xl font-bold text-gray-900">
+              <h1 className="font-[var(--font-dash-sans)] text-3xl font-semibold tracking-[-0.03em] text-slate-900 sm:text-[2.1rem]">
                 {t('title')}
               </h1>
-              <p className="text-gray-600 mt-0.5">{t('subtitle')}</p>
+              <p className="text-[15px] text-slate-500 mt-0.5">{t('subtitle')}</p>
             </div>
           </div>
         </div>
 
         {/* Tab Switcher */}
         <div className="mb-4">
-          <div className="flex border-b border-gray-200">
+          <div className="flex border-b border-slate-200">
             <button
               onClick={() => handleTabChange('general')}
               className={`px-4 py-2.5 text-sm font-medium border-b-2 transition-colors cursor-pointer ${
                 activePurpose === 'general'
-                  ? 'border-primary-600 text-primary-700'
-                  : 'border-transparent text-gray-500 hover:text-gray-700 hover:border-gray-300'
+                  ? 'border-violet-600 text-violet-700'
+                  : 'border-transparent text-slate-500 hover:text-slate-700 hover:border-slate-300'
               }`}
             >
               {t('tabs.general')}
@@ -326,8 +326,8 @@ export default function AiSettingsPage() {
               onClick={() => handleTabChange('chat')}
               className={`px-4 py-2.5 text-sm font-medium border-b-2 transition-colors cursor-pointer ${
                 activePurpose === 'chat'
-                  ? 'border-primary-600 text-primary-700'
-                  : 'border-transparent text-gray-500 hover:text-gray-700 hover:border-gray-300'
+                  ? 'border-violet-600 text-violet-700'
+                  : 'border-transparent text-slate-500 hover:text-slate-700 hover:border-slate-300'
               }`}
             >
               {t('tabs.chat')}
@@ -338,34 +338,32 @@ export default function AiSettingsPage() {
         {/* Chat AI Description */}
         {activePurpose === 'chat' && (
           <div className="mb-4">
-            <Card className="bg-blue-50/80 backdrop-blur-xs border-0 shadow-sm">
-              <CardContent className="p-4">
-                <div className="flex items-start gap-3">
-                  <InformationCircleIcon className="w-5 h-5 text-blue-500 shrink-0 mt-0.5" />
-                  <p className="text-sm text-blue-800">{t('chatDescription')}</p>
-                </div>
-              </CardContent>
-            </Card>
+            <div className="rounded-2xl border border-blue-200/60 bg-blue-50/80 backdrop-blur-xs p-4">
+              <div className="flex items-start gap-3">
+                <InformationCircleIcon className="w-5 h-5 text-blue-500 shrink-0 mt-0.5" />
+                <p className="text-sm text-blue-800">{t('chatDescription')}</p>
+              </div>
+            </div>
           </div>
         )}
 
         {isLoadingData ? (
-          <Card className="bg-white/90 backdrop-blur-xs border-0 shadow-lg">
+          <Card className="rounded-[26px] border border-violet-100/70 bg-white/92 shadow-[0_20px_46px_-30px_rgba(76,29,149,0.45)] backdrop-blur-xs">
             <CardContent className="p-6">
               <div className="animate-pulse space-y-4">
-                <div className="h-4 bg-gray-200 rounded w-1/3"></div>
-                <div className="h-10 bg-gray-200 rounded"></div>
-                <div className="h-4 bg-gray-200 rounded w-1/4"></div>
-                <div className="h-10 bg-gray-200 rounded"></div>
-                <div className="h-4 bg-gray-200 rounded w-1/4"></div>
-                <div className="h-10 bg-gray-200 rounded"></div>
+                <div className="h-4 bg-slate-200 rounded w-1/3"></div>
+                <div className="h-10 bg-slate-200 rounded"></div>
+                <div className="h-4 bg-slate-200 rounded w-1/4"></div>
+                <div className="h-10 bg-slate-200 rounded"></div>
+                <div className="h-4 bg-slate-200 rounded w-1/4"></div>
+                <div className="h-10 bg-slate-200 rounded"></div>
               </div>
             </CardContent>
           </Card>
         ) : (
           <div className="space-y-4">
             {/* Status Banner */}
-            <Card className="bg-white/90 backdrop-blur-xs border-0 shadow-lg">
+            <Card className="rounded-[26px] border border-violet-100/70 bg-white/92 shadow-[0_20px_46px_-30px_rgba(76,29,149,0.45)] backdrop-blur-xs">
               <CardContent className="p-4">
                 {settings ? (
                   <div className="flex items-start gap-3">
@@ -399,11 +397,11 @@ export default function AiSettingsPage() {
             </Card>
 
             {/* Configuration Form */}
-            <Card className="bg-white/90 backdrop-blur-xs border-0 shadow-lg">
+            <Card className="rounded-[26px] border border-violet-100/70 bg-white/92 shadow-[0_20px_46px_-30px_rgba(76,29,149,0.45)] backdrop-blur-xs">
               <CardContent className="p-6 space-y-5">
                 {/* Provider */}
                 <div>
-                  <label className="block text-sm font-medium text-gray-700 mb-1.5">
+                  <label className="block text-sm font-medium text-slate-700 mb-1.5">
                     {t('provider.label')}
                   </label>
                   <Select
@@ -425,12 +423,12 @@ export default function AiSettingsPage() {
 
                 {/* API Key */}
                 <div>
-                  <label className="block text-sm font-medium text-gray-700 mb-1.5">
+                  <label className="block text-sm font-medium text-slate-700 mb-1.5">
                     {t('apiKey.label')}
                   </label>
                   {settings?.hasApiKey && !apiKeyChanged ? (
                     <div className="flex items-center gap-3">
-                      <div className="flex-1 input bg-gray-50 text-gray-500 flex items-center">
+                      <div className="flex-1 input bg-slate-50 text-slate-500 flex items-center">
                         <span>{t('apiKey.current')}: ****{settings.apiKeyLastFour}</span>
                       </div>
                       <Button
@@ -453,12 +451,12 @@ export default function AiSettingsPage() {
                       className="w-full"
                     />
                   )}
-                  <p className="text-xs text-gray-500 mt-1.5">{t('apiKey.hint')}</p>
+                  <p className="text-xs text-slate-500 mt-1.5">{t('apiKey.hint')}</p>
                 </div>
 
                 {/* Model */}
                 <div>
-                  <label className="block text-sm font-medium text-gray-700 mb-1.5">
+                  <label className="block text-sm font-medium text-slate-700 mb-1.5">
                     {t('model.label')}
                   </label>
                   {selectedProvider && selectedProvider.models.length > 0 ? (
@@ -502,7 +500,7 @@ export default function AiSettingsPage() {
                 {/* Endpoint */}
                 {!isStandardOpenAI && (
                   <div>
-                    <label className="block text-sm font-medium text-gray-700 mb-1.5">
+                    <label className="block text-sm font-medium text-slate-700 mb-1.5">
                       {t('endpoint.label')}
                     </label>
                     <Input
@@ -543,7 +541,7 @@ export default function AiSettingsPage() {
                 </div>
 
                 {/* Actions */}
-                <div className="flex flex-col sm:flex-row gap-3 pt-3 border-t border-gray-100">
+                <div className="flex flex-col sm:flex-row gap-3 pt-3 border-t border-slate-100">
                   <Button
                     variant="primary"
                     onClick={handleSave}

--- a/frontend/src/app/settings/bank-connections/page.tsx
+++ b/frontend/src/app/settings/bank-connections/page.tsx
@@ -186,10 +186,10 @@ export default function BankConnectionsPage() {
     return (
       <div className="min-h-screen bg-[#faf8ff] flex items-center justify-center">
         <div className="text-center">
-          <div className="w-16 h-16 bg-gradient-to-br from-blue-500 to-blue-700 rounded-2xl shadow-2xl flex items-center justify-center animate-pulse mx-auto">
+          <div className="w-16 h-16 bg-gradient-to-br from-violet-500 to-violet-600 rounded-2xl shadow-2xl flex items-center justify-center animate-pulse mx-auto">
             <BuildingLibraryIcon className="w-8 h-8 text-white" />
           </div>
-          <div className="mt-6 text-gray-700 font-medium">{t('loading')}</div>
+          <div className="mt-6 text-slate-700 font-medium">{t('loading')}</div>
         </div>
       </div>
     );
@@ -210,17 +210,17 @@ export default function BankConnectionsPage() {
               href="/settings"
               className="p-1 hover:bg-white/50 rounded-lg transition-colors"
             >
-              <ArrowLeftIcon className="w-5 h-5 text-gray-600" />
+              <ArrowLeftIcon className="w-5 h-5 text-slate-600" />
             </Link>
-            <span className="text-sm text-gray-500">{tNav('settings')}</span>
+            <span className="text-sm text-slate-500">{tNav('settings')}</span>
           </div>
 
           <div className="flex flex-col sm:flex-row sm:items-center sm:justify-between gap-4">
             <div>
-              <h1 className="text-2xl sm:text-3xl lg:text-4xl font-bold text-gray-900">
+              <h1 className="font-[var(--font-dash-sans)] text-3xl font-semibold tracking-[-0.03em] text-slate-900 sm:text-[2.1rem]">
                 {t('title')}
               </h1>
-              <p className="text-gray-600 mt-1">
+              <p className="text-[15px] text-slate-500 mt-1.5">
                 {t('subtitle')}
               </p>
             </div>
@@ -251,25 +251,23 @@ export default function BankConnectionsPage() {
         </div>
 
         {/* Info Banner */}
-        <Card className="bg-blue-50 border-blue-200 mb-6">
-          <CardContent className="p-4">
-            <div className="flex items-start gap-3">
-              <InformationCircleIcon className="w-5 h-5 text-blue-600 shrink-0 mt-0.5" />
-              <div className="text-sm text-blue-800">
-                <p className="font-medium">{t('aboutTitle')}</p>
-                <p className="mt-1 text-blue-700">
-                  {t('aboutDescription')}
-                </p>
-              </div>
+        <div className="rounded-2xl border border-blue-200/60 bg-blue-50/80 backdrop-blur-xs p-4 mb-6">
+          <div className="flex items-start gap-3">
+            <InformationCircleIcon className="w-5 h-5 text-blue-600 shrink-0 mt-0.5" />
+            <div className="text-sm text-blue-800">
+              <p className="font-medium">{t('aboutTitle')}</p>
+              <p className="mt-1 text-blue-700">
+                {t('aboutDescription')}
+              </p>
             </div>
-          </CardContent>
-        </Card>
+          </div>
+        </div>
 
         {/* Connections List */}
-        <Card className="bg-white/90 backdrop-blur-xs border-0 shadow-lg">
+        <Card className="rounded-[26px] border border-violet-100/70 bg-white/92 shadow-[0_20px_46px_-30px_rgba(76,29,149,0.45)] backdrop-blur-xs">
           <CardHeader>
             <CardTitle className="flex items-center gap-2">
-              <BuildingLibraryIcon className="w-6 h-6 text-primary-600" />
+              <BuildingLibraryIcon className="w-6 h-6 text-violet-600" />
               {t('connectedAccounts')}
             </CardTitle>
           </CardHeader>

--- a/frontend/src/app/settings/page.tsx
+++ b/frontend/src/app/settings/page.tsx
@@ -198,7 +198,7 @@ export default function SettingsPage() {
           <div className="w-16 h-16 bg-gradient-to-br from-violet-500 to-fuchsia-500 rounded-2xl shadow-2xl flex items-center justify-center animate-pulse mx-auto">
             <CogIcon className="w-8 h-8 text-white" />
           </div>
-          <div className="mt-6 text-gray-700 font-medium">{tCommon('loading')}</div>
+          <div className="mt-6 text-slate-700 font-medium">{tCommon('loading')}</div>
         </div>
       </div>
     );
@@ -212,10 +212,10 @@ export default function SettingsPage() {
     <AppLayout>
         {/* Header */}
         <div className="mb-6 lg:mb-8">
-          <h1 className="text-2xl sm:text-3xl lg:text-4xl font-bold text-gray-900">
+          <h1 className="font-[var(--font-dash-sans)] text-3xl font-semibold tracking-[-0.03em] text-slate-900 sm:text-[2.1rem]">
             {t('title')}
           </h1>
-          <p className="text-gray-600 mt-1">
+          <p className="text-[15px] text-slate-500 mt-1.5">
             {t('subtitle')}
           </p>
         </div>
@@ -223,17 +223,17 @@ export default function SettingsPage() {
         {/* Settings Grid */}
         <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
           {/* Language Preference Card */}
-          <Card className="bg-white/90 backdrop-blur-xs border-0 shadow-lg h-full">
+          <Card className="rounded-[26px] border border-violet-100/70 bg-white/92 shadow-[0_20px_46px_-30px_rgba(76,29,149,0.45)] backdrop-blur-xs h-full">
             <CardContent className="p-6">
               <div className="flex items-start gap-4">
-                <div className="w-12 h-12 bg-gradient-to-br from-primary-400 to-primary-600 rounded-xl flex items-center justify-center shrink-0">
+                <div className="w-12 h-12 bg-gradient-to-br from-violet-500 to-violet-600 rounded-xl flex items-center justify-center shrink-0">
                   <LanguageIcon className="w-6 h-6 text-white" />
                 </div>
                 <div className="flex-1 min-w-0">
-                  <h3 className="text-lg font-semibold text-gray-900">
+                  <h3 className="text-lg font-semibold text-slate-900">
                     {t('language.title')}
                   </h3>
-                  <p className="text-sm text-gray-600 mt-1 mb-3">
+                  <p className="text-sm text-slate-500 mt-1 mb-3">
                     {t('language.description')}
                   </p>
                   <Select
@@ -249,7 +249,7 @@ export default function SettingsPage() {
                     ))}
                   </Select>
                   {isSavingLocale && (
-                    <p className="text-sm text-primary-600 mt-2">
+                    <p className="text-sm text-violet-600 mt-2">
                       {t('language.saving')}
                     </p>
                   )}
@@ -259,28 +259,28 @@ export default function SettingsPage() {
           </Card>
 
           {/* Default Categories Card */}
-          <Card className="bg-white/90 backdrop-blur-xs border-0 shadow-lg h-full">
+          <Card className="rounded-[26px] border border-violet-100/70 bg-white/92 shadow-[0_20px_46px_-30px_rgba(76,29,149,0.45)] backdrop-blur-xs h-full">
             <CardContent className="p-6">
               <div className="flex items-start gap-4">
-                <div className="w-12 h-12 bg-gradient-to-br from-primary-400 to-primary-600 rounded-xl flex items-center justify-center shrink-0">
+                <div className="w-12 h-12 bg-gradient-to-br from-violet-500 to-violet-600 rounded-xl flex items-center justify-center shrink-0">
                   <TagIcon className="w-6 h-6 text-white" />
                 </div>
                 <div className="flex-1 min-w-0">
-                  <h3 className="text-lg font-semibold text-gray-900">
+                  <h3 className="text-lg font-semibold text-slate-900">
                     {t('categorySeeding.title')}
                   </h3>
-                  <p className="text-sm text-gray-600 mt-1 mb-3">
+                  <p className="text-sm text-slate-500 mt-1 mb-3">
                     {t('categorySeeding.description')}
                   </p>
 
                   {isLoadingCategories ? (
-                    <p className="text-sm text-gray-500">{tCommon('loading')}</p>
+                    <p className="text-sm text-slate-500">{tCommon('loading')}</p>
                   ) : categoryCount !== null && categoryCount > 0 ? (
                     <div>
                       <p className="text-sm text-amber-700 bg-amber-50 border border-amber-200 rounded-lg p-3 mb-3">
                         {t('categorySeeding.alreadyHasCategories')}
                       </p>
-                      <p className="text-sm text-gray-500">
+                      <p className="text-sm text-slate-500">
                         {t('categorySeeding.hasCategories', { count: categoryCount })}
                       </p>
                     </div>
@@ -289,7 +289,7 @@ export default function SettingsPage() {
                       <p className="text-sm text-blue-700 bg-blue-50 border border-blue-200 rounded-lg p-3 mb-3">
                         {t('categorySeeding.noCategories')}
                       </p>
-                      <label className="block text-sm font-medium text-gray-700 mb-1">
+                      <label className="block text-sm font-medium text-slate-700 mb-1">
                         {t('categorySeeding.localeLabel')}
                       </label>
                       <Select
@@ -334,25 +334,25 @@ export default function SettingsPage() {
 
           {/* Transaction Import Card - only visible when AI Categorization is enabled */}
           {features.aiCategorization && (
-            <Card className="bg-white/90 backdrop-blur-xs border-0 shadow-lg h-full">
+            <Card className="rounded-[26px] border border-violet-100/70 bg-white/92 shadow-[0_20px_46px_-30px_rgba(76,29,149,0.45)] backdrop-blur-xs h-full">
               <CardContent className="p-6">
                 <div className="flex items-start gap-4">
-                  <div className="w-12 h-12 bg-gradient-to-br from-primary-400 to-primary-600 rounded-xl flex items-center justify-center shrink-0">
+                  <div className="w-12 h-12 bg-gradient-to-br from-violet-500 to-violet-600 rounded-xl flex items-center justify-center shrink-0">
                     <ArrowDownTrayIcon className="w-6 h-6 text-white" />
                   </div>
                   <div className="flex-1 min-w-0">
-                    <h3 className="text-lg font-semibold text-gray-900">
+                    <h3 className="text-lg font-semibold text-slate-900">
                       {t('transactionImport.title')}
                     </h3>
-                    <p className="text-sm text-gray-600 mt-1 mb-3">
+                    <p className="text-sm text-slate-500 mt-1 mb-3">
                       {t('transactionImport.description')}
                     </p>
                     <div className="flex items-center justify-between">
                       <div>
-                        <p className="text-sm font-medium text-gray-900">
+                        <p className="text-sm font-medium text-slate-900">
                           {t('transactionImport.aiCleaning')}
                         </p>
-                        <p className="text-xs text-gray-500 mt-0.5">
+                        <p className="text-xs text-slate-500 mt-0.5">
                           {t('transactionImport.aiCleaningDescription')}
                         </p>
                       </div>
@@ -362,8 +362,8 @@ export default function SettingsPage() {
                         aria-checked={aiCleaningEnabled}
                         onClick={handleAiCleaningToggle}
                         disabled={isSavingAiCleaning}
-                        className={`relative inline-flex h-6 w-11 shrink-0 cursor-pointer rounded-full border-2 border-transparent transition-colors duration-200 ease-in-out focus:outline-none focus:ring-2 focus:ring-primary-500 focus:ring-offset-2 disabled:opacity-50 disabled:cursor-not-allowed ${
-                          aiCleaningEnabled ? 'bg-primary-600' : 'bg-gray-200'
+                        className={`relative inline-flex h-6 w-11 shrink-0 cursor-pointer rounded-full border-2 border-transparent transition-colors duration-200 ease-in-out focus:outline-none focus:ring-2 focus:ring-violet-500 focus:ring-offset-2 disabled:opacity-50 disabled:cursor-not-allowed ${
+                          aiCleaningEnabled ? 'bg-violet-600' : 'bg-slate-200'
                         }`}
                       >
                         <span
@@ -380,22 +380,22 @@ export default function SettingsPage() {
           )}
 
           {/* Dashboard Template Card */}
-          <Card className="bg-white/90 backdrop-blur-xs border-0 shadow-lg h-full">
+          <Card className="rounded-[26px] border border-violet-100/70 bg-white/92 shadow-[0_20px_46px_-30px_rgba(76,29,149,0.45)] backdrop-blur-xs h-full">
             <CardContent className="p-6">
               <div className="flex items-start gap-4">
-                <div className="w-12 h-12 bg-gradient-to-br from-primary-400 to-primary-600 rounded-xl flex items-center justify-center shrink-0">
+                <div className="w-12 h-12 bg-gradient-to-br from-violet-500 to-violet-600 rounded-xl flex items-center justify-center shrink-0">
                   <PresentationChartBarIcon className="w-6 h-6 text-white" />
                 </div>
                 <div className="flex-1 min-w-0">
-                  <h3 className="text-lg font-semibold text-gray-900">
+                  <h3 className="text-lg font-semibold text-slate-900">
                     {t('dashboardLayout.title')}
                   </h3>
-                  <p className="text-sm text-gray-600 mt-1 mb-3">
+                  <p className="text-sm text-slate-500 mt-1 mb-3">
                     {t('dashboardLayout.description')}
                   </p>
                   <div className="flex items-center justify-between">
                     <div>
-                      <p className="text-sm font-medium text-gray-900">
+                      <p className="text-sm font-medium text-slate-900">
                         {dashboardTemplate === 'education'
                           ? t('dashboardLayout.education')
                           : t('dashboardLayout.advanced')}
@@ -406,8 +406,8 @@ export default function SettingsPage() {
                       role="switch"
                       aria-checked={dashboardTemplate === 'education'}
                       onClick={handleDashboardTemplateToggle}
-                      className={`relative inline-flex h-6 w-11 shrink-0 cursor-pointer rounded-full border-2 border-transparent transition-colors duration-200 ease-in-out focus:outline-none focus:ring-2 focus:ring-primary-500 focus:ring-offset-2 ${
-                        dashboardTemplate === 'education' ? 'bg-primary-600' : 'bg-gray-200'
+                      className={`relative inline-flex h-6 w-11 shrink-0 cursor-pointer rounded-full border-2 border-transparent transition-colors duration-200 ease-in-out focus:outline-none focus:ring-2 focus:ring-violet-500 focus:ring-offset-2 ${
+                        dashboardTemplate === 'education' ? 'bg-violet-600' : 'bg-slate-200'
                       }`}
                     >
                       <span
@@ -427,15 +427,15 @@ export default function SettingsPage() {
             const IconComponent = item.icon;
             return (
               <Link key={item.href} href={item.href}>
-                <Card className="bg-white/90 backdrop-blur-xs border-0 shadow-lg hover:shadow-xl transition-shadow cursor-pointer h-full">
+                <Card className="rounded-[26px] border border-violet-100/70 bg-white/92 shadow-[0_20px_46px_-30px_rgba(76,29,149,0.45)] backdrop-blur-xs hover:shadow-[0_24px_52px_-28px_rgba(76,29,149,0.55)] transition-shadow cursor-pointer h-full">
                   <CardContent className="p-6">
                     <div className="flex items-start gap-4">
-                      <div className="w-12 h-12 bg-gradient-to-br from-primary-400 to-primary-600 rounded-xl flex items-center justify-center shrink-0">
+                      <div className="w-12 h-12 bg-gradient-to-br from-violet-500 to-violet-600 rounded-xl flex items-center justify-center shrink-0">
                         <IconComponent className="w-6 h-6 text-white" />
                       </div>
                       <div className="flex-1 min-w-0">
                         <div className="flex items-center gap-2">
-                          <h3 className="text-lg font-semibold text-gray-900">
+                          <h3 className="text-lg font-semibold text-slate-900">
                             {t(`items.${item.labelKey}.title`)}
                           </h3>
                           {item.badge && (
@@ -444,11 +444,11 @@ export default function SettingsPage() {
                             </span>
                           )}
                         </div>
-                        <p className="text-sm text-gray-600 mt-1">
+                        <p className="text-sm text-slate-500 mt-1">
                           {t(`items.${item.labelKey}.description`)}
                         </p>
                       </div>
-                      <ChevronRightIcon className="w-5 h-5 text-gray-400 shrink-0" />
+                      <ChevronRightIcon className="w-5 h-5 text-slate-400 shrink-0" />
                     </div>
                   </CardContent>
                 </Card>
@@ -459,7 +459,7 @@ export default function SettingsPage() {
 
         {/* Coming Soon Section */}
         <div className="mt-8">
-          <h2 className="text-lg font-semibold text-gray-700 mb-4">{t('comingSoon.title')}</h2>
+          <h2 className="text-lg font-semibold text-slate-600 mb-4">{t('comingSoon.title')}</h2>
           <div className="grid grid-cols-1 md:grid-cols-3 gap-4">
             {[
               { icon: UserIcon, labelKey: 'profile' as const },
@@ -468,15 +468,15 @@ export default function SettingsPage() {
             ].map((item) => {
               const IconComponent = item.icon;
               return (
-                <Card key={item.labelKey} className="bg-white/50 border border-gray-200">
+                <Card key={item.labelKey} className="rounded-2xl bg-white/60 border border-violet-100/40">
                   <CardContent className="p-4">
                     <div className="flex items-center gap-3 opacity-50">
-                      <div className="w-10 h-10 bg-gray-300 rounded-lg flex items-center justify-center">
-                        <IconComponent className="w-5 h-5 text-gray-500" />
+                      <div className="w-10 h-10 bg-slate-200 rounded-xl flex items-center justify-center">
+                        <IconComponent className="w-5 h-5 text-slate-500" />
                       </div>
                       <div>
-                        <h3 className="font-medium text-gray-700">{t(`comingSoon.items.${item.labelKey}.title`)}</h3>
-                        <p className="text-xs text-gray-500">{t(`comingSoon.items.${item.labelKey}.description`)}</p>
+                        <h3 className="font-medium text-slate-600">{t(`comingSoon.items.${item.labelKey}.title`)}</h3>
+                        <p className="text-xs text-slate-500">{t(`comingSoon.items.${item.labelKey}.description`)}</p>
                       </div>
                     </div>
                   </CardContent>

--- a/frontend/src/app/settings/privacy/page.tsx
+++ b/frontend/src/app/settings/privacy/page.tsx
@@ -111,7 +111,7 @@ export default function PrivacySettingsPage() {
           <div className="w-16 h-16 bg-gradient-to-br from-violet-500 to-fuchsia-500 rounded-2xl shadow-2xl flex items-center justify-center animate-pulse mx-auto">
             <ShieldCheckIcon className="w-8 h-8 text-white" />
           </div>
-          <div className="mt-6 text-gray-700 font-medium">{tCommon('loading')}</div>
+          <div className="mt-6 text-slate-700 font-medium">{tCommon('loading')}</div>
         </div>
       </div>
     );
@@ -125,65 +125,65 @@ export default function PrivacySettingsPage() {
     <AppLayout>
       {/* Header */}
         <div className="mb-6 lg:mb-8">
-          <Link href="/settings" className="inline-flex items-center text-primary-600 hover:text-primary-800 mb-4">
-            <ArrowLeftIcon className="w-4 h-4 mr-2" />
+          <Link href="/settings" className="inline-flex items-center gap-2 text-sm text-violet-600 hover:text-violet-800 mb-4">
+            <ArrowLeftIcon className="w-4 h-4" />
             {t('backToSettings')}
           </Link>
-          <h1 className="text-2xl sm:text-3xl lg:text-4xl font-bold text-gray-900">
+          <h1 className="font-[var(--font-dash-sans)] text-3xl font-semibold tracking-[-0.03em] text-slate-900 sm:text-[2.1rem]">
             {t('title')}
           </h1>
-          <p className="text-gray-600 mt-1">
+          <p className="text-[15px] text-slate-500 mt-1.5">
             {t('subtitle')}
           </p>
         </div>
 
         <div className="space-y-6">
           {/* Data Summary Card */}
-          <Card className="bg-white/90 backdrop-blur-xs border-0 shadow-lg">
+          <Card className="rounded-[26px] border border-violet-100/70 bg-white/92 shadow-[0_20px_46px_-30px_rgba(76,29,149,0.45)] backdrop-blur-xs">
             <CardContent className="p-6">
-              <h2 className="text-lg font-semibold text-gray-900 mb-4">{t('dataSummary.title')}</h2>
+              <h2 className="text-lg font-semibold text-slate-900 mb-4">{t('dataSummary.title')}</h2>
 
               {loadingSummary ? (
                 <div className="animate-pulse space-y-2">
-                  <div className="h-4 bg-gray-200 rounded w-3/4"></div>
-                  <div className="h-4 bg-gray-200 rounded w-1/2"></div>
-                  <div className="h-4 bg-gray-200 rounded w-2/3"></div>
+                  <div className="h-4 bg-slate-200 rounded w-3/4"></div>
+                  <div className="h-4 bg-slate-200 rounded w-1/2"></div>
+                  <div className="h-4 bg-slate-200 rounded w-2/3"></div>
                 </div>
               ) : summary ? (
                 <div className="grid grid-cols-2 md:grid-cols-4 gap-4">
-                  <div className="text-center p-3 bg-gray-50 rounded-lg">
-                    <div className="text-2xl font-bold text-primary-600">{summary.totalAccounts}</div>
-                    <div className="text-sm text-gray-600">{t('dataSummary.accounts')}</div>
+                  <div className="text-center p-3 bg-violet-50/40 rounded-xl border border-violet-100/60">
+                    <div className="text-2xl font-bold text-violet-600">{summary.totalAccounts}</div>
+                    <div className="text-sm text-slate-600">{t('dataSummary.accounts')}</div>
                   </div>
-                  <div className="text-center p-3 bg-gray-50 rounded-lg">
-                    <div className="text-2xl font-bold text-primary-600">{summary.totalTransactions}</div>
-                    <div className="text-sm text-gray-600">{t('dataSummary.transactions')}</div>
+                  <div className="text-center p-3 bg-violet-50/40 rounded-xl border border-violet-100/60">
+                    <div className="text-2xl font-bold text-violet-600">{summary.totalTransactions}</div>
+                    <div className="text-sm text-slate-600">{t('dataSummary.transactions')}</div>
                   </div>
-                  <div className="text-center p-3 bg-gray-50 rounded-lg">
-                    <div className="text-2xl font-bold text-primary-600">{summary.totalCategories}</div>
-                    <div className="text-sm text-gray-600">{t('dataSummary.categories')}</div>
+                  <div className="text-center p-3 bg-violet-50/40 rounded-xl border border-violet-100/60">
+                    <div className="text-2xl font-bold text-violet-600">{summary.totalCategories}</div>
+                    <div className="text-sm text-slate-600">{t('dataSummary.categories')}</div>
                   </div>
-                  <div className="text-center p-3 bg-gray-50 rounded-lg">
-                    <div className="text-2xl font-bold text-primary-600">{summary.totalRules}</div>
-                    <div className="text-sm text-gray-600">{t('dataSummary.rules')}</div>
+                  <div className="text-center p-3 bg-violet-50/40 rounded-xl border border-violet-100/60">
+                    <div className="text-2xl font-bold text-violet-600">{summary.totalRules}</div>
+                    <div className="text-sm text-slate-600">{t('dataSummary.rules')}</div>
                   </div>
                 </div>
               ) : (
-                <p className="text-gray-500">{t('dataSummary.unavailable')}</p>
+                <p className="text-slate-500">{t('dataSummary.unavailable')}</p>
               )}
             </CardContent>
           </Card>
 
           {/* Export Data Card */}
-          <Card className="bg-white/90 backdrop-blur-xs border-0 shadow-lg">
+          <Card className="rounded-[26px] border border-violet-100/70 bg-white/92 shadow-[0_20px_46px_-30px_rgba(76,29,149,0.45)] backdrop-blur-xs">
             <CardContent className="p-6">
               <div className="flex items-start gap-4">
                 <div className="w-12 h-12 bg-gradient-to-br from-blue-400 to-blue-600 rounded-xl flex items-center justify-center shrink-0">
                   <ArrowDownTrayIcon className="w-6 h-6 text-white" />
                 </div>
                 <div className="flex-1">
-                  <h2 className="text-lg font-semibold text-gray-900">{t('export.title')}</h2>
-                  <p className="text-sm text-gray-600 mt-1 mb-4">
+                  <h2 className="text-lg font-semibold text-slate-900">{t('export.title')}</h2>
+                  <p className="text-sm text-slate-500 mt-1 mb-4">
                     {t('export.description')}
                   </p>
                   <Button
@@ -199,15 +199,15 @@ export default function PrivacySettingsPage() {
           </Card>
 
           {/* Delete Account Card */}
-          <Card className="bg-white/90 backdrop-blur-xs border-0 shadow-lg border-l-4 border-l-red-500">
+          <Card className="rounded-[26px] border border-violet-100/70 bg-white/92 shadow-[0_20px_46px_-30px_rgba(76,29,149,0.45)] backdrop-blur-xs border-l-4 border-l-red-500">
             <CardContent className="p-6">
               <div className="flex items-start gap-4">
                 <div className="w-12 h-12 bg-gradient-to-br from-red-400 to-red-600 rounded-xl flex items-center justify-center shrink-0">
                   <TrashIcon className="w-6 h-6 text-white" />
                 </div>
                 <div className="flex-1">
-                  <h2 className="text-lg font-semibold text-gray-900">{t('delete.title')}</h2>
-                  <p className="text-sm text-gray-600 mt-1 mb-4">
+                  <h2 className="text-lg font-semibold text-slate-900">{t('delete.title')}</h2>
+                  <p className="text-sm text-slate-500 mt-1 mb-4">
                     {t('delete.description')}
                   </p>
 

--- a/frontend/src/app/settings/telegram/page.tsx
+++ b/frontend/src/app/settings/telegram/page.tsx
@@ -131,7 +131,7 @@ export default function TelegramSettingsPage() {
           <div className="w-16 h-16 bg-gradient-to-br from-violet-500 to-fuchsia-500 rounded-2xl shadow-2xl flex items-center justify-center animate-pulse mx-auto">
             <ChatBubbleBottomCenterTextIcon className="w-8 h-8 text-white" />
           </div>
-          <div className="mt-6 text-gray-700 font-medium">{tCommon('loading')}</div>
+          <div className="mt-6 text-slate-700 font-medium">{tCommon('loading')}</div>
         </div>
       </div>
     );
@@ -146,7 +146,7 @@ export default function TelegramSettingsPage() {
       {/* Back link */}
         <Link
           href="/settings"
-          className="inline-flex items-center gap-2 text-sm text-gray-600 hover:text-gray-900 mb-4"
+          className="inline-flex items-center gap-2 text-sm text-slate-600 hover:text-slate-900 mb-4"
         >
           <ArrowLeftIcon className="w-4 h-4" />
           {t('backToSettings')}
@@ -155,32 +155,32 @@ export default function TelegramSettingsPage() {
         {/* Header */}
         <div className="mb-6 lg:mb-8">
           <div className="flex items-center gap-3 mb-1">
-            <div className="w-10 h-10 bg-gradient-to-br from-primary-400 to-primary-600 rounded-xl flex items-center justify-center">
+            <div className="w-10 h-10 bg-gradient-to-br from-violet-500 to-violet-600 rounded-xl flex items-center justify-center">
               <ChatBubbleBottomCenterTextIcon className="w-5 h-5 text-white" />
             </div>
             <div>
-              <h1 className="text-2xl sm:text-3xl lg:text-4xl font-bold text-gray-900">
+              <h1 className="font-[var(--font-dash-sans)] text-3xl font-semibold tracking-[-0.03em] text-slate-900 sm:text-[2.1rem]">
                 {t('title')}
               </h1>
-              <p className="text-gray-600 mt-0.5">{t('subtitle')}</p>
+              <p className="text-[15px] text-slate-500 mt-0.5">{t('subtitle')}</p>
             </div>
           </div>
         </div>
 
         {loadingSettings ? (
-          <Card className="bg-white/90 backdrop-blur-xs border-0 shadow-lg">
+          <Card className="rounded-[26px] border border-violet-100/70 bg-white/92 shadow-[0_20px_46px_-30px_rgba(76,29,149,0.45)] backdrop-blur-xs">
             <CardContent className="p-6">
               <div className="animate-pulse space-y-4">
-                <div className="h-4 bg-gray-200 rounded w-1/3"></div>
-                <div className="h-10 bg-gray-200 rounded"></div>
-                <div className="h-4 bg-gray-200 rounded w-1/4"></div>
+                <div className="h-4 bg-slate-200 rounded w-1/3"></div>
+                <div className="h-10 bg-slate-200 rounded"></div>
+                <div className="h-4 bg-slate-200 rounded w-1/4"></div>
               </div>
             </CardContent>
           </Card>
         ) : settings?.hasSettings ? (
           /* State 2: Connected */
           <div className="space-y-4">
-            <Card className="bg-white/90 backdrop-blur-xs border-0 shadow-lg">
+            <Card className="rounded-[26px] border border-violet-100/70 bg-white/92 shadow-[0_20px_46px_-30px_rgba(76,29,149,0.45)] backdrop-blur-xs">
               <CardContent className="p-4">
                 <div className="flex items-start gap-3">
                   <CheckCircleIcon className="w-5 h-5 text-green-600 shrink-0 mt-0.5" />
@@ -201,9 +201,9 @@ export default function TelegramSettingsPage() {
               </CardContent>
             </Card>
 
-            <Card className="bg-white/90 backdrop-blur-xs border-0 shadow-lg">
+            <Card className="rounded-[26px] border border-violet-100/70 bg-white/92 shadow-[0_20px_46px_-30px_rgba(76,29,149,0.45)] backdrop-blur-xs">
               <CardContent className="p-6">
-                <p className="text-sm text-gray-600 mb-4">{t('connectedDescription')}</p>
+                <p className="text-sm text-slate-500 mb-4">{t('connectedDescription')}</p>
                 <Button
                   variant="danger"
                   onClick={() => setShowDisconnectConfirm(true)}
@@ -218,10 +218,10 @@ export default function TelegramSettingsPage() {
           /* State 1: Not configured (wizard) */
           <div className="space-y-4">
             {/* Instructions */}
-            <Card className="bg-white/90 backdrop-blur-xs border-0 shadow-lg">
+            <Card className="rounded-[26px] border border-violet-100/70 bg-white/92 shadow-[0_20px_46px_-30px_rgba(76,29,149,0.45)] backdrop-blur-xs">
               <CardContent className="p-6">
-                <h2 className="text-lg font-semibold text-gray-900 mb-3">{t('setup.title')}</h2>
-                <ol className="list-decimal list-inside space-y-2 text-sm text-gray-700">
+                <h2 className="text-lg font-semibold text-slate-900 mb-3">{t('setup.title')}</h2>
+                <ol className="list-decimal list-inside space-y-2 text-sm text-slate-700">
                   <li>{t('setup.step1')}</li>
                   <li>{t('setup.step2')}</li>
                   <li>{t('setup.step3')}</li>
@@ -231,7 +231,7 @@ export default function TelegramSettingsPage() {
                   href="https://t.me/BotFather"
                   target="_blank"
                   rel="noopener noreferrer"
-                  className="inline-block mt-3 text-sm text-primary-600 hover:text-primary-800 font-medium"
+                  className="inline-block mt-3 text-sm text-violet-600 hover:text-violet-800 font-medium"
                 >
                   {t('setup.openBotFather')}
                 </a>
@@ -239,10 +239,10 @@ export default function TelegramSettingsPage() {
             </Card>
 
             {/* Token Input & Actions */}
-            <Card className="bg-white/90 backdrop-blur-xs border-0 shadow-lg">
+            <Card className="rounded-[26px] border border-violet-100/70 bg-white/92 shadow-[0_20px_46px_-30px_rgba(76,29,149,0.45)] backdrop-blur-xs">
               <CardContent className="p-6 space-y-5">
                 <div>
-                  <label className="block text-sm font-medium text-gray-700 mb-1.5">
+                  <label className="block text-sm font-medium text-slate-700 mb-1.5">
                     {t('token.label')}
                   </label>
                   <Input
@@ -255,7 +255,7 @@ export default function TelegramSettingsPage() {
                     placeholder={t('token.placeholder')}
                     className="w-full"
                   />
-                  <p className="text-xs text-gray-500 mt-1.5">{t('token.hint')}</p>
+                  <p className="text-xs text-slate-500 mt-1.5">{t('token.hint')}</p>
                 </div>
 
                 {/* Test Token */}
@@ -286,7 +286,7 @@ export default function TelegramSettingsPage() {
                 </div>
 
                 {/* Connect */}
-                <div className="pt-3 border-t border-gray-100">
+                <div className="pt-3 border-t border-slate-100">
                   <Button
                     variant="primary"
                     onClick={handleConnect}


### PR DESCRIPTION
## Summary

- Applied consistent design tokens from the analytics/rules reference pages across all 6 pages
- Replaced `text-gray-*` with `text-slate-*` throughout
- Updated card styles to use `rounded-[26px] border border-violet-100/70 bg-white/92 shadow-[0_20px_46px_-30px_rgba(76,29,149,0.45)] backdrop-blur-xs`
- Changed icon gradients from `from-primary-400 to-primary-600` to `from-violet-500 to-violet-600`
- Updated headings to use `font-[var(--font-dash-sans)] text-3xl font-semibold tracking-[-0.03em]`
- Toggle switches updated to `bg-violet-600` / `bg-slate-200`
- Chat: user message bubbles `bg-violet-600`, suggested prompts with violet hover, textarea `focus:ring-violet-500`
- Privacy: data summary stat boxes use violet accent instead of primary
- No functionality changes — styling only

## Pages updated
1. `settings/page.tsx` — Settings Main
2. `settings/ai/page.tsx` — AI Settings
3. `settings/bank-connections/page.tsx` — Bank Connections
4. `settings/telegram/page.tsx` — Telegram Settings
5. `settings/privacy/page.tsx` — Privacy Settings
6. `chat/page.tsx` — Chat / Ask Alce

## Test plan
- [ ] Visit `/settings` — cards use violet shadow, slate text, violet icon gradients
- [ ] Visit `/settings/ai` — tabs use violet underline, cards use modern shadow
- [ ] Visit `/settings/bank-connections` — violet icon on card title, slate header
- [ ] Visit `/settings/telegram` — consistent card styling, violet BotFather link
- [ ] Visit `/settings/privacy` — violet stat boxes, modern card panels
- [ ] Visit `/chat` — violet user bubbles, violet suggested prompt hover, violet send button ring
- [ ] `npm run build` passes ✅

🤖 Generated with [Claude Code](https://claude.com/claude-code)