### PR TITLE
feat: Fly.io deployment infrastructure

### DIFF
--- a/.github/workflows/deploy-fly.yml
+++ b/.github/workflows/deploy-fly.yml
@@ -1,0 +1,75 @@
+name: Deploy to Fly.io
+
+on:
+  push:
+    branches: [main]
+  workflow_dispatch:
+    inputs:
+      service:
+        description: 'Service to deploy'
+        required: true
+        type: choice
+        options:
+          - all
+          - api
+          - frontend
+
+concurrency:
+  group: fly-deploy
+  cancel-in-progress: false
+
+jobs:
+  changes:
+    name: Detect changes
+    runs-on: ubuntu-latest
+    outputs:
+      api: ${{ steps.filter.outputs.api }}
+      frontend: ${{ steps.filter.outputs.frontend }}
+    steps:
+      - uses: actions/checkout@v4
+      - uses: dorny/paths-filter@v3
+        id: filter
+        with:
+          filters: |
+            api:
+              - 'src/**'
+              - 'deploy/fly/fly.api.toml'
+            frontend:
+              - 'frontend/**'
+              - 'deploy/fly/fly.frontend.toml'
+
+  deploy-api:
+    name: Deploy API
+    needs: changes
+    if: |
+      github.event_name == 'workflow_dispatch' && (github.event.inputs.service == 'all' || github.event.inputs.service == 'api') ||
+      github.event_name == 'push' && needs.changes.outputs.api == 'true'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: superfly/flyctl-actions/setup-flyctl@master
+
+      - run: flyctl deploy --config deploy/fly/fly.api.toml --remote-only
+        env:
+          FLY_API_TOKEN: ${{ secrets.FLY_API_TOKEN }}
+
+  deploy-frontend:
+    name: Deploy Frontend
+    needs: [changes, deploy-api]
+    if: |
+      always() &&
+      (needs.deploy-api.result == 'success' || needs.deploy-api.result == 'skipped') &&
+      (
+        github.event_name == 'workflow_dispatch' && (github.event.inputs.service == 'all' || github.event.inputs.service == 'frontend') ||
+        github.event_name == 'push' && needs.changes.outputs.frontend == 'true'
+      )
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: superfly/flyctl-actions/setup-flyctl@master
+
+      - run: flyctl deploy --config deploy/fly/fly.frontend.toml --remote-only
+        env:
+          FLY_API_TOKEN: ${{ secrets.FLY_API_TOKEN }}

--- a/deploy/fly/README.md
+++ b/deploy/fly/README.md
@@ -1,0 +1,145 @@
+# Fly.io Deployment
+
+MyMascada production deployment on Fly.io.
+
+## Prerequisites
+
+1. Install flyctl: `curl -L https://fly.io/install.sh | sh`
+2. Login: `flyctl auth login`
+3. Create the apps (first time only):
+   ```bash
+   flyctl apps create mymascada-api
+   flyctl apps create mymascada-web
+   ```
+
+## Initial Setup
+
+### 1. Create Postgres cluster
+
+```bash
+flyctl postgres create \
+  --name mymascada-db \
+  --region syd \
+  --vm-size shared-cpu-1x \
+  --volume-size 10 \
+  --initial-cluster-size 1
+```
+
+### 2. Attach Postgres to API
+
+```bash
+flyctl postgres attach mymascada-db --app mymascada-api
+```
+
+This automatically sets `DATABASE_URL` as a secret on the API app.
+
+### 3. Set API secrets
+
+```bash
+flyctl secrets set --app mymascada-api \
+  JWT_KEY="your-jwt-signing-key" \
+  JWT_ISSUER="MyMascada" \
+  JWT_AUDIENCE="MyMascadaUsers" \
+  FRONTEND_URL="https://mymascada-web.fly.dev" \
+  CORS_ALLOWED_ORIGINS="https://mymascada-web.fly.dev,https://mymascada.com"
+```
+
+Optional integrations:
+```bash
+flyctl secrets set --app mymascada-api \
+  OPENAI_API_KEY="sk-..." \
+  GOOGLE_CLIENT_ID="..." \
+  GOOGLE_CLIENT_SECRET="..."
+```
+
+### 4. Deploy API
+
+```bash
+flyctl deploy --config deploy/fly/fly.api.toml
+```
+
+### 5. Deploy Frontend
+
+```bash
+flyctl deploy --config deploy/fly/fly.frontend.toml
+```
+
+## Custom Domain
+
+```bash
+# API
+flyctl certs create --app mymascada-api api.mymascada.com
+
+# Frontend
+flyctl certs create --app mymascada-web mymascada.com
+flyctl certs create --app mymascada-web www.mymascada.com
+```
+
+Then point DNS:
+- `api.mymascada.com` → CNAME `mymascada-api.fly.dev`
+- `mymascada.com` → CNAME `mymascada-web.fly.dev` (or A record from `flyctl ips list`)
+
+After setting custom domains, update the frontend build arg and API env:
+```bash
+# Redeploy frontend with production API URL
+# Edit fly.frontend.toml: NEXT_PUBLIC_API_URL = "https://api.mymascada.com"
+flyctl deploy --config deploy/fly/fly.frontend.toml
+
+# Update API secrets
+flyctl secrets set --app mymascada-api \
+  FRONTEND_URL="https://mymascada.com" \
+  CORS_ALLOWED_ORIGINS="https://mymascada.com,https://www.mymascada.com"
+```
+
+## Scaling
+
+### Add a region
+```bash
+flyctl scale count 1 --region iad --app mymascada-api
+flyctl scale count 1 --region iad --app mymascada-web
+```
+
+### Scale up VM
+```bash
+flyctl scale vm shared-cpu-2x --memory 1024 --app mymascada-api
+```
+
+### Postgres read replica
+```bash
+flyctl postgres create \
+  --name mymascada-db-replica \
+  --region iad \
+  --vm-size shared-cpu-1x \
+  --volume-size 10 \
+  --initial-cluster-size 1 \
+  --fork-from mymascada-db
+```
+
+## Monitoring
+
+```bash
+flyctl logs --app mymascada-api
+flyctl status --app mymascada-api
+flyctl dashboard --app mymascada-api
+```
+
+## CI/CD
+
+See `.github/workflows/deploy-fly.yml` for GitHub Actions deployment pipeline.
+
+## Connection string format
+
+Fly Postgres provides `DATABASE_URL` in the format:
+```
+postgres://user:password@mymascada-db.internal:5432/mymascada?sslmode=disable
+```
+
+The API's connection string configuration may need to parse this. Check `appsettings.Production.json` for the expected format.
+
+## Notes
+
+- **Auto-stop:** Both apps scale to zero when idle (saves cost)
+- **Auto-start:** Fly proxy wakes apps on incoming requests (~1-2s cold start)
+- **Internal networking:** Apps communicate via `.internal` DNS (e.g., `mymascada-api.internal:5126`)
+- **SSL:** Automatic via Fly proxy, no Caddy needed
+- **Region:** `syd` (Sydney) is primary — closest to NZ

--- a/deploy/fly/fly.api.toml
+++ b/deploy/fly/fly.api.toml
@@ -1,0 +1,36 @@
+# MyMascada API — Fly.io configuration
+# Deploy: flyctl deploy --config deploy/fly/fly.api.toml --dockerfile src/Dockerfile.api
+app = "mymascada-api"
+primary_region = "syd"
+
+[build]
+  dockerfile = "src/Dockerfile.api"
+
+[env]
+  ASPNETCORE_ENVIRONMENT = "Production"
+  ASPNETCORE_URLS = "http://+:5126"
+
+[http_service]
+  internal_port = 5126
+  force_https = true
+  auto_stop_machines = "stop"
+  auto_start_machines = true
+  min_machines_running = 0
+  processes = ["app"]
+
+  [http_service.concurrency]
+    type = "requests"
+    hard_limit = 250
+    soft_limit = 200
+
+[[http_service.checks]]
+  grace_period = "10s"
+  interval = "30s"
+  method = "GET"
+  path = "/health"
+  timeout = "5s"
+
+[[vm]]
+  size = "shared-cpu-1x"
+  memory = "512mb"
+  processes = ["app"]

--- a/deploy/fly/fly.frontend.toml
+++ b/deploy/fly/fly.frontend.toml
@@ -1,0 +1,42 @@
+# MyMascada Frontend — Fly.io configuration
+# Deploy: flyctl deploy --config deploy/fly/fly.frontend.toml --dockerfile frontend/Dockerfile
+app = "mymascada-web"
+primary_region = "syd"
+
+[build]
+  dockerfile = "frontend/Dockerfile"
+
+  [build.args]
+    NEXT_PUBLIC_API_URL = "https://mymascada-api.fly.dev"
+
+[env]
+  NODE_ENV = "production"
+  PORT = "3000"
+  HOSTNAME = "0.0.0.0"
+  # Internal API URL for server-side rewrites (Fly internal DNS)
+  INTERNAL_API_URL = "http://mymascada-api.internal:5126"
+
+[http_service]
+  internal_port = 3000
+  force_https = true
+  auto_stop_machines = "stop"
+  auto_start_machines = true
+  min_machines_running = 0
+  processes = ["app"]
+
+  [http_service.concurrency]
+    type = "requests"
+    hard_limit = 250
+    soft_limit = 200
+
+[[http_service.checks]]
+  grace_period = "15s"
+  interval = "30s"
+  method = "GET"
+  path = "/"
+  timeout = "5s"
+
+[[vm]]
+  size = "shared-cpu-1x"
+  memory = "256mb"
+  processes = ["app"]


### PR DESCRIPTION
## Summary
Adds Fly.io deployment configuration for MyMascada production hosting.

## Decision
After evaluating Azure Container Apps, Google Cloud Run, AWS App Runner, Railway, Render, and Fly.io — chose Fly.io for:
- Lowest cost (~$12-13/mo to start, less with auto-stop)
- Multi-region from day 1 (Sydney primary)
- Container-native (uses existing Dockerfiles)
- Clear migration path to Azure when needed

Full decision documented in Obsidian.

## Files
- `deploy/fly/fly.api.toml` — API config (shared-cpu-1x, 512MB, auto-stop)
- `deploy/fly/fly.frontend.toml` — Frontend config (shared-cpu-1x, 256MB, auto-stop)
- `deploy/fly/README.md` — Complete setup guide (Postgres, secrets, domains, scaling)
- `.github/workflows/deploy-fly.yml` — CI/CD with path-based change detection

## Next steps (after merge)
1. Create Fly.io account + apps
2. Set up Postgres cluster
3. Configure secrets
4. Add `FLY_API_TOKEN` to GitHub Secrets
5. Deploy! 🚀