### PR TITLE
fix: make categorization ribbon responsive on mobile

### DIFF
--- a/frontend/src/components/forms/categorization-ribbon.tsx
+++ b/frontend/src/components/forms/categorization-ribbon.tsx
@@ -631,12 +631,12 @@ export function CategorizationRibbon({
                 )}
               </div>
 
-              <div className="flex gap-2">
+              <div className="flex flex-col sm:flex-row gap-2">
                 <Button
                   variant="secondary"
                   size="sm"
                   onClick={() => setShowRulePreview(false)}
-                  className="flex-1 sm:flex-none"
+                  className="w-full sm:w-auto"
                 >
                   {tCommon('cancel')}
                 </Button>
@@ -644,7 +644,7 @@ export function CategorizationRibbon({
                   onClick={handleApplySelectedRules}
                   disabled={isApplyingRules || !rulePreview.ruleMatches?.some(m => m.isSelected)}
                   size="sm"
-                  className="bg-gradient-to-r from-green-500 to-blue-500 hover:from-green-600 hover:to-primary-600 flex-1 sm:flex-none"
+                  className="bg-gradient-to-r from-green-500 to-blue-500 hover:from-green-600 hover:to-primary-600 w-full sm:w-auto"
                 >
                   {isApplyingRules ? (
                     <>


### PR DESCRIPTION
## Summary
- Stack the Smart Categorization buttons vertically on narrow screens (`<640px`) instead of side-by-side, preventing horizontal overflow/clipping
- Apply the same responsive pattern to the AI Assistant expanded section
- Add `shrink-0` to icon containers so they don't compress on tight layouts

Fixes #190

## Test plan
- [ ] Open `/transactions/categorize` on a ~375px viewport — buttons should stack vertically
- [ ] On `>=640px` viewport — buttons remain side-by-side as before
- [ ] AI section (click "AI Assistant") should also be responsive
- [ ] No horizontal scrollbar on mobile

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Style**
  * Improved responsive form layouts so headers and control rows stack and align better on small screens.
  * Decorative icons no longer shrink, preserving visual integrity across sizes.
  * Action buttons (cancel/apply, Apply All High Confidence, Batch Categorize) become full-width on small screens and revert on larger screens.
  * Minor whitespace and spacing refinements for consistent presentation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->