### PR TITLE
feat: add API versioning with v1 prefix

### DIFF
--- a/src/WebAPI/MyMascada.WebAPI/Controllers/AccountSharingController.cs
+++ b/src/WebAPI/MyMascada.WebAPI/Controllers/AccountSharingController.cs
@@ -1,3 +1,4 @@
+using Asp.Versioning;
 using MediatR;
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;
@@ -10,6 +11,8 @@ using MyMascada.Domain.Enums;
 namespace MyMascada.WebAPI.Controllers;
 
 [ApiController]
+[ApiVersion("1.0")]
+[Route("api/v{version:apiVersion}")]
 [Route("api")]
 [Authorize]
 public class AccountSharingController : ControllerBase

--- a/src/WebAPI/MyMascada.WebAPI/Controllers/AccountsController.cs
+++ b/src/WebAPI/MyMascada.WebAPI/Controllers/AccountsController.cs
@@ -1,3 +1,4 @@
+using Asp.Versioning;
 using AutoMapper;
 using MediatR;
 using Microsoft.AspNetCore.Authorization;
@@ -12,6 +13,8 @@ using MyMascada.Domain.Enums;
 namespace MyMascada.WebAPI.Controllers;
 
 [ApiController]
+[ApiVersion("1.0")]
+[Route("api/v{version:apiVersion}/[controller]")]
 [Route("api/[controller]")]
 [Authorize]
 public class AccountsController : ControllerBase

--- a/src/WebAPI/MyMascada.WebAPI/Controllers/AdminController.cs
+++ b/src/WebAPI/MyMascada.WebAPI/Controllers/AdminController.cs
@@ -1,3 +1,4 @@
+using Asp.Versioning;
 using MediatR;
 using Microsoft.AspNetCore.Mvc;
 using MyMascada.Application.Common.Interfaces;
@@ -8,6 +9,8 @@ using MyMascada.WebAPI.Filters;
 namespace MyMascada.WebAPI.Controllers;
 
 [ApiController]
+[ApiVersion("1.0")]
+[Route("api/v{version:apiVersion}/admin")]
 [Route("api/admin")]
 [AdminApiKey]
 public class AdminController : ControllerBase

--- a/src/WebAPI/MyMascada.WebAPI/Controllers/AiChatController.cs
+++ b/src/WebAPI/MyMascada.WebAPI/Controllers/AiChatController.cs
@@ -1,3 +1,4 @@
+using Asp.Versioning;
 using MediatR;
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;
@@ -11,6 +12,8 @@ using MyMascada.WebAPI.Extensions;
 namespace MyMascada.WebAPI.Controllers;
 
 [ApiController]
+[ApiVersion("1.0")]
+[Route("api/v{version:apiVersion}/ai-chat")]
 [Route("api/ai-chat")]
 [Authorize]
 public class AiChatController : ControllerBase

--- a/src/WebAPI/MyMascada.WebAPI/Controllers/AiSettingsController.cs
+++ b/src/WebAPI/MyMascada.WebAPI/Controllers/AiSettingsController.cs
@@ -1,3 +1,4 @@
+using Asp.Versioning;
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;
 using MyMascada.Application.Common.Interfaces;
@@ -7,6 +8,8 @@ using MyMascada.Domain.Entities;
 namespace MyMascada.WebAPI.Controllers;
 
 [ApiController]
+[ApiVersion("1.0")]
+[Route("api/v{version:apiVersion}/ai-settings")]
 [Route("api/ai-settings")]
 [Authorize]
 public class AiSettingsController : ControllerBase

--- a/src/WebAPI/MyMascada.WebAPI/Controllers/AuthController.cs
+++ b/src/WebAPI/MyMascada.WebAPI/Controllers/AuthController.cs
@@ -1,3 +1,4 @@
+using Asp.Versioning;
 using MediatR;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.AspNetCore.Authorization;
@@ -15,6 +16,8 @@ using MyMascada.WebAPI.Extensions;
 namespace MyMascada.WebAPI.Controllers;
 
 [ApiController]
+[ApiVersion("1.0")]
+[Route("api/v{version:apiVersion}/[controller]")]
 [Route("api/[controller]")]
 public class AuthController : ControllerBase
 {

--- a/src/WebAPI/MyMascada.WebAPI/Controllers/BankCategoryMappingsController.cs
+++ b/src/WebAPI/MyMascada.WebAPI/Controllers/BankCategoryMappingsController.cs
@@ -1,3 +1,4 @@
+using Asp.Versioning;
 using MediatR;
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;
@@ -14,6 +15,8 @@ namespace MyMascada.WebAPI.Controllers;
 /// with the user's MyMascada categories for automatic categorization.
 /// </summary>
 [ApiController]
+[ApiVersion("1.0")]
+[Route("api/v{version:apiVersion}/[controller]")]
 [Route("api/[controller]")]
 [Authorize]
 public class BankCategoryMappingsController : ControllerBase

--- a/src/WebAPI/MyMascada.WebAPI/Controllers/BankConnectionsController.cs
+++ b/src/WebAPI/MyMascada.WebAPI/Controllers/BankConnectionsController.cs
@@ -1,4 +1,5 @@
 using System.Text.Json.Serialization;
+using Asp.Versioning;
 using MediatR;
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;
@@ -15,6 +16,8 @@ namespace MyMascada.WebAPI.Controllers;
 /// managing those connections, and triggering transaction synchronization.
 /// </summary>
 [ApiController]
+[ApiVersion("1.0")]
+[Route("api/v{version:apiVersion}/[controller]")]
 [Route("api/[controller]")]
 [Authorize]
 public class BankConnectionsController : ControllerBase

--- a/src/WebAPI/MyMascada.WebAPI/Controllers/BillingController.cs
+++ b/src/WebAPI/MyMascada.WebAPI/Controllers/BillingController.cs
@@ -1,3 +1,4 @@
+using Asp.Versioning;
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.Extensions.Options;
@@ -7,6 +8,8 @@ using MyMascada.Application.Common.Interfaces;
 namespace MyMascada.WebAPI.Controllers;
 
 [ApiController]
+[ApiVersion("1.0")]
+[Route("api/v{version:apiVersion}/[controller]")]
 [Route("api/[controller]")]
 [Authorize]
 public class BillingController : ControllerBase

--- a/src/WebAPI/MyMascada.WebAPI/Controllers/BudgetsController.cs
+++ b/src/WebAPI/MyMascada.WebAPI/Controllers/BudgetsController.cs
@@ -1,3 +1,4 @@
+using Asp.Versioning;
 using MediatR;
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;
@@ -9,6 +10,8 @@ using MyMascada.Application.Features.Budgets.Queries;
 namespace MyMascada.WebAPI.Controllers;
 
 [ApiController]
+[ApiVersion("1.0")]
+[Route("api/v{version:apiVersion}/[controller]")]
 [Route("api/[controller]")]
 [Authorize]
 public class BudgetsController : ControllerBase

--- a/src/WebAPI/MyMascada.WebAPI/Controllers/CategoriesController.cs
+++ b/src/WebAPI/MyMascada.WebAPI/Controllers/CategoriesController.cs
@@ -1,3 +1,4 @@
+using Asp.Versioning;
 using MediatR;
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;
@@ -9,6 +10,8 @@ using MyMascada.Application.Features.Categories.Queries;
 namespace MyMascada.WebAPI.Controllers;
 
 [ApiController]
+[ApiVersion("1.0")]
+[Route("api/v{version:apiVersion}/[controller]")]
 [Route("api/[controller]")]
 [Authorize]
 public class CategoriesController : ControllerBase

--- a/src/WebAPI/MyMascada.WebAPI/Controllers/CategorizationController.cs
+++ b/src/WebAPI/MyMascada.WebAPI/Controllers/CategorizationController.cs
@@ -1,4 +1,5 @@
 using System.Security.Claims;
+using Asp.Versioning;
 using MediatR;
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;
@@ -12,6 +13,8 @@ using MyMascada.Domain.Enums;
 namespace MyMascada.WebAPI.Controllers;
 
 [ApiController]
+[ApiVersion("1.0")]
+[Route("api/v{version:apiVersion}/[controller]")]
 [Route("api/[controller]")]
 [Authorize]
 public class CategorizationController : ControllerBase

--- a/src/WebAPI/MyMascada.WebAPI/Controllers/CsvImportController.cs
+++ b/src/WebAPI/MyMascada.WebAPI/Controllers/CsvImportController.cs
@@ -1,3 +1,4 @@
+using Asp.Versioning;
 using MediatR;
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;
@@ -10,6 +11,8 @@ using MyMascada.Application.Features.Transactions.DTOs;
 namespace MyMascada.WebAPI.Controllers;
 
 [ApiController]
+[ApiVersion("1.0")]
+[Route("api/v{version:apiVersion}/[controller]")]
 [Route("api/[controller]")]
 [Authorize]
 public class CsvImportController : ControllerBase

--- a/src/WebAPI/MyMascada.WebAPI/Controllers/DashboardNudgesController.cs
+++ b/src/WebAPI/MyMascada.WebAPI/Controllers/DashboardNudgesController.cs
@@ -1,3 +1,4 @@
+using Asp.Versioning;
 using MediatR;
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;
@@ -8,6 +9,8 @@ using MyMascada.Application.Features.DashboardNudges.Queries;
 namespace MyMascada.WebAPI.Controllers;
 
 [ApiController]
+[ApiVersion("1.0")]
+[Route("api/v{version:apiVersion}/dashboard-nudges")]
 [Route("api/dashboard-nudges")]
 [Authorize]
 public class DashboardNudgesController : ControllerBase

--- a/src/WebAPI/MyMascada.WebAPI/Controllers/DescriptionCleaningController.cs
+++ b/src/WebAPI/MyMascada.WebAPI/Controllers/DescriptionCleaningController.cs
@@ -1,3 +1,4 @@
+using Asp.Versioning;
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;
 using MyMascada.Application.Common.Interfaces;
@@ -6,6 +7,8 @@ namespace MyMascada.WebAPI.Controllers;
 
 [Authorize]
 [ApiController]
+[ApiVersion("1.0")]
+[Route("api/v{version:apiVersion}/description-cleaning")]
 [Route("api/description-cleaning")]
 public class DescriptionCleaningController : ControllerBase
 {

--- a/src/WebAPI/MyMascada.WebAPI/Controllers/FeaturesController.cs
+++ b/src/WebAPI/MyMascada.WebAPI/Controllers/FeaturesController.cs
@@ -1,3 +1,4 @@
+using Asp.Versioning;
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;
 using MyMascada.Application.Common.Interfaces;
@@ -5,6 +6,8 @@ using MyMascada.Application.Common.Interfaces;
 namespace MyMascada.WebAPI.Controllers;
 
 [ApiController]
+[ApiVersion("1.0")]
+[Route("api/v{version:apiVersion}/[controller]")]
 [Route("api/[controller]")]
 public class FeaturesController : ControllerBase
 {

--- a/src/WebAPI/MyMascada.WebAPI/Controllers/GoalsController.cs
+++ b/src/WebAPI/MyMascada.WebAPI/Controllers/GoalsController.cs
@@ -1,3 +1,4 @@
+using Asp.Versioning;
 using MediatR;
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;
@@ -9,6 +10,8 @@ using MyMascada.Application.Features.Goals.Queries;
 namespace MyMascada.WebAPI.Controllers;
 
 [ApiController]
+[ApiVersion("1.0")]
+[Route("api/v{version:apiVersion}/[controller]")]
 [Route("api/[controller]")]
 [Authorize]
 public class GoalsController : ControllerBase

--- a/src/WebAPI/MyMascada.WebAPI/Controllers/ImportReviewController.cs
+++ b/src/WebAPI/MyMascada.WebAPI/Controllers/ImportReviewController.cs
@@ -1,3 +1,4 @@
+using Asp.Versioning;
 using MediatR;
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;
@@ -11,6 +12,8 @@ using CsvHelper;
 namespace MyMascada.WebAPI.Controllers;
 
 [ApiController]
+[ApiVersion("1.0")]
+[Route("api/v{version:apiVersion}/[controller]")]
 [Route("api/[controller]")]
 [Authorize]
 public class ImportReviewController : ControllerBase

--- a/src/WebAPI/MyMascada.WebAPI/Controllers/LlmCategorizationController.cs
+++ b/src/WebAPI/MyMascada.WebAPI/Controllers/LlmCategorizationController.cs
@@ -1,3 +1,4 @@
+using Asp.Versioning;
 using MediatR;
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;
@@ -8,6 +9,8 @@ namespace MyMascada.WebAPI.Controllers;
 
 [Authorize]
 [ApiController]
+[ApiVersion("1.0")]
+[Route("api/v{version:apiVersion}/[controller]")]
 [Route("api/[controller]")]
 public class LlmCategorizationController : ControllerBase
 {

--- a/src/WebAPI/MyMascada.WebAPI/Controllers/OfxImportController.cs
+++ b/src/WebAPI/MyMascada.WebAPI/Controllers/OfxImportController.cs
@@ -1,3 +1,4 @@
+using Asp.Versioning;
 using MediatR;
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;
@@ -11,6 +12,8 @@ namespace MyMascada.WebAPI.Controllers;
 /// Controller for handling OFX file imports
 /// </summary>
 [ApiController]
+[ApiVersion("1.0")]
+[Route("api/v{version:apiVersion}/ofx-import")]
 [Route("api/ofx-import")]
 [Authorize]
 public class OfxImportController : ControllerBase

--- a/src/WebAPI/MyMascada.WebAPI/Controllers/OnboardingController.cs
+++ b/src/WebAPI/MyMascada.WebAPI/Controllers/OnboardingController.cs
@@ -1,3 +1,4 @@
+using Asp.Versioning;
 using MediatR;
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;
@@ -9,6 +10,8 @@ using MyMascada.Application.Features.Onboarding.Queries;
 namespace MyMascada.WebAPI.Controllers;
 
 [ApiController]
+[ApiVersion("1.0")]
+[Route("api/v{version:apiVersion}/[controller]")]
 [Route("api/[controller]")]
 [Authorize]
 public class OnboardingController : ControllerBase

--- a/src/WebAPI/MyMascada.WebAPI/Controllers/ReconciliationController.cs
+++ b/src/WebAPI/MyMascada.WebAPI/Controllers/ReconciliationController.cs
@@ -1,3 +1,4 @@
+using Asp.Versioning;
 using MediatR;
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;
@@ -10,6 +11,8 @@ using AkahuReconciliationRequest = MyMascada.Application.Features.Reconciliation
 namespace MyMascada.WebAPI.Controllers;
 
 [ApiController]
+[ApiVersion("1.0")]
+[Route("api/v{version:apiVersion}/[controller]")]
 [Route("api/[controller]")]
 [Authorize]
 public class ReconciliationController : ControllerBase

--- a/src/WebAPI/MyMascada.WebAPI/Controllers/ReportsController.cs
+++ b/src/WebAPI/MyMascada.WebAPI/Controllers/ReportsController.cs
@@ -1,3 +1,4 @@
+using Asp.Versioning;
 using MediatR;
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;
@@ -10,6 +11,8 @@ using MyMascada.Application.Features.UpcomingBills.Queries;
 namespace MyMascada.WebAPI.Controllers;
 
 [ApiController]
+[ApiVersion("1.0")]
+[Route("api/v{version:apiVersion}/[controller]")]
 [Route("api/[controller]")]
 [Authorize]
 public class ReportsController : ControllerBase

--- a/src/WebAPI/MyMascada.WebAPI/Controllers/RuleSuggestionsController.cs
+++ b/src/WebAPI/MyMascada.WebAPI/Controllers/RuleSuggestionsController.cs
@@ -1,3 +1,4 @@
+using Asp.Versioning;
 using MediatR;
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;
@@ -9,6 +10,8 @@ using MyMascada.Application.Features.RuleSuggestions.Queries;
 namespace MyMascada.WebAPI.Controllers;
 
 [ApiController]
+[ApiVersion("1.0")]
+[Route("api/v{version:apiVersion}/[controller]")]
 [Route("api/[controller]")]
 [Authorize]
 public class RuleSuggestionsController : ControllerBase

--- a/src/WebAPI/MyMascada.WebAPI/Controllers/RulesController.cs
+++ b/src/WebAPI/MyMascada.WebAPI/Controllers/RulesController.cs
@@ -1,3 +1,4 @@
+using Asp.Versioning;
 using MediatR;
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;
@@ -9,6 +10,8 @@ using MyMascada.Application.Features.Rules.Queries;
 namespace MyMascada.WebAPI.Controllers;
 
 [ApiController]
+[ApiVersion("1.0")]
+[Route("api/v{version:apiVersion}/[controller]")]
 [Route("api/[controller]")]
 [Authorize]
 public class RulesController : ControllerBase

--- a/src/WebAPI/MyMascada.WebAPI/Controllers/StripeWebhookController.cs
+++ b/src/WebAPI/MyMascada.WebAPI/Controllers/StripeWebhookController.cs
@@ -1,3 +1,4 @@
+using Asp.Versioning;
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.Extensions.Options;
@@ -8,6 +9,8 @@ using Stripe;
 namespace MyMascada.WebAPI.Controllers;
 
 [ApiController]
+[ApiVersion("1.0")]
+[Route("api/v{version:apiVersion}/webhooks/stripe")]
 [Route("api/webhooks/stripe")]
 [AllowAnonymous]
 public class StripeWebhookController : ControllerBase

--- a/src/WebAPI/MyMascada.WebAPI/Controllers/TelegramSettingsController.cs
+++ b/src/WebAPI/MyMascada.WebAPI/Controllers/TelegramSettingsController.cs
@@ -1,3 +1,4 @@
+using Asp.Versioning;
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.Extensions.Options;
@@ -11,6 +12,8 @@ using System.Security.Cryptography;
 namespace MyMascada.WebAPI.Controllers;
 
 [ApiController]
+[ApiVersion("1.0")]
+[Route("api/v{version:apiVersion}/telegram/settings")]
 [Route("api/telegram/settings")]
 [Authorize]
 public class TelegramSettingsController : ControllerBase

--- a/src/WebAPI/MyMascada.WebAPI/Controllers/TelegramWebhookController.cs
+++ b/src/WebAPI/MyMascada.WebAPI/Controllers/TelegramWebhookController.cs
@@ -1,4 +1,5 @@
 using System.Text.Json;
+using Asp.Versioning;
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;
 using MyMascada.Application.Common.Interfaces;
@@ -8,6 +9,8 @@ using MyMascada.Infrastructure.Services.Telegram.Models;
 namespace MyMascada.WebAPI.Controllers;
 
 [ApiController]
+[ApiVersion("1.0")]
+[Route("api/v{version:apiVersion}/telegram/webhook")]
 [Route("api/telegram/webhook")]
 [AllowAnonymous]
 public class TelegramWebhookController : ControllerBase

--- a/src/WebAPI/MyMascada.WebAPI/Controllers/TestingController.cs
+++ b/src/WebAPI/MyMascada.WebAPI/Controllers/TestingController.cs
@@ -1,3 +1,4 @@
+using Asp.Versioning;
 using Microsoft.AspNetCore.Mvc;
 using MediatR;
 using MyMascada.Application.Features.Testing.Commands;
@@ -9,6 +10,8 @@ namespace MyMascada.WebAPI.Controllers;
 /// Only available in development environment
 /// </summary>
 [ApiController]
+[ApiVersion("1.0")]
+[Route("api/v{version:apiVersion}/[controller]")]
 [Route("api/[controller]")]
 public class TestingController : ControllerBase
 {

--- a/src/WebAPI/MyMascada.WebAPI/Controllers/TransactionsController.cs
+++ b/src/WebAPI/MyMascada.WebAPI/Controllers/TransactionsController.cs
@@ -1,3 +1,4 @@
+using Asp.Versioning;
 using MediatR;
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;
@@ -11,6 +12,8 @@ using MyMascada.Domain.Enums;
 namespace MyMascada.WebAPI.Controllers;
 
 [ApiController]
+[ApiVersion("1.0")]
+[Route("api/v{version:apiVersion}/[controller]")]
 [Route("api/[controller]")]
 [Authorize]
 public class TransactionsController : ControllerBase

--- a/src/WebAPI/MyMascada.WebAPI/Controllers/TransferController.cs
+++ b/src/WebAPI/MyMascada.WebAPI/Controllers/TransferController.cs
@@ -1,3 +1,4 @@
+using Asp.Versioning;
 using MediatR;
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;
@@ -12,6 +13,8 @@ namespace MyMascada.WebAPI.Controllers;
 /// API controller for managing transfers between accounts
 /// </summary>
 [ApiController]
+[ApiVersion("1.0")]
+[Route("api/v{version:apiVersion}/[controller]")]
 [Route("api/[controller]")]
 [Authorize]
 public class TransferController : ControllerBase

--- a/src/WebAPI/MyMascada.WebAPI/Controllers/UserDataController.cs
+++ b/src/WebAPI/MyMascada.WebAPI/Controllers/UserDataController.cs
@@ -1,5 +1,6 @@
 using System.Text;
 using System.Text.Json;
+using Asp.Versioning;
 using MediatR;
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;
@@ -15,6 +16,8 @@ namespace MyMascada.WebAPI.Controllers;
 /// Controller for LGPD/GDPR compliance features including data export and account deletion.
 /// </summary>
 [ApiController]
+[ApiVersion("1.0")]
+[Route("api/v{version:apiVersion}/[controller]")]
 [Route("api/[controller]")]
 [Authorize]
 public class UserDataController : ControllerBase

--- a/src/WebAPI/MyMascada.WebAPI/Controllers/VersionController.cs
+++ b/src/WebAPI/MyMascada.WebAPI/Controllers/VersionController.cs
@@ -1,10 +1,13 @@
 using System.Reflection;
+using Asp.Versioning;
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;
 
 namespace MyMascada.WebAPI.Controllers;
 
 [ApiController]
+[ApiVersion("1.0")]
+[Route("api/v{version:apiVersion}/[controller]")]
 [Route("api/[controller]")]
 public class VersionController : ControllerBase
 {

--- a/src/WebAPI/MyMascada.WebAPI/Controllers/WaitlistController.cs
+++ b/src/WebAPI/MyMascada.WebAPI/Controllers/WaitlistController.cs
@@ -1,3 +1,4 @@
+using Asp.Versioning;
 using MediatR;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.AspNetCore.RateLimiting;
@@ -8,6 +9,8 @@ using MyMascada.WebAPI.Extensions;
 namespace MyMascada.WebAPI.Controllers;
 
 [ApiController]
+[ApiVersion("1.0")]
+[Route("api/v{version:apiVersion}/[controller]")]
 [Route("api/[controller]")]
 public class WaitlistController : ControllerBase
 {

--- a/src/WebAPI/MyMascada.WebAPI/MyMascada.WebAPI.csproj
+++ b/src/WebAPI/MyMascada.WebAPI/MyMascada.WebAPI.csproj
@@ -32,6 +32,8 @@
     <PackageReference Include="Serilog.Sinks.Console" Version="6.0.0" />
     <PackageReference Include="Serilog.Sinks.File" Version="7.0.0" />
     <PackageReference Include="Serilog.Sinks.Seq" Version="9.0.0" />
+    <PackageReference Include="Asp.Versioning.Mvc" Version="8.1.0" />
+    <PackageReference Include="Asp.Versioning.Mvc.ApiExplorer" Version="8.1.0" />
     <PackageReference Include="Swashbuckle.AspNetCore" Version="10.1.0" />
   </ItemGroup>
 

--- a/src/WebAPI/MyMascada.WebAPI/Program.cs
+++ b/src/WebAPI/MyMascada.WebAPI/Program.cs
@@ -6,6 +6,7 @@ using MyMascada.WebAPI.Extensions;
 using MyMascada.WebAPI.Middleware;
 using MyMascada.WebAPI.Services;
 using MediatR;
+using Asp.Versioning;
 using Serilog;
 using Serilog.Events;
 using Hangfire;
@@ -77,6 +78,20 @@ builder.Services.AddSwaggerGen(options =>
     // Configure Swagger to use string values for enums
     options.UseInlineDefinitionsForEnums();
     options.CustomSchemaIds(type => type.FullName);
+});
+
+// Add API versioning (URL segment: /api/v1/...)
+builder.Services.AddApiVersioning(options =>
+{
+    options.DefaultApiVersion = new ApiVersion(1, 0);
+    options.AssumeDefaultVersionWhenUnspecified = true;
+    options.ReportApiVersions = true;
+    options.ApiVersionReader = new UrlSegmentApiVersionReader();
+})
+.AddApiExplorer(options =>
+{
+    options.GroupNameFormat = "'v'VVV";
+    options.SubstituteApiVersionInUrl = true;
 });
 
 // Add HTTP context accessor and current user service


### PR DESCRIPTION
Closes #101

Adds API versioning using Asp.Versioning.Mvc:
- All endpoints now under /api/v1/ prefix
- Backward compatibility maintained
- Frontend API client updated