### PR TITLE
feat: Terms of Service and Privacy Policy pages (#52)

### DIFF
--- a/frontend/src/app/privacy/page.tsx
+++ b/frontend/src/app/privacy/page.tsx
@@ -12,7 +12,7 @@ export default function PrivacyPolicyPage() {
 
         <div className="bg-white rounded-lg shadow-sm p-8 sm:p-12 prose prose-gray max-w-none">
           <h1 className="text-3xl font-bold text-gray-900 mb-2">Privacy Policy</h1>
-          <p className="text-sm text-gray-500 mb-8">Last updated: February 2025</p>
+          <p className="text-sm text-gray-500 mb-8">Last updated: February 2026</p>
 
           <h2 className="text-xl font-semibold text-gray-900 mt-8 mb-4">Overview</h2>
           <p className="text-gray-700 mb-4">
@@ -76,10 +76,24 @@ export default function PrivacyPolicyPage() {
           <ul className="list-disc pl-6 text-gray-700 mb-4 space-y-1">
             <li><strong>What is shared:</strong> Transaction descriptions and amounts are sent to OpenAI for categorization suggestions.</li>
             <li><strong>When:</strong> Only when AI-powered categorization is triggered during transaction review.</li>
+            <li><strong>Data retention:</strong> OpenAI API usage data is subject to OpenAI&apos;s data retention policies. We use the API with zero data retention where available.</li>
             <li>
               <strong>Their policy:</strong>{' '}
               <a href="https://openai.com/privacy/" target="_blank" rel="noopener noreferrer" className="text-primary hover:text-primary-600 underline">
                 OpenAI Privacy Policy
+              </a>
+            </li>
+          </ul>
+
+          <h3 className="text-lg font-semibold text-gray-900 mt-6 mb-3">Stripe (Payment Processing)</h3>
+          <ul className="list-disc pl-6 text-gray-700 mb-4 space-y-1">
+            <li><strong>What is shared:</strong> Email address and payment information are processed by Stripe for subscription management.</li>
+            <li><strong>When:</strong> Only if you subscribe to a paid plan or make a payment.</li>
+            <li><strong>Note:</strong> We do not store your full credit card details. All payment data is handled securely by Stripe.</li>
+            <li>
+              <strong>Their policy:</strong>{' '}
+              <a href="https://stripe.com/privacy" target="_blank" rel="noopener noreferrer" className="text-primary hover:text-primary-600 underline">
+                Stripe Privacy Policy
               </a>
             </li>
           </ul>
@@ -93,15 +107,44 @@ export default function PrivacyPolicyPage() {
           <h2 className="text-xl font-semibold text-gray-900 mt-8 mb-4">Data Retention</h2>
           <p className="text-gray-700 mb-4">
             Your data is retained for as long as your account is active. If you delete your account,
-            your data will be removed from our systems.
+            your data will be permanently removed from our systems. Backups containing your data may
+            persist for up to 30 days after deletion before being fully purged.
           </p>
 
           <h2 className="text-xl font-semibold text-gray-900 mt-8 mb-4">Your Rights</h2>
           <ul className="list-disc pl-6 text-gray-700 mb-4 space-y-2">
-            <li><strong>Export:</strong> You can export your transaction data from within the application.</li>
-            <li><strong>Deletion:</strong> You can delete your account and all associated data from your account settings.</li>
             <li><strong>Access:</strong> All your data is visible to you within the application at all times.</li>
+            <li><strong>Export:</strong> You can export your transaction data from within the application.</li>
+            <li><strong>Rectification:</strong> You can edit and correct your data directly in the application.</li>
+            <li><strong>Deletion:</strong> You can delete your account and all associated data from your account settings.</li>
+            <li><strong>Portability:</strong> You can export your data in standard formats for use with other services.</li>
           </ul>
+
+          <h2 className="text-xl font-semibold text-gray-900 mt-8 mb-4">GDPR &amp; European Users</h2>
+          <p className="text-gray-700 mb-4">
+            If you are located in the European Economic Area (EEA), you have rights under the General
+            Data Protection Regulation (GDPR). In addition to the rights listed above, you may:
+          </p>
+          <ul className="list-disc pl-6 text-gray-700 mb-4 space-y-2">
+            <li><strong>Object</strong> to certain types of data processing.</li>
+            <li><strong>Restrict</strong> the processing of your personal data in specific circumstances.</li>
+            <li><strong>Lodge a complaint</strong> with your local data protection authority.</li>
+          </ul>
+          <p className="text-gray-700 mb-4">
+            The legal basis for processing your data is your consent (provided at registration) and the
+            legitimate interest of providing the service you signed up for. To exercise any of these rights,
+            contact us at{' '}
+            <a href="mailto:support@mymascada.com" className="text-primary hover:text-primary-600 underline">
+              support@mymascada.com
+            </a>.
+          </p>
+
+          <h2 className="text-xl font-semibold text-gray-900 mt-8 mb-4">Security</h2>
+          <p className="text-gray-700 mb-4">
+            We take reasonable measures to protect your data, including encrypted connections (HTTPS),
+            hashed passwords, and access controls. However, no system is 100% secure, and we cannot
+            guarantee absolute security.
+          </p>
 
           <h2 className="text-xl font-semibold text-gray-900 mt-8 mb-4">Changes to This Policy</h2>
           <p className="text-gray-700 mb-4">
@@ -112,7 +155,11 @@ export default function PrivacyPolicyPage() {
           <hr className="my-8 border-gray-200" />
 
           <p className="text-sm text-gray-500">
-            Questions about your data? Reach out via the{' '}
+            Questions about your data? Reach out at{' '}
+            <a href="mailto:support@mymascada.com" className="text-primary hover:text-primary-600 underline">
+              support@mymascada.com
+            </a>{' '}
+            or via the{' '}
             <a href="https://github.com/digaomatias/mymascada/discussions" target="_blank" rel="noopener noreferrer" className="text-primary hover:text-primary-600 underline">
               GitHub Discussions
             </a> page. Also see our <Link href="/terms" className="text-primary hover:text-primary-600 underline">Terms of Service</Link>.

--- a/frontend/src/app/terms/page.tsx
+++ b/frontend/src/app/terms/page.tsx
@@ -12,7 +12,7 @@ export default function TermsOfServicePage() {
 
         <div className="bg-white rounded-lg shadow-sm p-8 sm:p-12 prose prose-gray max-w-none">
           <h1 className="text-3xl font-bold text-gray-900 mb-2">Terms of Service</h1>
-          <p className="text-sm text-gray-500 mb-8">Last updated: February 2025</p>
+          <p className="text-sm text-gray-500 mb-8">Last updated: February 2026</p>
 
           <h2 className="text-xl font-semibold text-gray-900 mt-8 mb-4">What is MyMascada?</h2>
           <p className="text-gray-700 mb-4">
@@ -33,7 +33,9 @@ export default function TermsOfServicePage() {
           <p className="text-gray-700 mb-4">
             MyMascada is a tool for tracking and organizing your personal finances. Nothing in this application
             constitutes financial advice, investment advice, tax advice, or any other form of professional advice.
-            You are solely responsible for your financial decisions.
+            Any AI-generated categorizations or insights are for informational purposes only. You are solely
+            responsible for your financial decisions. Always consult a qualified professional for financial,
+            tax, or legal matters.
           </p>
 
           <h2 className="text-xl font-semibold text-gray-900 mt-8 mb-4">Limitation of Liability</h2>
@@ -51,6 +53,17 @@ export default function TermsOfServicePage() {
             <li>You agree not to attempt to access other users&apos; data or disrupt the service.</li>
           </ul>
 
+          <h2 className="text-xl font-semibold text-gray-900 mt-8 mb-4">Your Rights</h2>
+          <p className="text-gray-700 mb-4">
+            You retain ownership of all data you enter into MyMascada. You have the right to:
+          </p>
+          <ul className="list-disc pl-6 text-gray-700 mb-4 space-y-2">
+            <li><strong>Access</strong> all your personal data at any time through the application.</li>
+            <li><strong>Export</strong> your transaction and financial data.</li>
+            <li><strong>Delete</strong> your account and all associated data from your account settings.</li>
+            <li><strong>Rectify</strong> any inaccurate data by editing it within the application.</li>
+          </ul>
+
           <h2 className="text-xl font-semibold text-gray-900 mt-8 mb-4">Account Termination</h2>
           <p className="text-gray-700 mb-4">
             The operator reserves the right to suspend or terminate any account, or discontinue the service
@@ -62,6 +75,35 @@ export default function TermsOfServicePage() {
           <p className="text-gray-700 mb-4">
             For details on how your data is collected, used, and stored, please refer to
             the <Link href="/privacy" className="text-primary hover:text-primary-600 underline">Privacy Policy</Link>.
+          </p>
+
+          <h2 className="text-xl font-semibold text-gray-900 mt-8 mb-4">Third-Party Services</h2>
+          <p className="text-gray-700 mb-4">
+            MyMascada may integrate with third-party services to provide its features. These include, but
+            are not limited to:
+          </p>
+          <ul className="list-disc pl-6 text-gray-700 mb-4 space-y-2">
+            <li><strong>OpenAI</strong> &mdash; for AI-powered transaction categorization (optional, only when enabled).</li>
+            <li><strong>Stripe</strong> &mdash; for payment processing (optional, only if subscription features are used).</li>
+            <li><strong>Akahu</strong> &mdash; for bank account syncing in New Zealand (optional, only when connected).</li>
+            <li><strong>Google</strong> &mdash; for OAuth sign-in (optional, only if you choose &quot;Sign in with Google&quot;).</li>
+          </ul>
+          <p className="text-gray-700 mb-4">
+            Your use of these integrations is subject to each provider&apos;s own terms and privacy policies.
+            Data is only shared with these services when you actively use the corresponding feature. See
+            our <Link href="/privacy" className="text-primary hover:text-primary-600 underline">Privacy Policy</Link> for
+            full details.
+          </p>
+
+          <h2 className="text-xl font-semibold text-gray-900 mt-8 mb-4">GDPR &amp; Data Protection</h2>
+          <p className="text-gray-700 mb-4">
+            If you are located in the European Economic Area (EEA), you have additional rights under the
+            General Data Protection Regulation (GDPR), including the right to access, rectify, port, and
+            erase your personal data, as well as the right to restrict or object to certain processing.
+            To exercise these rights, contact us at{' '}
+            <a href="mailto:support@mymascada.com" className="text-primary hover:text-primary-600 underline">
+              support@mymascada.com
+            </a>.
           </p>
 
           <h2 className="text-xl font-semibold text-gray-900 mt-8 mb-4">Open Source</h2>
@@ -81,7 +123,11 @@ export default function TermsOfServicePage() {
           <hr className="my-8 border-gray-200" />
 
           <p className="text-sm text-gray-500">
-            Questions? Reach out via the{' '}
+            Questions? Reach out at{' '}
+            <a href="mailto:support@mymascada.com" className="text-primary hover:text-primary-600 underline">
+              support@mymascada.com
+            </a>{' '}
+            or via the{' '}
             <a href="https://github.com/digaomatias/mymascada/discussions" target="_blank" rel="noopener noreferrer" className="text-primary hover:text-primary-600 underline">
               GitHub Discussions
             </a> page.


### PR DESCRIPTION
## Summary
Comprehensive legal pages for SaaS readiness.

### Changes
- **Terms of Service** (`/terms`): no warranty, not financial advice, limitation of liability, user rights (access/export/delete data), account termination, third-party services
- **Privacy Policy** (`/privacy`): data collection details, encryption, third-party services (AI & Stripe — clearly marked as optional), GDPR rights, cookie policy, data retention
- Registration checkbox already existed ✅

### Self-hosting impact
**None.** Pages exist for anyone to customize with their own terms. Content references MyMascada defaults.

Closes #52