### PR TITLE
fix: use real-time balances for dashboard net worth calculation

### DIFF
--- a/src/Core/MyMascada.Application/Features/Reports/Queries/GetDashboardSummaryQuery.cs
+++ b/src/Core/MyMascada.Application/Features/Reports/Queries/GetDashboardSummaryQuery.cs
@@ -36,16 +36,16 @@ public class GetDashboardSummaryQueryHandler : IRequestHandler<GetDashboardSumma
 
         decimal GetBalance(Domain.Entities.Account a) => accountBalances.GetValueOrDefault(a.Id, a.CurrentBalance);
 
-        // Calculate total balance from real-time balances
-        var totalBalance = userAccounts.Sum(GetBalance);
+        // Calculate total balance, assets, and liabilities in one pass
+        var balanceByType = userAccounts
+            .GroupBy(a => a.Type == AccountType.CreditCard || a.Type == AccountType.Loan) // true: liabilities, false: assets
+            .ToDictionary(g => g.Key, g => g.Sum(GetBalance));
 
-        // Net worth breakdown: CreditCard(3) + Loan(5) = liabilities, rest = assets
-        var totalAssets = userAccounts
-            .Where(a => a.Type != AccountType.CreditCard && a.Type != AccountType.Loan)
-            .Sum(GetBalance);
-        var totalLiabilities = Math.Abs(userAccounts
-            .Where(a => a.Type == AccountType.CreditCard || a.Type == AccountType.Loan)
-            .Sum(GetBalance));
+        var totalAssets = balanceByType.GetValueOrDefault(false, 0m);
+        var totalLiabilitiesRaw = balanceByType.GetValueOrDefault(true, 0m);
+
+        var totalBalance = totalAssets + totalLiabilitiesRaw;
+        var totalLiabilities = Math.Abs(totalLiabilitiesRaw);
         var netWorth = totalAssets - totalLiabilities;
 
         // Get current month boundaries


### PR DESCRIPTION
## Summary
- Dashboard was using only `Account.CurrentBalance` (static initial balance) to compute TotalBalance, NetWorth, TotalAssets, and TotalLiabilities — ignoring all transactions
- Now uses `GetAccountBalancesAsync()` which calculates `InitialBalance + Sum(Transactions)`, matching the accounts page calculation
- This was a backend-only bug — both web and mobile dashboards were affected since they share the same API endpoint

Fixes #199

## Test plan
- [ ] Verify dashboard net worth/total balance matches the accounts page totals
- [ ] Verify TotalAssets and TotalLiabilities are also correct
- [ ] Verify runway calculation (which depends on totalBalance) is accurate

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Dashboard summary now uses real-time account balances for more accurate totals. Assets, liabilities, total balance and net worth calculations were corrected to reflect up-to-date effective balances, improving the accuracy of displayed financial summaries.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->