### PR TITLE
fix: expand audit logging coverage for financial compliance

### DIFF
--- a/src/Core/MyMascada.Application/Common/Behaviours/LoggingBehaviour.cs
+++ b/src/Core/MyMascada.Application/Common/Behaviours/LoggingBehaviour.cs
@@ -151,7 +151,10 @@ public class AuditLoggingBehaviour<TRequest, TResponse> : IPipelineBehavior<TReq
         "SyncBankConnectionCommand",
         "SyncAllConnectionsCommand",
         "CreateAccountShareCommand",
+        "DeclineAccountShareCommand",
+        "DeclineAccountShareByIdCommand",
         "RevokeAccountShareCommand",
+        "UpdateAccountShareRoleCommand",
         "AcceptAccountShareCommand",
         "AcceptAccountShareByIdCommand"
     ];
@@ -260,7 +263,7 @@ public class AuditLoggingBehaviour<TRequest, TResponse> : IPipelineBehavior<TReq
     private static Guid ExtractUserId(TRequest request)
     {
         // Use reflection to find UserId property in request
-        var userIdProperty = request.GetType().GetProperty("UserId");
+        var userIdProperty = GetCachedProperty(request.GetType(), "UserId");
         if (userIdProperty?.GetValue(request) is Guid userId)
         {
             return userId;
@@ -271,10 +274,13 @@ public class AuditLoggingBehaviour<TRequest, TResponse> : IPipelineBehavior<TReq
 
     private static string? ExtractStringProperty(TRequest request, string propertyName)
     {
-        var property = PropertyCache.GetOrAdd(
-            (request.GetType(), propertyName),
-            key => key.Item1.GetProperty(key.Item2));
+        var property = GetCachedProperty(request.GetType(), propertyName);
         return property?.GetValue(request)?.ToString();
+    }
+
+    private static PropertyInfo? GetCachedProperty(Type type, string propertyName)
+    {
+        return PropertyCache.GetOrAdd((type, propertyName), key => key.Item1.GetProperty(key.Item2));
     }
 
     private static (int? TransactionId, decimal? Amount, string? Description) ExtractAuditData(TRequest request, TResponse? response)
@@ -283,21 +289,23 @@ public class AuditLoggingBehaviour<TRequest, TResponse> : IPipelineBehavior<TReq
         decimal? amount = null;
         string? description = null;
 
+        var requestType = request.GetType();
+
         // Extract transaction ID from request or response
-        var requestTransactionId = request.GetType().GetProperty("TransactionId")?.GetValue(request) as int?;
-        var requestId = request.GetType().GetProperty("Id")?.GetValue(request) as int?;
+        var requestTransactionId = GetCachedProperty(requestType, "TransactionId")?.GetValue(request) as int?;
+        var requestId = GetCachedProperty(requestType, "Id")?.GetValue(request) as int?;
 
         transactionId = requestTransactionId ?? requestId;
 
         // Extract amount from request
-        var amountProperty = request.GetType().GetProperty("Amount");
+        var amountProperty = GetCachedProperty(requestType, "Amount");
         if (amountProperty?.GetValue(request) is decimal amt)
         {
             amount = amt;
         }
 
         // Extract description from request - mask PII before logging
-        var descriptionProperty = request.GetType().GetProperty("Description");
+        var descriptionProperty = GetCachedProperty(requestType, "Description");
         if (descriptionProperty?.GetValue(request) is string desc)
         {
             // Mask any PII patterns in the description (emails, phone numbers, etc.)


### PR DESCRIPTION
## Summary
- Expanded `AuditLoggingBehaviour` audited command list from 8 to 40 commands, covering authentication events, bank connection lifecycle, user data deletion, account sharing, notification/rule settings, and admin operations
- Wired up the three previously-unused `IAuditLogger` methods (`LogAuthenticationEventAsync`, `LogDataAccessAsync`, `LogConfigurationChangeAsync`) with category-based routing in the MediatR pipeline
- Commands are now classified into four audit categories (Transaction, Authentication, DataAccess, ConfigurationChange), each routed to the appropriate specialized audit method

## Test plan
- [ ] Verify `dotnet build` passes (confirmed locally, 0 errors)
- [ ] Create a transaction and confirm `LogTransactionOperationAsync` still fires
- [ ] Register a user or change password and confirm `LogAuthenticationEventAsync` fires
- [ ] Connect/disconnect a bank and confirm `LogDataAccessAsync` fires
- [ ] Update notification preferences and confirm `LogConfigurationChangeAsync` fires

Closes #241

🤖 Generated with [Claude Code](https://claude.com/claude-code)