### PR TITLE
fix: make categorization screen responsive on mobile

### DIFF
--- a/frontend/src/components/forms/categorization-ribbon.tsx
+++ b/frontend/src/components/forms/categorization-ribbon.tsx
@@ -405,7 +405,7 @@ export function CategorizationRibbon({
                 </div>
               </div>
 
-              <div className="flex flex-col sm:flex-row gap-2 sm:gap-3">
+              <div className="flex flex-col sm:flex-row sm:items-center gap-2 sm:gap-3">
                 {/* AI Assistant Button */}
                 <Button
                   onClick={() => setShowAiSection(true)}
@@ -631,12 +631,12 @@ export function CategorizationRibbon({
                 )}
               </div>
 
-              <div className="flex gap-2">
+              <div className="flex flex-col sm:flex-row gap-2">
                 <Button
                   variant="secondary"
                   size="sm"
                   onClick={() => setShowRulePreview(false)}
-                  className="flex-1 sm:flex-none"
+                  className="w-full sm:w-auto"
                 >
                   {tCommon('cancel')}
                 </Button>
@@ -644,7 +644,7 @@ export function CategorizationRibbon({
                   onClick={handleApplySelectedRules}
                   disabled={isApplyingRules || !rulePreview.ruleMatches?.some(m => m.isSelected)}
                   size="sm"
-                  className="bg-gradient-to-r from-green-500 to-blue-500 hover:from-green-600 hover:to-primary-600 flex-1 sm:flex-none"
+                  className="bg-gradient-to-r from-green-500 to-blue-500 hover:from-green-600 hover:to-primary-600 w-full sm:w-auto"
                 >
                   {isApplyingRules ? (
                     <>


### PR DESCRIPTION
## Summary
- Stack Smart Categorization card buttons vertically on mobile (< 640px) instead of side-by-side, fixing horizontal overflow and text clipping
- Apply the same responsive stacking to the AI section header, transaction selection bar, and rule preview action bar
- Buttons become full-width on mobile for easy tap targets

## Test plan
- [ ] Open `/transactions/categorize` on a mobile viewport (375px-430px width)
- [ ] Verify "AI Assistant" and "Auto Categorize with Rules" buttons are fully visible and tappable
- [ ] Verify buttons stack vertically on small screens and sit side-by-side on desktop
- [ ] Expand the AI section and verify layout is clean on mobile
- [ ] Verify no horizontal scrolling or overflow on the categorization page

Closes #190

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Improved responsive layout behavior to better adapt to different screen sizes
  * Enhanced button sizing and spacing across the categorization interface for improved mobile experience
  * Ensured icons and buttons maintain proper proportions and don't shrink unexpectedly on smaller viewports
  * Refined dialog button layouts to intelligently share available space on mobile while adapting to larger screens

<!-- end of auto-generated comment: release notes by coderabbit.ai -->