### PR TITLE
fix: restrict CORS policy to specific HTTP methods and headers

### DIFF
--- a/src/WebAPI/MyMascada.WebAPI/Extensions/CorsServiceExtensions.cs
+++ b/src/WebAPI/MyMascada.WebAPI/Extensions/CorsServiceExtensions.cs
@@ -36,8 +36,8 @@ public static class CorsServiceExtensions
                     .ToArray();
 
                 policy.WithOrigins(allOrigins)
-                      .AllowAnyMethod()
-                      .AllowAnyHeader()
+                      .WithMethods("GET", "POST", "PUT", "DELETE", "PATCH", "OPTIONS")
+                      .WithHeaders("Content-Type", "Authorization", "Accept", "X-Requested-With")
                       .AllowCredentials()
                       .SetPreflightMaxAge(TimeSpan.FromMinutes(10))
                       .WithExposedHeaders("Authorization", "Content-Type", "Accept", "Origin", "Access-Control-Allow-Origin");


### PR DESCRIPTION
## Summary
- Replace `AllowAnyMethod()` with explicit allowlist: `GET`, `POST`, `PUT`, `DELETE`, `PATCH`, `OPTIONS`
- Replace `AllowAnyHeader()` with explicit allowlist: `Content-Type`, `Authorization`, `Accept`, `X-Requested-With`
- Reduces attack surface without affecting frontend functionality

Closes #232

## Test plan
- [ ] Verify frontend API calls work (login, CRUD operations, file uploads)
- [ ] Verify preflight OPTIONS requests succeed
- [ ] Confirm no CORS errors in browser console

🤖 Generated with [Claude Code](https://claude.com/claude-code)