### PR TITLE
fix: move Telegram webhook secret from URL path to header

### DIFF
--- a/src/WebAPI/MyMascada.WebAPI/Controllers/TelegramSettingsController.cs
+++ b/src/WebAPI/MyMascada.WebAPI/Controllers/TelegramSettingsController.cs
@@ -96,7 +96,7 @@ public class TelegramSettingsController : ControllerBase
 
         var encryptedToken = _encryptionService.Encrypt(request.BotToken);
         var webhookSecret = GenerateWebhookSecret();
-        var webhookUrl = BuildWebhookUrl(webhookSecret);
+        var webhookUrl = BuildWebhookUrl();
 
         // Set webhook with Telegram
         var webhookSet = await _telegramBotService.SetWebhookAsync(request.BotToken, webhookUrl, webhookSecret);
@@ -199,7 +199,7 @@ public class TelegramSettingsController : ControllerBase
         });
     }
 
-    private string BuildWebhookUrl(string webhookSecret)
+    private string BuildWebhookUrl()
     {
         var baseUrl = _configuration["Telegram:WebhookBaseUrl"];
         if (string.IsNullOrEmpty(baseUrl))
@@ -209,7 +209,7 @@ public class TelegramSettingsController : ControllerBase
 
         // Remove trailing slash
         baseUrl = baseUrl.TrimEnd('/');
-        return $"{baseUrl}/api/telegram/webhook/{webhookSecret}";
+        return $"{baseUrl}/api/telegram/webhook";
     }
 
     private static string GenerateWebhookSecret()

--- a/src/WebAPI/MyMascada.WebAPI/Controllers/TelegramWebhookController.cs
+++ b/src/WebAPI/MyMascada.WebAPI/Controllers/TelegramWebhookController.cs
@@ -41,12 +41,20 @@ public class TelegramWebhookController : ControllerBase
         _logger = logger;
     }
 
-    [HttpPost("{secret}")]
-    public async Task<IActionResult> HandleWebhook(string secret)
+    [HttpPost]
+    public async Task<IActionResult> HandleWebhook()
     {
         // Always return 200 to prevent Telegram retries
         try
         {
+            // Validate the secret from Telegram's X-Telegram-Bot-Api-Secret-Token header
+            var secret = Request.Headers["X-Telegram-Bot-Api-Secret-Token"].FirstOrDefault();
+            if (string.IsNullOrEmpty(secret))
+            {
+                _logger.LogWarning("Webhook called without secret token header");
+                return Ok();
+            }
+
             // Read the raw body
             using var reader = new StreamReader(Request.Body);
             var body = await reader.ReadToEndAsync();


### PR DESCRIPTION
## Summary
- Moved webhook secret validation from URL path parameter (`POST /telegram/webhook/{secret}`) to the `X-Telegram-Bot-Api-Secret-Token` header, which Telegram natively sends when `secret_token` is configured via `setWebhook`
- Removed the secret from the registered webhook URL so it no longer appears in server/proxy access logs
- No behavioral change — Telegram already sends this header; the endpoint now reads it from the right place

Closes #229

## Test plan
- [ ] Disconnect and reconnect a Telegram bot to trigger webhook re-registration with the new URL format
- [ ] Send a message to the bot and verify it responds (secret validated via header)
- [ ] Verify server access logs no longer contain the secret in the URL path

🤖 Generated with [Claude Code](https://claude.com/claude-code)