### PR TITLE
chore(deps): bump lucide-react from 0.468.0 to 0.576.0 in /frontend

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -22,7 +22,7 @@
         "eslint": "^9.29.0",
         "eslint-config-next": "^16.1.6",
         "google-auth-library": "^10.6.1",
-        "lucide-react": "^0.468.0",
+        "lucide-react": "^0.576.0",
         "next": "^16.1.6",
         "next-intl": "^4.8.3",
         "next-pwa": "^5.6.0",
@@ -13115,12 +13115,12 @@
       }
     },
     "node_modules/lucide-react": {
-      "version": "0.468.0",
-      "resolved": "https://registry.npmjs.org/lucide-react/-/lucide-react-0.468.0.tgz",
-      "integrity": "sha512-6koYRhnM2N0GGZIdXzSeiNwguv1gt/FAjZOiPl76roBi3xKEXa4WmfpxgQwTTL4KipXjefrnf3oV4IsYhi4JFA==",
+      "version": "0.576.0",
+      "resolved": "https://registry.npmjs.org/lucide-react/-/lucide-react-0.576.0.tgz",
+      "integrity": "sha512-koNxU14BXrxUfZQ9cUaP0ES1uyPZKYDjk31FQZB6dQ/x+tXk979sVAn9ppZ/pVeJJyOxVM8j1E+8QEuSc02Vug==",
       "license": "ISC",
       "peerDependencies": {
-        "react": "^16.5.1 || ^17.0.0 || ^18.0.0 || ^19.0.0-rc"
+        "react": "^16.5.1 || ^17.0.0 || ^18.0.0 || ^19.0.0"
       }
     },
     "node_modules/lz-string": {

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -34,7 +34,7 @@
     "eslint": "^9.29.0",
     "eslint-config-next": "^16.1.6",
     "google-auth-library": "^10.6.1",
-    "lucide-react": "^0.468.0",
+    "lucide-react": "^0.576.0",
     "next": "^16.1.6",
     "next-intl": "^4.8.3",
     "next-pwa": "^5.6.0",


### PR DESCRIPTION
Clean recreation of #78 (had merge conflicts after other deps were merged).

Bumps [lucide-react](https://github.com/lucide-icons/lucide) from 0.468.0 to 0.576.0.