### PR TITLE
fix(auth): allow mobile deep-link scheme in Google OAuth redirect

### DIFF
--- a/src/WebAPI/MyMascada.WebAPI/Controllers/AuthController.cs
+++ b/src/WebAPI/MyMascada.WebAPI/Controllers/AuthController.cs
@@ -537,17 +537,27 @@ public class AuthController : ControllerBase
             return BadRequest("Google Client ID not configured");
         }
 
-        // Validate returnUrl against allowed frontend origin to prevent open redirects
+        // Validate returnUrl against allowed frontend origin to prevent open redirects.
+        // Also allow registered mobile app deep-link schemes.
+        var allowedMobileSchemes = new[] { "mymascada" };
         var safeReturnUrl = $"{_appOptions.FrontendUrl}/dashboard";
         if (!string.IsNullOrEmpty(returnUrl))
         {
             var frontendUri = new Uri(_appOptions.FrontendUrl);
-            if (Uri.TryCreate(returnUrl, UriKind.Absolute, out var parsedReturn)
-                && string.Equals(parsedReturn.Host, frontendUri.Host, StringComparison.OrdinalIgnoreCase)
-                && string.Equals(parsedReturn.Scheme, frontendUri.Scheme, StringComparison.OrdinalIgnoreCase)
-                && parsedReturn.Port == frontendUri.Port)
+            if (Uri.TryCreate(returnUrl, UriKind.Absolute, out var parsedReturn))
             {
-                safeReturnUrl = returnUrl;
+                var isFrontendOrigin =
+                    string.Equals(parsedReturn.Host, frontendUri.Host, StringComparison.OrdinalIgnoreCase)
+                    && string.Equals(parsedReturn.Scheme, frontendUri.Scheme, StringComparison.OrdinalIgnoreCase)
+                    && parsedReturn.Port == frontendUri.Port;
+
+                var isMobileDeepLink = allowedMobileSchemes.Contains(
+                    parsedReturn.Scheme, StringComparer.OrdinalIgnoreCase);
+
+                if (isFrontendOrigin || isMobileDeepLink)
+                {
+                    safeReturnUrl = returnUrl;
+                }
             }
         }
 
@@ -662,15 +672,24 @@ public class AuthController : ControllerBase
                 }
 
                 // Validate the final return URL against the allowed frontend origin
+                // and registered mobile deep-link schemes.
                 var frontendBase = new Uri(_appOptions.FrontendUrl);
                 var redirectTarget = $"{_appOptions.FrontendUrl}/dashboard";
                 if (!string.IsNullOrEmpty(finalReturnUrl)
-                    && Uri.TryCreate(finalReturnUrl, UriKind.Absolute, out var parsedReturn)
-                    && string.Equals(parsedReturn.Host, frontendBase.Host, StringComparison.OrdinalIgnoreCase)
-                    && string.Equals(parsedReturn.Scheme, frontendBase.Scheme, StringComparison.OrdinalIgnoreCase)
-                    && parsedReturn.Port == frontendBase.Port)
+                    && Uri.TryCreate(finalReturnUrl, UriKind.Absolute, out var parsedReturn))
                 {
-                    redirectTarget = finalReturnUrl;
+                    var isFrontendOrigin =
+                        string.Equals(parsedReturn.Host, frontendBase.Host, StringComparison.OrdinalIgnoreCase)
+                        && string.Equals(parsedReturn.Scheme, frontendBase.Scheme, StringComparison.OrdinalIgnoreCase)
+                        && parsedReturn.Port == frontendBase.Port;
+
+                    var isMobileDeepLink = new[] { "mymascada" }.Contains(
+                        parsedReturn.Scheme, StringComparer.OrdinalIgnoreCase);
+
+                    if (isFrontendOrigin || isMobileDeepLink)
+                    {
+                        redirectTarget = finalReturnUrl;
+                    }
                 }
 
                 // Pass a short-lived encrypted auth code instead of the raw JWT


### PR DESCRIPTION
## Problem
The Google OAuth return URL validation in `AuthController` only accepts URLs matching the configured `FrontendUrl` host/scheme. The mobile app uses a custom deep-link scheme (`mymascada://auth/google-callback`), which gets silently rejected — causing the user to be redirected to the web frontend instead of back to the mobile app after Google sign-in.

## Fix
Both redirect validation points now also accept the registered `mymascada` custom URL scheme:
- `GetGoogleLoginUrl` — validates the initial `returnUrl` parameter
- `GoogleResponse` — validates the final redirect target after auth

The allowlist is explicit (`allowedMobileSchemes`) so no open redirect risk is introduced.

## Related
- Mobile Google Sign-In PR: digaomatias/mymascada-mobile#13

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for mobile deep-link redirection during Google authentication, allowing users to be seamlessly redirected to native mobile app experiences after login.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->