### PR TITLE
fix: avoid Sync All UI freeze/jank on bank connections

### DIFF
--- a/frontend/src/app/settings/bank-connections/page.tsx
+++ b/frontend/src/app/settings/bank-connections/page.tsx
@@ -2,7 +2,7 @@
 
 import { useAuth } from '@/contexts/auth-context';
 import { useRouter } from 'next/navigation';
-import { useEffect, useState } from 'react';
+import { useEffect, useRef, useState } from 'react';
 import { AppLayout } from '@/components/app-layout';
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
 import { Button } from '@/components/ui/button';
@@ -14,7 +14,8 @@ import { toast } from 'sonner';
 import {
   BuildingLibraryIcon,
   PlusIcon,
-  InformationCircleIcon
+  InformationCircleIcon,
+  ArrowPathIcon
 } from '@heroicons/react/24/outline';
 import { BackButton } from '@/components/ui/back-button';
 import { useTranslations } from 'next-intl';
@@ -33,6 +34,8 @@ export default function BankConnectionsPage() {
   const [showSetupDialog, setShowSetupDialog] = useState(false);
   const [credentialsError, setCredentialsError] = useState<string | undefined>(undefined);
   const [isInitiatingConnection, setIsInitiatingConnection] = useState(false);
+  const [isSyncing, setIsSyncing] = useState(false);
+  const isSyncingRef = useRef(false);
 
   useEffect(() => {
     if (!isLoading && !isAuthenticated) {
@@ -68,8 +71,11 @@ export default function BankConnectionsPage() {
     }
   }, []);
 
-  const loadConnections = async () => {
-    setLoadingConnections(true);
+  const loadConnections = async (options?: { silent?: boolean }) => {
+    if (!options?.silent) {
+      setLoadingConnections(true);
+    }
+
     try {
       const data = await apiClient.getBankConnections();
       setConnections(data);
@@ -77,7 +83,9 @@ export default function BankConnectionsPage() {
       console.error('Failed to load connections:', error);
       toast.error(t('toasts.loadFailed'));
     } finally {
-      setLoadingConnections(false);
+      if (!options?.silent) {
+        setLoadingConnections(false);
+      }
     }
   };
 
@@ -147,7 +155,7 @@ export default function BankConnectionsPage() {
 
       toast.success(t('toasts.connected'));
       setShowLinkDialog(false);
-      loadConnections();
+      await loadConnections({ silent: true });
     } catch (error) {
       console.error('Failed to complete connection:', error);
       toast.error(t('toasts.linkFailed'));
@@ -168,6 +176,12 @@ export default function BankConnectionsPage() {
   };
 
   const handleSyncAll = async () => {
+    if (isSyncingRef.current) return;
+
+    isSyncingRef.current = true;
+    setIsSyncing(true);
+    toast.info(t('toasts.syncStarting'));
+
     try {
       const results = await apiClient.syncAllConnections();
       const successful = results.filter(r => r.isSuccess).length;
@@ -178,10 +192,14 @@ export default function BankConnectionsPage() {
       } else {
         toast.warning(t('toasts.syncPartial', { successful, total: results.length }));
       }
-      loadConnections();
+
+      await loadConnections({ silent: true });
     } catch (error) {
       console.error('Failed to sync all:', error);
       toast.error(t('toasts.syncAllFailed'));
+    } finally {
+      isSyncingRef.current = false;
+      setIsSyncing(false);
     }
   };
 
@@ -225,9 +243,11 @@ export default function BankConnectionsPage() {
                 <Button
                   variant="outline"
                   onClick={handleSyncAll}
+                  disabled={isSyncing}
                   className="flex items-center gap-2"
                 >
-                  {t('syncAll')}
+                  <ArrowPathIcon className={`w-4 h-4 ${isSyncing ? 'animate-spin' : ''}`} />
+                  {isSyncing ? t('syncing') : t('syncAll')}
                 </Button>
               )}
 

--- a/frontend/src/components/bank-connections/bank-connection-card.tsx
+++ b/frontend/src/components/bank-connections/bank-connection-card.tsx
@@ -20,7 +20,7 @@ interface BankConnectionCardProps {
   connection: BankConnection;
   onSync: (connectionId: number) => Promise<void>;
   onDisconnect: (connectionId: number) => Promise<void>;
-  onRefresh: () => void;
+  onRefresh: () => Promise<void>;
 }
 
 export function BankConnectionCard({
@@ -40,7 +40,7 @@ export function BankConnectionCard({
     try {
       await onSync(connection.id);
       toast.success(tToasts('bankSyncSuccess'));
-      onRefresh();
+      await onRefresh();
     } catch (error) {
       console.error('Sync failed:', error);
       toast.error(tToasts('bankSyncFailed'));
@@ -53,7 +53,7 @@ export function BankConnectionCard({
     try {
       await onDisconnect(connection.id);
       toast.success(tToasts('bankConnectionRemoved'));
-      onRefresh();
+      await onRefresh();
     } catch (error) {
       console.error('Disconnect failed:', error);
       toast.error(tToasts('bankDisconnectFailed'));

--- a/frontend/src/components/bank-connections/bank-connection-list.tsx
+++ b/frontend/src/components/bank-connections/bank-connection-list.tsx
@@ -9,7 +9,7 @@ interface BankConnectionListProps {
   connections: BankConnection[];
   onSync: (connectionId: number) => Promise<void>;
   onDisconnect: (connectionId: number) => Promise<void>;
-  onRefresh: () => void;
+  onRefresh: () => Promise<void>;
   isLoading?: boolean;
 }
 


### PR DESCRIPTION
## What
Fixes intermittent UI freeze/jank on Settings > Bank Connections when tapping Sync All repeatedly on mobile.

## Changes
- Add explicit re-entry guard for Sync All (isSyncingRef) in addition to disabled button state
- Show syncing spinner + label while request is in flight
- Use silent refresh after sync (refreshes data without toggling full list skeleton), reducing layout jumps/blank areas during scroll
- Make onRefresh async and await refresh in bank connection card actions (sync/disconnect) to avoid fire-and-forget race conditions

## Validation
- Frontend production build succeeds (npm --prefix frontend run -s build)

## Notes
This is scoped to UI stability/interaction flow; no backend behavior changed.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added visual loading indicator (spinning icon) to the Sync All button during synchronization operations.
  * Implemented concurrent sync prevention to ensure only one sync operation runs at a time.

* **Improvements**
  * Bank connection refresh operations now use silent loading, eliminating full page reloads after sync or disconnect actions for a smoother user experience.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->