### PR TITLE
feat: AI token usage monitoring and tracking

### DIFF
--- a/src/Core/MyMascada.Application/Common/Interfaces/IAiTokenTracker.cs
+++ b/src/Core/MyMascada.Application/Common/Interfaces/IAiTokenTracker.cs
@@ -1,0 +1,53 @@
+namespace MyMascada.Application.Common.Interfaces;
+
+public interface IAiTokenTracker
+{
+    Task TrackUsageAsync(Guid userId, string model, string operation, int promptTokens, int completionTokens);
+    Task<AiUsageSummary> GetUsageSummaryAsync(Guid userId, DateTime from, DateTime to);
+    Task<int> GetTotalTokensUsedTodayAsync();
+    Task<AiUsageAdminSummary> GetAdminSummaryAsync(DateTime from, DateTime to);
+}
+
+public class AiUsageSummary
+{
+    public int TotalPromptTokens { get; set; }
+    public int TotalCompletionTokens { get; set; }
+    public int TotalTokens { get; set; }
+    public decimal TotalEstimatedCostUsd { get; set; }
+    public List<AiUsageByOperation> ByOperation { get; set; } = new();
+    public List<AiUsageByDay> ByDay { get; set; } = new();
+}
+
+public class AiUsageByOperation
+{
+    public string Operation { get; set; } = string.Empty;
+    public int TotalTokens { get; set; }
+    public int RequestCount { get; set; }
+    public decimal EstimatedCostUsd { get; set; }
+}
+
+public class AiUsageByDay
+{
+    public DateTime Date { get; set; }
+    public int TotalTokens { get; set; }
+    public int RequestCount { get; set; }
+    public decimal EstimatedCostUsd { get; set; }
+}
+
+public class AiUsageAdminSummary
+{
+    public int TotalTokensToday { get; set; }
+    public int TotalRequestsToday { get; set; }
+    public decimal TotalCostToday { get; set; }
+    public List<AiUsageByUser> ByUser { get; set; } = new();
+    public List<AiUsageByOperation> ByOperation { get; set; } = new();
+    public List<AiUsageByDay> Daily { get; set; } = new();
+}
+
+public class AiUsageByUser
+{
+    public Guid UserId { get; set; }
+    public int TotalTokens { get; set; }
+    public int RequestCount { get; set; }
+    public decimal EstimatedCostUsd { get; set; }
+}

--- a/src/Core/MyMascada.Domain/Entities/AiTokenUsage.cs
+++ b/src/Core/MyMascada.Domain/Entities/AiTokenUsage.cs
@@ -1,0 +1,15 @@
+using MyMascada.Domain.Common;
+
+namespace MyMascada.Domain.Entities;
+
+public class AiTokenUsage : BaseEntity<int>
+{
+    public Guid UserId { get; set; }
+    public DateTime Timestamp { get; set; }
+    public string Model { get; set; } = string.Empty;
+    public string Operation { get; set; } = string.Empty; // chat, categorization, csv-import, rule-suggestion
+    public int PromptTokens { get; set; }
+    public int CompletionTokens { get; set; }
+    public int TotalTokens { get; set; }
+    public decimal EstimatedCostUsd { get; set; }
+}

--- a/src/Infrastructure/MyMascada.Infrastructure/Data/ApplicationDbContext.cs
+++ b/src/Infrastructure/MyMascada.Infrastructure/Data/ApplicationDbContext.cs
@@ -47,6 +47,7 @@ public class ApplicationDbContext : DbContext
     public DbSet<Goal> Goals => Set<Goal>();
     public DbSet<UserFinancialProfile> UserFinancialProfiles => Set<UserFinancialProfile>();
     public DbSet<DashboardNudgeDismissal> DashboardNudgeDismissals => Set<DashboardNudgeDismissal>();
+    public DbSet<AiTokenUsage> AiTokenUsages => Set<AiTokenUsage>();
 
     protected override void OnModelCreating(ModelBuilder modelBuilder)
     {
@@ -815,6 +816,24 @@ public class ApplicationDbContext : DbContext
             entity.Property(e => e.NudgeType).IsRequired().HasMaxLength(50);
 
             entity.HasIndex(e => new { e.UserId, e.NudgeType }).IsUnique();
+
+            entity.HasQueryFilter(e => !e.IsDeleted);
+        });
+
+        // AiTokenUsage configuration
+        modelBuilder.Entity<AiTokenUsage>(entity =>
+        {
+            entity.HasKey(e => e.Id);
+            entity.Property(e => e.UserId).IsRequired();
+            entity.Property(e => e.Timestamp).IsRequired();
+            entity.Property(e => e.Model).IsRequired().HasMaxLength(100);
+            entity.Property(e => e.Operation).IsRequired().HasMaxLength(50);
+            entity.Property(e => e.EstimatedCostUsd).HasPrecision(18, 8);
+
+            entity.HasIndex(e => e.UserId);
+            entity.HasIndex(e => e.Timestamp);
+            entity.HasIndex(e => new { e.UserId, e.Timestamp });
+            entity.HasIndex(e => e.Operation);
 
             entity.HasQueryFilter(e => !e.IsDeleted);
         });

--- a/src/Infrastructure/MyMascada.Infrastructure/Services/AI/AiTokenTracker.cs
+++ b/src/Infrastructure/MyMascada.Infrastructure/Services/AI/AiTokenTracker.cs
@@ -1,0 +1,165 @@
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Logging;
+using MyMascada.Application.Common.Interfaces;
+using MyMascada.Domain.Common;
+using MyMascada.Domain.Entities;
+using MyMascada.Infrastructure.Data;
+
+namespace MyMascada.Infrastructure.Services.AI;
+
+public class AiTokenTracker : IAiTokenTracker
+{
+    private readonly ApplicationDbContext _dbContext;
+    private readonly ILogger<AiTokenTracker> _logger;
+
+    public AiTokenTracker(ApplicationDbContext dbContext, ILogger<AiTokenTracker> logger)
+    {
+        _dbContext = dbContext;
+        _logger = logger;
+    }
+
+    public async Task TrackUsageAsync(Guid userId, string model, string operation, int promptTokens, int completionTokens)
+    {
+        try
+        {
+            var totalTokens = promptTokens + completionTokens;
+            var estimatedCost = CalculateEstimatedCost(model, promptTokens, completionTokens);
+
+            var usage = new AiTokenUsage
+            {
+                UserId = userId,
+                Timestamp = DateTimeProvider.UtcNow,
+                Model = model,
+                Operation = operation,
+                PromptTokens = promptTokens,
+                CompletionTokens = completionTokens,
+                TotalTokens = totalTokens,
+                EstimatedCostUsd = estimatedCost
+            };
+
+            _dbContext.AiTokenUsages.Add(usage);
+            await _dbContext.SaveChangesAsync();
+
+            _logger.LogInformation(
+                "AI token usage tracked - User: {UserId}, Operation: {Operation}, Model: {Model}, Tokens: {TotalTokens}, Cost: ${Cost:F6}",
+                userId, operation, model, totalTokens, estimatedCost);
+        }
+        catch (Exception ex)
+        {
+            // Don't let tracking failures break the main flow
+            _logger.LogError(ex, "Failed to track AI token usage for user {UserId}, operation {Operation}", userId, operation);
+        }
+    }
+
+    public async Task<AiUsageSummary> GetUsageSummaryAsync(Guid userId, DateTime from, DateTime to)
+    {
+        var usages = await _dbContext.AiTokenUsages
+            .Where(u => u.UserId == userId && u.Timestamp >= from && u.Timestamp <= to)
+            .ToListAsync();
+
+        return new AiUsageSummary
+        {
+            TotalPromptTokens = usages.Sum(u => u.PromptTokens),
+            TotalCompletionTokens = usages.Sum(u => u.CompletionTokens),
+            TotalTokens = usages.Sum(u => u.TotalTokens),
+            TotalEstimatedCostUsd = usages.Sum(u => u.EstimatedCostUsd),
+            ByOperation = usages
+                .GroupBy(u => u.Operation)
+                .Select(g => new AiUsageByOperation
+                {
+                    Operation = g.Key,
+                    TotalTokens = g.Sum(u => u.TotalTokens),
+                    RequestCount = g.Count(),
+                    EstimatedCostUsd = g.Sum(u => u.EstimatedCostUsd)
+                })
+                .OrderByDescending(o => o.TotalTokens)
+                .ToList(),
+            ByDay = usages
+                .GroupBy(u => u.Timestamp.Date)
+                .Select(g => new AiUsageByDay
+                {
+                    Date = g.Key,
+                    TotalTokens = g.Sum(u => u.TotalTokens),
+                    RequestCount = g.Count(),
+                    EstimatedCostUsd = g.Sum(u => u.EstimatedCostUsd)
+                })
+                .OrderBy(d => d.Date)
+                .ToList()
+        };
+    }
+
+    public async Task<int> GetTotalTokensUsedTodayAsync()
+    {
+        var todayUtc = DateTimeProvider.UtcNow.Date;
+        return await _dbContext.AiTokenUsages
+            .Where(u => u.Timestamp >= todayUtc)
+            .SumAsync(u => u.TotalTokens);
+    }
+
+    public async Task<AiUsageAdminSummary> GetAdminSummaryAsync(DateTime from, DateTime to)
+    {
+        var usages = await _dbContext.AiTokenUsages
+            .Where(u => u.Timestamp >= from && u.Timestamp <= to)
+            .ToListAsync();
+
+        var todayUtc = DateTimeProvider.UtcNow.Date;
+        var todayUsages = usages.Where(u => u.Timestamp >= todayUtc).ToList();
+
+        return new AiUsageAdminSummary
+        {
+            TotalTokensToday = todayUsages.Sum(u => u.TotalTokens),
+            TotalRequestsToday = todayUsages.Count,
+            TotalCostToday = todayUsages.Sum(u => u.EstimatedCostUsd),
+            ByUser = usages
+                .GroupBy(u => u.UserId)
+                .Select(g => new AiUsageByUser
+                {
+                    UserId = g.Key,
+                    TotalTokens = g.Sum(u => u.TotalTokens),
+                    RequestCount = g.Count(),
+                    EstimatedCostUsd = g.Sum(u => u.EstimatedCostUsd)
+                })
+                .OrderByDescending(u => u.TotalTokens)
+                .ToList(),
+            ByOperation = usages
+                .GroupBy(u => u.Operation)
+                .Select(g => new AiUsageByOperation
+                {
+                    Operation = g.Key,
+                    TotalTokens = g.Sum(u => u.TotalTokens),
+                    RequestCount = g.Count(),
+                    EstimatedCostUsd = g.Sum(u => u.EstimatedCostUsd)
+                })
+                .OrderByDescending(o => o.TotalTokens)
+                .ToList(),
+            Daily = usages
+                .GroupBy(u => u.Timestamp.Date)
+                .Select(g => new AiUsageByDay
+                {
+                    Date = g.Key,
+                    TotalTokens = g.Sum(u => u.TotalTokens),
+                    RequestCount = g.Count(),
+                    EstimatedCostUsd = g.Sum(u => u.EstimatedCostUsd)
+                })
+                .OrderBy(d => d.Date)
+                .ToList()
+        };
+    }
+
+    private static decimal CalculateEstimatedCost(string model, int promptTokens, int completionTokens)
+    {
+        // Pricing per 1M tokens (as of 2025)
+        var (inputPricePerMillion, outputPricePerMillion) = model.ToLowerInvariant() switch
+        {
+            var m when m.Contains("gpt-4o-mini") => (0.15m, 0.60m),
+            var m when m.Contains("gpt-4o") => (2.50m, 10.00m),
+            var m when m.Contains("gpt-4-turbo") => (10.00m, 30.00m),
+            var m when m.Contains("gpt-4") => (30.00m, 60.00m),
+            var m when m.Contains("gpt-3.5") => (0.50m, 1.50m),
+            _ => (0.15m, 0.60m) // Default to gpt-4o-mini pricing
+        };
+
+        return (promptTokens * inputPricePerMillion / 1_000_000m)
+             + (completionTokens * outputPricePerMillion / 1_000_000m);
+    }
+}

--- a/src/Infrastructure/MyMascada.Infrastructure/Services/AI/SemanticKernelTokenExtractor.cs
+++ b/src/Infrastructure/MyMascada.Infrastructure/Services/AI/SemanticKernelTokenExtractor.cs
@@ -1,0 +1,68 @@
+using Microsoft.Extensions.Logging;
+
+namespace MyMascada.Infrastructure.Services.AI;
+
+/// <summary>
+/// Extracts token usage information from Semantic Kernel response metadata.
+/// Semantic Kernel stores OpenAI usage data in Metadata["Usage"] as a CompletionsUsage object.
+/// </summary>
+public static class SemanticKernelTokenExtractor
+{
+    public static (int promptTokens, int completionTokens, int totalTokens) ExtractTokenUsage(
+        IReadOnlyDictionary<string, object?>? metadata, ILogger? logger = null)
+    {
+        if (metadata == null)
+            return (0, 0, 0);
+
+        try
+        {
+            if (!metadata.TryGetValue("Usage", out var usageObj) || usageObj == null)
+                return (0, 0, 0);
+
+            // Semantic Kernel exposes usage as dynamic objects from different OpenAI SDK versions.
+            // Use reflection to extract the token counts robustly.
+            var usageType = usageObj.GetType();
+
+            var promptTokens = TryGetIntProperty(usageType, usageObj, "InputTokenCount")
+                ?? TryGetIntProperty(usageType, usageObj, "PromptTokens")
+                ?? 0;
+
+            var completionTokens = TryGetIntProperty(usageType, usageObj, "OutputTokenCount")
+                ?? TryGetIntProperty(usageType, usageObj, "CompletionTokens")
+                ?? 0;
+
+            var totalTokens = TryGetIntProperty(usageType, usageObj, "TotalTokenCount")
+                ?? TryGetIntProperty(usageType, usageObj, "TotalTokens")
+                ?? (promptTokens + completionTokens);
+
+            return (promptTokens, completionTokens, totalTokens);
+        }
+        catch (Exception ex)
+        {
+            logger?.LogDebug(ex, "Failed to extract token usage from metadata");
+            return (0, 0, 0);
+        }
+    }
+
+    public static string ExtractModelId(IReadOnlyDictionary<string, object?>? metadata)
+    {
+        if (metadata == null)
+            return "unknown";
+
+        if (metadata.TryGetValue("ModelId", out var modelObj) && modelObj is string modelId && !string.IsNullOrEmpty(modelId))
+            return modelId;
+
+        return "unknown";
+    }
+
+    private static int? TryGetIntProperty(Type type, object obj, string propertyName)
+    {
+        var prop = type.GetProperty(propertyName);
+        if (prop == null) return null;
+
+        var value = prop.GetValue(obj);
+        if (value == null) return null;
+
+        return Convert.ToInt32(value);
+    }
+}

--- a/src/WebAPI/MyMascada.WebAPI/Controllers/AdminController.cs
+++ b/src/WebAPI/MyMascada.WebAPI/Controllers/AdminController.cs
@@ -15,15 +15,18 @@ public class AdminController : ControllerBase
     private readonly IMediator _mediator;
     private readonly IWaitlistRepository _waitlistRepository;
     private readonly IInvitationCodeRepository _invitationCodeRepository;
+    private readonly IAiTokenTracker _aiTokenTracker;
 
     public AdminController(
         IMediator mediator,
         IWaitlistRepository waitlistRepository,
-        IInvitationCodeRepository invitationCodeRepository)
+        IInvitationCodeRepository invitationCodeRepository,
+        IAiTokenTracker aiTokenTracker)
     {
         _mediator = mediator;
         _waitlistRepository = waitlistRepository;
         _invitationCodeRepository = invitationCodeRepository;
+        _aiTokenTracker = aiTokenTracker;
     }
 
     [HttpGet("waitlist")]
@@ -75,6 +78,16 @@ public class AdminController : ControllerBase
         code.Status = InvitationCodeStatus.Revoked;
         await _invitationCodeRepository.UpdateAsync(code);
         return Ok(new { message = "Code revoked" });
+    }
+
+    [HttpGet("ai-usage")]
+    public async Task<IActionResult> GetAiUsage([FromQuery] int days = 30)
+    {
+        var from = DateTime.UtcNow.Date.AddDays(-days);
+        var to = DateTime.UtcNow;
+
+        var summary = await _aiTokenTracker.GetAdminSummaryAsync(from, to);
+        return Ok(summary);
     }
 }
 

--- a/src/WebAPI/MyMascada.WebAPI/Extensions/AiChatServiceExtensions.cs
+++ b/src/WebAPI/MyMascada.WebAPI/Extensions/AiChatServiceExtensions.cs
@@ -9,6 +9,7 @@ public static class AiChatServiceExtensions
     {
         services.AddScoped<IFinancialContextBuilder, FinancialContextBuilder>();
         services.AddScoped<IAiChatService, AiChatService>();
+        services.AddScoped<IAiTokenTracker, AiTokenTracker>();
         return services;
     }
 }

--- a/src/WebAPI/MyMascada.WebAPI/MyMascada.WebAPI.csproj
+++ b/src/WebAPI/MyMascada.WebAPI/MyMascada.WebAPI.csproj
@@ -8,7 +8,7 @@
 
   <ItemGroup>
     <PackageReference Include="FluentValidation.AspNetCore" Version="11.3.1" />
-    <PackageReference Include="Hangfire.Core" Version="1.8.6" />
+    <PackageReference Include="Hangfire.Core" Version="1.8.22" />
     <PackageReference Include="Hangfire.PostgreSql" Version="1.20.6" />
     <PackageReference Include="Hangfire.AspNetCore" Version="1.8.22" />
     <PackageReference Include="Microsoft.AspNetCore.Authentication.Google" Version="10.0.0" />


### PR DESCRIPTION
## Summary
Tracks all AI token usage across the app for cost monitoring and future billing integration.

### New files
- **AiTokenUsage** entity — stores per-request token counts (prompt, completion, total, estimated cost, model, operation)
- **IAiTokenTracker** interface — track usage, get summaries, check daily totals
- **AiTokenTracker** implementation — persists to DB, calculates estimated costs per model
- **SemanticKernelTokenExtractor** — extracts token usage from Semantic Kernel's ChatMessageContent.Metadata

### Wired into
- **AiChatService** — tracks chat token usage after each response
- **LlmCategorizationService** — tracks categorization token usage
- **AdminController** — GET /api/admin/ai-usage endpoint for usage stats

### Cost estimation
Built-in rates for common models:
- gpt-4o-mini: $0.15/1M input, $0.60/1M output
- gpt-4o: $2.50/1M input, $10.00/1M output

### Why
- Monitor free-tier token consumption (OpenAI data sharing program)
- Foundation for per-plan usage limits (Stripe billing integration)
- Cost visibility for the operator

### Self-hosting impact
**Positive.** Self-hosters get visibility into their AI costs too.