### PR TITLE
fix: use 3-month average for financial runway calculation

### DIFF
--- a/frontend/src/components/dashboard/cards/financial-runway-card.tsx
+++ b/frontend/src/components/dashboard/cards/financial-runway-card.tsx
@@ -7,6 +7,8 @@ import { apiClient } from '@/lib/api-client';
 import { formatCurrency, cn } from '@/lib/utils';
 
 type Period = 'month' | 'quarter';
+type MonthlySummary = { totalIncome: number; totalExpenses: number };
+const emptySummary: MonthlySummary = { totalIncome: 0, totalExpenses: 0 };
 
 interface RunwayData {
   totalBalance: number;
@@ -48,9 +50,6 @@ export function FinancialRunwayCard() {
           prevMonths.push({ year: y, month: m });
         }
 
-        type MonthlySummary = { totalIncome: number; totalExpenses: number };
-        const emptySummary: MonthlySummary = { totalIncome: 0, totalExpenses: 0 };
-
         const [accounts, currentSummary, ...prevSummaries] = await Promise.all([
           apiClient.getAccountsWithBalances() as Promise<
             { calculatedBalance: number }[]
@@ -77,7 +76,8 @@ export function FinancialRunwayCard() {
         );
 
         // If fewer than 3 complete months, project current partial month
-        if (validMonths.length < 3 && dayOfMonth > 0) {
+        // Only project if enough days have passed to avoid volatile early-month estimates
+        if (validMonths.length < 3 && dayOfMonth > 5) {
           const curIncome = currentSummary?.totalIncome || 0;
           const curExpenses = currentSummary?.totalExpenses || 0;
           if (curIncome > 0 || curExpenses > 0) {


### PR DESCRIPTION
Closes #97

The Financial Runway card was calculating runway as `totalBalance / currentMonthExpenses`, which gave misleading results early in the month (e.g. 1.0 months on day 5).

**Changes:**
- Fetches last 3 complete months of data in parallel
- Averages income/expenses across available complete months
- Falls back to projecting current partial month when < 3 months of history exist
- All KPIs (earned, spent, kept, saved) use the averaged baseline
- Quarter toggle uses the improved 3-month average × 3