### PR TITLE
fix: add replay protection for Akahu webhooks

### DIFF
--- a/src/WebAPI/MyMascada.WebAPI/Controllers/AkahuWebhookController.cs
+++ b/src/WebAPI/MyMascada.WebAPI/Controllers/AkahuWebhookController.cs
@@ -84,33 +84,34 @@ public class AkahuWebhookController : ControllerBase
                 return Ok();
             }
 
-            _cache.Set(cacheKey, true, ReplayWindow);
+            // Parse and process — always return 200 to prevent Akahu retries
+            try
+            {
+                var payload = JsonSerializer.Deserialize<AkahuWebhookPayload>(body, JsonOptions);
+                if (payload == null)
+                {
+                    _logger.LogWarning("Failed to deserialize Akahu webhook payload");
+                    return Ok();
+                }
+
+                _logger.LogInformation("Akahu webhook received: {Type}/{Code}", payload.WebhookType, payload.WebhookCode);
+
+                await _mediator.Send(new ProcessAkahuWebhookCommand(payload));
+
+                // Mark as processed only after the handler completes successfully.
+                _cache.Set(cacheKey, true, ReplayWindow);
+            }
+            catch (Exception ex)
+            {
+                // Log but don't throw — return 200 to prevent Akahu from retrying
+                _logger.LogError(ex, "Error processing Akahu webhook");
+            }
+
+            return Ok();
         }
         finally
         {
             ReplayLock.Release();
         }
-
-        // Parse and process — always return 200 to prevent Akahu retries
-        try
-        {
-            var payload = JsonSerializer.Deserialize<AkahuWebhookPayload>(body, JsonOptions);
-            if (payload == null)
-            {
-                _logger.LogWarning("Failed to deserialize Akahu webhook payload");
-                return Ok();
-            }
-
-            _logger.LogInformation("Akahu webhook received: {Type}/{Code}", payload.WebhookType, payload.WebhookCode);
-
-            await _mediator.Send(new ProcessAkahuWebhookCommand(payload));
-        }
-        catch (Exception ex)
-        {
-            // Log but don't throw — return 200 to prevent Akahu from retrying
-            _logger.LogError(ex, "Error processing Akahu webhook");
-        }
-
-        return Ok();
     }
 }


### PR DESCRIPTION
## Summary
- Adds replay protection to `AkahuWebhookController` using `IMemoryCache` with a 24-hour expiry window
- SHA-256 hashes of webhook request bodies are cached after successful signature verification
- Duplicate payloads are silently acknowledged (200 OK) to prevent Akahu retries while blocking replay attacks

Closes #228

## Test plan
- [ ] Verify first webhook delivery is processed normally
- [ ] Verify replayed (identical) payload within 24h is rejected with 200 OK and logged as duplicate
- [ ] Verify signature verification still rejects tampered payloads before replay check

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Implemented replay protection for webhook processing to detect and prevent duplicate payloads from being processed multiple times. This ensures webhooks are handled idempotently, significantly improves system reliability, and prevents unintended side effects and data inconsistencies resulting from webhook retries, network duplications, or repeated payload processing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->