### PR TITLE
fix: remove Akahu access token from API response to browser

### DIFF
--- a/frontend/src/lib/api-client.ts
+++ b/frontend/src/lib/api-client.ts
@@ -1593,7 +1593,7 @@ class ApiClient {
   }
 
   // Note: This is for Production App OAuth mode only, not Personal App mode
-  async exchangeAkahuCode(code: string, state?: string, appIdToken?: string): Promise<{ accounts: AkahuAccount[]; accessToken: string }> {
+  async exchangeAkahuCode(code: string, state?: string, appIdToken?: string): Promise<{ accounts: AkahuAccount[] }> {
     return this.request('/api/BankConnections/akahu/exchange', {
       method: 'POST',
       body: JSON.stringify({ code, state: state ?? null, appIdToken: appIdToken || '' }),

--- a/src/Core/MyMascada.Application/Features/BankConnections/Queries/ExchangeAkahuCodeQuery.cs
+++ b/src/Core/MyMascada.Application/Features/BankConnections/Queries/ExchangeAkahuCodeQuery.cs
@@ -18,11 +18,11 @@ public record ExchangeAkahuCodeQuery(
 ) : IRequest<ExchangeAkahuCodeResult>;
 
 /// <summary>
-/// Result of the OAuth code exchange, containing available accounts and the access token.
+/// Result of the OAuth code exchange, containing available accounts.
+/// The access token is persisted server-side only and never returned to the client.
 /// </summary>
 public record ExchangeAkahuCodeResult(
-    IEnumerable<AkahuAccountDto> Accounts,
-    string AccessToken
+    IEnumerable<AkahuAccountDto> Accounts
 );
 
 /// <summary>
@@ -136,6 +136,6 @@ public class ExchangeAkahuCodeQueryHandler : IRequestHandler<ExchangeAkahuCodeQu
             "Found {TotalCount} Akahu accounts, {LinkedCount} already linked for user {UserId}",
             accountDtos.Count, accountDtos.Count(a => a.IsAlreadyLinked), request.UserId);
 
-        return new ExchangeAkahuCodeResult(accountDtos, tokenResponse.AccessToken);
+        return new ExchangeAkahuCodeResult(accountDtos);
     }
 }

--- a/src/WebAPI/MyMascada.WebAPI/Controllers/BankConnectionsController.cs
+++ b/src/WebAPI/MyMascada.WebAPI/Controllers/BankConnectionsController.cs
@@ -217,7 +217,7 @@ public class BankConnectionsController : ControllerBase
                 _akahuOptions.AppIdToken
             );
             var result = await _mediator.Send(query);
-            return Ok(new ExchangeAkahuCodeResponse(result.Accounts, result.AccessToken));
+            return Ok(new ExchangeAkahuCodeResponse(result.Accounts));
         }
         catch (ArgumentException ex)
         {
@@ -481,10 +481,5 @@ public record ExchangeAkahuCodeResponse(
     /// <summary>
     /// List of available Akahu accounts that can be linked.
     /// </summary>
-    [property: JsonPropertyName("accounts")] IEnumerable<AkahuAccountDto> Accounts,
-
-    /// <summary>
-    /// The access token for subsequent API calls.
-    /// </summary>
-    [property: JsonPropertyName("accessToken")] string AccessToken
+    [property: JsonPropertyName("accounts")] IEnumerable<AkahuAccountDto> Accounts
 );

--- a/tests/MyMascada.Tests.Unit/Controllers/BankConnectionsControllerTests.cs
+++ b/tests/MyMascada.Tests.Unit/Controllers/BankConnectionsControllerTests.cs
@@ -25,7 +25,7 @@ public class BankConnectionsControllerTests
         });
 
         mediator.Send(Arg.Any<ExchangeAkahuCodeQuery>(), Arg.Any<CancellationToken>())
-            .Returns(new ExchangeAkahuCodeResult(Array.Empty<MyMascada.Application.Features.BankConnections.DTOs.AkahuAccountDto>(), "access_token"));
+            .Returns(new ExchangeAkahuCodeResult(Array.Empty<MyMascada.Application.Features.BankConnections.DTOs.AkahuAccountDto>()));
 
         var logger = Substitute.For<ILogger<BankConnectionsController>>();
         var controller = new BankConnectionsController(mediator, currentUserService, options, logger);

--- a/tests/MyMascada.Tests.Unit/Queries/ExchangeAkahuCodeQueryHandlerTests.cs
+++ b/tests/MyMascada.Tests.Unit/Queries/ExchangeAkahuCodeQueryHandlerTests.cs
@@ -59,7 +59,6 @@ public class ExchangeAkahuCodeQueryHandlerTests
             new ExchangeAkahuCodeQuery(userId, "code-123", null, "app_token_123"),
             CancellationToken.None);
 
-        result.AccessToken.Should().Be("user_token_oauth");
         result.Accounts.Should().ContainSingle(a => a.Id == "acc_123" && !a.IsAlreadyLinked);
 
         await credentialRepository.Received(1).AddAsync(


### PR DESCRIPTION
The /api/BankConnections/akahu/exchange endpoint was returning the
user access token in the HTTP response body, exposing it to the
browser. This violates Akahu's production accreditation requirement
that user access tokens must never be exposed to the client.

The token is already persisted server-side (encrypted) during the
OAuth exchange — the frontend never needed it.

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Modified the Akahu authentication exchange response to return connected accounts only, removing the access token from the response.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->