### PR TITLE
fix: add persistent volume mount to Fly deployment config

### DIFF
--- a/deploy/fly/README.md
+++ b/deploy/fly/README.md
@@ -52,13 +52,29 @@ flyctl secrets set --app mymascada-api \
   GOOGLE_CLIENT_SECRET="..."
 ```
 
-### 4. Deploy API
+### 4. Create persistent volume for Data Protection keys
+
+The API requires a persistent volume at `/app/data` to store Data Protection keys.
+Without this volume, keys are lost on container restart, breaking encrypted data
+(auth cookies, tokens, etc.).
+
+```bash
+flyctl volumes create mymascada_data \
+  --region syd \
+  --size 1 \
+  --app mymascada-api
+```
+
+> **Warning:** If the volume is not mounted, the API will log a warning on startup
+> but will still run. Encrypted data from previous instances will be unreadable.
+
+### 5. Deploy API
 
 ```bash
 flyctl deploy --config deploy/fly/fly.api.toml
 ```
 
-### 5. Deploy Frontend
+### 6. Deploy Frontend
 
 ```bash
 flyctl deploy --config deploy/fly/fly.frontend.toml

--- a/deploy/fly/fly.api.toml
+++ b/deploy/fly/fly.api.toml
@@ -6,9 +6,28 @@ primary_region = "syd"
 [build]
   dockerfile = "src/Dockerfile.api"
 
+[deploy]
+  release_command = "/app/migrate.sh"
+
 [env]
   ASPNETCORE_ENVIRONMENT = "Production"
   ASPNETCORE_URLS = "http://+:5126"
+  App__FrontendUrl = "https://app.mymascada.com"
+  Cors__AllowedOrigins = "https://mymascada.com,https://www.mymascada.com,https://app.mymascada.com,https://mymascada-api.fly.dev"
+  Jwt__Issuer = "https://mymascada.com"
+  Jwt__Audience = "https://mymascada.com"
+  BetaAccess__RequireInviteCode = "true"
+  Email__Enabled = "false"
+  Email__Provider = "smtp"
+  Email__DefaultFromEmail = "noreply@mymascada.com"
+  Email__DefaultFromName = "MyMascada"
+  Email__Smtp__Host = "mail.mymascada.com"
+  Email__Smtp__Port = "587"
+  Email__Smtp__Username = "mymascada/mymascada"
+  Email__Smtp__UseStartTls = "false"
+  Email__Smtp__UseSsl = "false"
+  PasswordReset__FrontendResetUrl = "https://app.mymascada.com/auth/reset-password"
+  EmailVerification__FrontendVerifyUrl = "https://app.mymascada.com/auth/verify-email"
 
 [http_service]
   internal_port = 5126
@@ -34,3 +53,7 @@ primary_region = "syd"
   size = "shared-cpu-1x"
   memory = "512mb"
   processes = ["app"]
+
+[[mounts]]
+  source = "mymascada_data"
+  destination = "/app/data"

--- a/src/WebAPI/MyMascada.WebAPI/Program.cs
+++ b/src/WebAPI/MyMascada.WebAPI/Program.cs
@@ -109,6 +109,39 @@ var keysDirectory = isLocalDev
 
 Directory.CreateDirectory(keysDirectory);
 
+if (!isLocalDev)
+{
+    // Verify the key directory is on a persistent volume.
+    // If /app/data is not mounted, keys will be lost on container restart,
+    // breaking encrypted data (cookies, tokens, Data Protection payloads).
+    var markerFile = Path.Combine("/app/data", ".volume-marker");
+    if (!Directory.Exists("/app/data") || !IsPersistentVolume(markerFile))
+    {
+        Log.Warning(
+            "Data Protection key directory {KeysDirectory} may not be on a persistent volume. " +
+            "Ensure a volume is mounted at /app/data to prevent key loss on restart.",
+            keysDirectory);
+    }
+
+    static bool IsPersistentVolume(string markerPath)
+    {
+        // Write a marker file on first boot; if it exists on subsequent boots,
+        // the volume survived a restart.
+        if (File.Exists(markerPath))
+            return true;
+
+        try
+        {
+            File.WriteAllText(markerPath, DateTimeOffset.UtcNow.ToString("O"));
+        }
+        catch
+        {
+            // If we can't write, the directory isn't usable anyway
+        }
+        return false;
+    }
+}
+
 builder.Services.AddDataProtection()
     .PersistKeysToFileSystem(new DirectoryInfo(keysDirectory))
     .SetApplicationName("MyMascada");


### PR DESCRIPTION
## Summary

- **Added `[[mounts]]` section** to `deploy/fly/fly.api.toml` so Data Protection keys persist across container restarts
- **Aligned `fly.api.toml`** with root `fly.toml` — added missing `[deploy]` release_command and `[env]` variables
- **Added startup volume check** in `Program.cs` that warns if `/app/data` is not on a persistent volume (marker file approach)
- **Documented volume requirement** in `deploy/fly/README.md` with creation command

## Context

The root `fly.toml` correctly mounts `mymascada_data` at `/app/data`, but `deploy/fly/fly.api.toml` (the config actually used for deployment) had no `[[mounts]]`. This meant Data Protection keys were stored on ephemeral disk and lost on every restart, breaking auth cookies and encrypted tokens.

Closes #236

## Test plan

- [ ] Verify `flyctl deploy --config deploy/fly/fly.api.toml` picks up the volume mount
- [ ] Confirm API starts without volume-related warnings when volume is attached
- [ ] Confirm warning is logged when volume is missing

🤖 Generated with [Claude Code](https://claude.com/claude-code)