### PR TITLE
fix: persist currency/timezone in locale endpoint, include onboarding status

### DIFF
--- a/src/Core/MyMascada.Application/Common/CurrencyConstants.cs
+++ b/src/Core/MyMascada.Application/Common/CurrencyConstants.cs
@@ -1,13 +1,17 @@
+using System.Text.RegularExpressions;
+
 namespace MyMascada.Application.Common;
 
 /// <summary>
-/// Currencies accepted across the application. Must stay in sync with frontend/src/lib/countries.ts.
+/// Currency validation — accepts any syntactically valid 3-letter ISO 4217 code.
 /// </summary>
 public static class CurrencyConstants
 {
-    public static readonly HashSet<string> Supported = new(StringComparer.OrdinalIgnoreCase)
-    {
-        "USD", "EUR", "GBP", "BRL", "NZD", "AUD", "CAD", "JPY",
-        "ARS", "CLP", "COP", "MXN"
-    };
+    private static readonly Regex Iso4217Pattern = new(@"^[A-Z]{3}$", RegexOptions.Compiled);
+
+    /// <summary>
+    /// Returns true when the value is exactly three uppercase ASCII letters.
+    /// </summary>
+    public static bool IsValid(string? code) =>
+        code is not null && Iso4217Pattern.IsMatch(code);
 }

--- a/src/Core/MyMascada.Application/Common/CurrencyConstants.cs
+++ b/src/Core/MyMascada.Application/Common/CurrencyConstants.cs
@@ -1,0 +1,13 @@
+namespace MyMascada.Application.Common;
+
+/// <summary>
+/// Currencies accepted across the application. Must stay in sync with frontend/src/lib/countries.ts.
+/// </summary>
+public static class CurrencyConstants
+{
+    public static readonly HashSet<string> Supported = new(StringComparer.OrdinalIgnoreCase)
+    {
+        "USD", "EUR", "GBP", "BRL", "NZD", "AUD", "CAD", "JPY",
+        "ARS", "CLP", "COP", "MXN"
+    };
+}

--- a/src/Core/MyMascada.Application/Common/Interfaces/IUserStatusService.cs
+++ b/src/Core/MyMascada.Application/Common/Interfaces/IUserStatusService.cs
@@ -1,0 +1,10 @@
+namespace MyMascada.Application.Common.Interfaces;
+
+/// <summary>
+/// Computes user onboarding and AI configuration status flags.
+/// Centralises the logic so all auth-related endpoints return consistent values.
+/// </summary>
+public interface IUserStatusService
+{
+    Task<(bool IsOnboardingComplete, bool HasAiConfigured)> GetStatusAsync(Guid userId);
+}

--- a/src/Core/MyMascada.Application/Common/Interfaces/IUserStatusService.cs
+++ b/src/Core/MyMascada.Application/Common/Interfaces/IUserStatusService.cs
@@ -6,5 +6,5 @@ namespace MyMascada.Application.Common.Interfaces;
 /// </summary>
 public interface IUserStatusService
 {
-    Task<(bool IsOnboardingComplete, bool HasAiConfigured)> GetStatusAsync(Guid userId);
+    Task<(bool IsOnboardingComplete, bool HasAiConfigured)> GetStatusAsync(Guid userId, CancellationToken ct = default);
 }

--- a/src/Core/MyMascada.Application/Features/Authentication/Queries/LoginQuery.cs
+++ b/src/Core/MyMascada.Application/Features/Authentication/Queries/LoginQuery.cs
@@ -151,7 +151,7 @@ public class LoginQueryHandler : IRequestHandler<LoginQuery, AuthenticationRespo
         response.RefreshToken = refreshTokenResult.RawToken;
         response.RefreshTokenExpiresAt = refreshTokenResult.ExpiresAt;
 
-        var (isOnboardingComplete, hasAiConfigured) = await _userStatusService.GetStatusAsync(user.Id);
+        var (isOnboardingComplete, hasAiConfigured) = await _userStatusService.GetStatusAsync(user.Id, cancellationToken);
 
         response.User = new UserDto
         {

--- a/src/Core/MyMascada.Application/Features/Authentication/Queries/LoginQuery.cs
+++ b/src/Core/MyMascada.Application/Features/Authentication/Queries/LoginQuery.cs
@@ -22,10 +22,7 @@ public class LoginQueryHandler : IRequestHandler<LoginQuery, AuthenticationRespo
     private readonly IUserRepository _userRepository;
     private readonly IAuthenticationService _authenticationService;
     private readonly ITokenService _tokenService;
-    private readonly IUserFinancialProfileRepository _financialProfileRepository;
-    private readonly IUserAiSettingsRepository _aiSettingsRepository;
-    private readonly IAccountRepository _accountRepository;
-    private readonly IFeatureFlags _featureFlags;
+    private readonly IUserStatusService _userStatusService;
     private readonly LockoutOptions _lockoutOptions;
     private readonly ILogger<LoginQueryHandler> _logger;
 
@@ -33,20 +30,14 @@ public class LoginQueryHandler : IRequestHandler<LoginQuery, AuthenticationRespo
         IUserRepository userRepository,
         IAuthenticationService authenticationService,
         ITokenService tokenService,
-        IUserFinancialProfileRepository financialProfileRepository,
-        IUserAiSettingsRepository aiSettingsRepository,
-        IAccountRepository accountRepository,
-        IFeatureFlags featureFlags,
+        IUserStatusService userStatusService,
         IOptions<LockoutOptions> lockoutOptions,
         ILogger<LoginQueryHandler> logger)
     {
         _userRepository = userRepository;
         _authenticationService = authenticationService;
         _tokenService = tokenService;
-        _financialProfileRepository = financialProfileRepository;
-        _aiSettingsRepository = aiSettingsRepository;
-        _accountRepository = accountRepository;
-        _featureFlags = featureFlags;
+        _userStatusService = userStatusService;
         _lockoutOptions = lockoutOptions.Value;
         _logger = logger;
     }
@@ -159,15 +150,8 @@ public class LoginQueryHandler : IRequestHandler<LoginQuery, AuthenticationRespo
         response.ExpiresAt = expiresAt;
         response.RefreshToken = refreshTokenResult.RawToken;
         response.RefreshTokenExpiresAt = refreshTokenResult.ExpiresAt;
-        // Check if user has AI configured (own key or global key)
-        var aiSettings = await _aiSettingsRepository.GetByUserIdAsync(user.Id);
-        var hasAiConfigured = (aiSettings != null && !string.IsNullOrEmpty(aiSettings.EncryptedApiKey))
-            || _featureFlags.HasGlobalAiKey;
 
-        // Check onboarding status — also skip for users who already have accounts
-        var financialProfile = await _financialProfileRepository.GetByUserIdAsync(user.Id);
-        var hasAccounts = (await _accountRepository.GetByUserIdAsync(user.Id)).Any();
-        var isOnboardingComplete = (financialProfile != null && financialProfile.OnboardingCompleted) || hasAccounts;
+        var (isOnboardingComplete, hasAiConfigured) = await _userStatusService.GetStatusAsync(user.Id);
 
         response.User = new UserDto
         {

--- a/src/Core/MyMascada.Application/Features/Authentication/Validators/RegisterCommandValidator.cs
+++ b/src/Core/MyMascada.Application/Features/Authentication/Validators/RegisterCommandValidator.cs
@@ -90,7 +90,7 @@ public class RegisterCommandValidator : AbstractValidator<RegisterCommand>
         RuleFor(x => x.Currency)
             .NotEmpty()
             .WithMessage("Currency is required")
-            .Must(c => CurrencyConstants.IsValid(c.Trim().ToUpperInvariant()))
+            .Must(c => CurrencyConstants.IsValid(c))
             .WithMessage("Currency must be a valid 3-letter ISO 4217 code (e.g., USD, EUR, BRL)");
 
         RuleFor(x => x.TimeZone)

--- a/src/Core/MyMascada.Application/Features/Authentication/Validators/RegisterCommandValidator.cs
+++ b/src/Core/MyMascada.Application/Features/Authentication/Validators/RegisterCommandValidator.cs
@@ -1,4 +1,5 @@
 using FluentValidation;
+using MyMascada.Application.Common;
 using MyMascada.Application.Features.Authentication.Commands;
 using System.Text.RegularExpressions;
 
@@ -89,10 +90,8 @@ public class RegisterCommandValidator : AbstractValidator<RegisterCommand>
         RuleFor(x => x.Currency)
             .NotEmpty()
             .WithMessage("Currency is required")
-            .Length(3)
-            .WithMessage("Currency must be a 3-letter ISO code (e.g., USD, EUR, GBP)")
-            .Matches(@"^[A-Z]{3}$")
-            .WithMessage("Currency must be uppercase letters only");
+            .Must(c => CurrencyConstants.Supported.Contains(c))
+            .WithMessage($"Currency must be one of: {string.Join(", ", CurrencyConstants.Supported.Order())}");
 
         RuleFor(x => x.TimeZone)
             .NotEmpty()

--- a/src/Core/MyMascada.Application/Features/Authentication/Validators/RegisterCommandValidator.cs
+++ b/src/Core/MyMascada.Application/Features/Authentication/Validators/RegisterCommandValidator.cs
@@ -90,8 +90,8 @@ public class RegisterCommandValidator : AbstractValidator<RegisterCommand>
         RuleFor(x => x.Currency)
             .NotEmpty()
             .WithMessage("Currency is required")
-            .Must(c => CurrencyConstants.Supported.Contains(c))
-            .WithMessage($"Currency must be one of: {string.Join(", ", CurrencyConstants.Supported.Order())}");
+            .Must(c => CurrencyConstants.IsValid(c.Trim().ToUpperInvariant()))
+            .WithMessage("Currency must be a valid 3-letter ISO 4217 code (e.g., USD, EUR, BRL)");
 
         RuleFor(x => x.TimeZone)
             .NotEmpty()

--- a/src/Infrastructure/MyMascada.Infrastructure/Services/UserStatusService.cs
+++ b/src/Infrastructure/MyMascada.Infrastructure/Services/UserStatusService.cs
@@ -21,10 +21,10 @@ public class UserStatusService : IUserStatusService
         _featureFlags = featureFlags;
     }
 
-    public async Task<(bool IsOnboardingComplete, bool HasAiConfigured)> GetStatusAsync(Guid userId)
+    public async Task<(bool IsOnboardingComplete, bool HasAiConfigured)> GetStatusAsync(Guid userId, CancellationToken ct = default)
     {
         // Sequential — all repositories share a scoped DbContext which is not thread-safe
-        var financialProfile = await _financialProfileRepository.GetByUserIdAsync(userId);
+        var financialProfile = await _financialProfileRepository.GetByUserIdAsync(userId, ct);
         var accounts = await _accountRepository.GetByUserIdAsync(userId);
         var aiSettings = await _aiSettingsRepository.GetByUserIdAsync(userId);
 

--- a/src/Infrastructure/MyMascada.Infrastructure/Services/UserStatusService.cs
+++ b/src/Infrastructure/MyMascada.Infrastructure/Services/UserStatusService.cs
@@ -1,0 +1,38 @@
+using MyMascada.Application.Common.Interfaces;
+
+namespace MyMascada.Infrastructure.Services;
+
+public class UserStatusService : IUserStatusService
+{
+    private readonly IUserFinancialProfileRepository _financialProfileRepository;
+    private readonly IAccountRepository _accountRepository;
+    private readonly IUserAiSettingsRepository _aiSettingsRepository;
+    private readonly IFeatureFlags _featureFlags;
+
+    public UserStatusService(
+        IUserFinancialProfileRepository financialProfileRepository,
+        IAccountRepository accountRepository,
+        IUserAiSettingsRepository aiSettingsRepository,
+        IFeatureFlags featureFlags)
+    {
+        _financialProfileRepository = financialProfileRepository;
+        _accountRepository = accountRepository;
+        _aiSettingsRepository = aiSettingsRepository;
+        _featureFlags = featureFlags;
+    }
+
+    public async Task<(bool IsOnboardingComplete, bool HasAiConfigured)> GetStatusAsync(Guid userId)
+    {
+        // Sequential — all repositories share a scoped DbContext which is not thread-safe
+        var financialProfile = await _financialProfileRepository.GetByUserIdAsync(userId);
+        var accounts = await _accountRepository.GetByUserIdAsync(userId);
+        var aiSettings = await _aiSettingsRepository.GetByUserIdAsync(userId);
+
+        var hasAccounts = accounts.Any();
+        var isOnboardingComplete = (financialProfile != null && financialProfile.OnboardingCompleted) || hasAccounts;
+        var hasAiConfigured = (aiSettings != null && !string.IsNullOrEmpty(aiSettings.EncryptedApiKey))
+            || _featureFlags.HasGlobalAiKey;
+
+        return (isOnboardingComplete, hasAiConfigured);
+    }
+}

--- a/src/Infrastructure/MyMascada.Infrastructure/Services/UserStatusService.cs
+++ b/src/Infrastructure/MyMascada.Infrastructure/Services/UserStatusService.cs
@@ -5,31 +5,27 @@ namespace MyMascada.Infrastructure.Services;
 public class UserStatusService : IUserStatusService
 {
     private readonly IUserFinancialProfileRepository _financialProfileRepository;
-    private readonly IAccountRepository _accountRepository;
     private readonly IUserAiSettingsRepository _aiSettingsRepository;
     private readonly IFeatureFlags _featureFlags;
 
     public UserStatusService(
         IUserFinancialProfileRepository financialProfileRepository,
-        IAccountRepository accountRepository,
         IUserAiSettingsRepository aiSettingsRepository,
         IFeatureFlags featureFlags)
     {
         _financialProfileRepository = financialProfileRepository;
-        _accountRepository = accountRepository;
         _aiSettingsRepository = aiSettingsRepository;
         _featureFlags = featureFlags;
     }
 
     public async Task<(bool IsOnboardingComplete, bool HasAiConfigured)> GetStatusAsync(Guid userId, CancellationToken ct = default)
     {
-        // Sequential — all repositories share a scoped DbContext which is not thread-safe
+        // Sequential — repositories share a scoped DbContext which is not thread-safe
         var financialProfile = await _financialProfileRepository.GetByUserIdAsync(userId, ct);
-        var accounts = await _accountRepository.GetByUserIdAsync(userId);
         var aiSettings = await _aiSettingsRepository.GetByUserIdAsync(userId);
 
-        var hasAccounts = accounts.Any();
-        var isOnboardingComplete = (financialProfile != null && financialProfile.OnboardingCompleted) || hasAccounts;
+        // Align with canonical source: GetOnboardingStatusQuery checks only OnboardingCompleted
+        var isOnboardingComplete = financialProfile?.OnboardingCompleted ?? false;
         var hasAiConfigured = (aiSettings != null && !string.IsNullOrEmpty(aiSettings.EncryptedApiKey))
             || _featureFlags.HasGlobalAiKey;
 

--- a/src/WebAPI/MyMascada.WebAPI/Controllers/AuthController.cs
+++ b/src/WebAPI/MyMascada.WebAPI/Controllers/AuthController.cs
@@ -294,7 +294,7 @@ public class AuthController : ControllerBase
         }
 
         // Nothing to update — return current state without a DB write
-        if (request.Locale == null && request.Currency == null && request.TimeZone == null)
+        if (string.IsNullOrWhiteSpace(request.Locale) && string.IsNullOrWhiteSpace(request.Currency) && string.IsNullOrWhiteSpace(request.TimeZone))
         {
             return Ok(await BuildUserDtoAsync(user));
         }
@@ -310,13 +310,13 @@ public class AuthController : ControllerBase
             user.Locale = request.Locale;
         }
 
-        // Validate and update currency (ISO 4217 subset — must match countries.ts on the frontend)
+        // Validate and update currency (any valid 3-letter ISO 4217 code)
         if (!string.IsNullOrWhiteSpace(request.Currency))
         {
             var normalizedCurrency = request.Currency.Trim().ToUpperInvariant();
-            if (!CurrencyConstants.Supported.Contains(normalizedCurrency))
+            if (!CurrencyConstants.IsValid(normalizedCurrency))
             {
-                return BadRequest(new { Error = $"Unsupported currency. Supported: {string.Join(", ", CurrencyConstants.Supported.Order())}" });
+                return BadRequest(new { Error = "Currency must be a valid 3-letter ISO 4217 code (e.g., USD, EUR, BRL)" });
             }
             user.Currency = normalizedCurrency;
         }

--- a/src/WebAPI/MyMascada.WebAPI/Controllers/AuthController.cs
+++ b/src/WebAPI/MyMascada.WebAPI/Controllers/AuthController.cs
@@ -28,10 +28,7 @@ public class AuthController : ControllerBase
     private readonly IUserRepository _userRepository;
     private readonly MyMascada.Application.Common.Configuration.AppOptions _appOptions;
     private readonly IWebHostEnvironment _environment;
-    private readonly IUserAiSettingsRepository _aiSettingsRepository;
-    private readonly IConfiguration _configuration;
-    private readonly IUserFinancialProfileRepository _financialProfileRepository;
-    private readonly IAccountRepository _accountRepository;
+    private readonly IUserStatusService _userStatusService;
     private readonly ISubscriptionService _subscriptionService;
     private readonly ILogger<AuthController> _logger;
 
@@ -42,10 +39,7 @@ public class AuthController : ControllerBase
         IUserRepository userRepository,
         Microsoft.Extensions.Options.IOptions<MyMascada.Application.Common.Configuration.AppOptions> appOptions,
         IWebHostEnvironment environment,
-        IUserAiSettingsRepository aiSettingsRepository,
-        IConfiguration configuration,
-        IUserFinancialProfileRepository financialProfileRepository,
-        IAccountRepository accountRepository,
+        IUserStatusService userStatusService,
         ISubscriptionService subscriptionService,
         ILogger<AuthController> logger)
     {
@@ -55,10 +49,7 @@ public class AuthController : ControllerBase
         _userRepository = userRepository;
         _appOptions = appOptions.Value;
         _environment = environment;
-        _aiSettingsRepository = aiSettingsRepository;
-        _configuration = configuration;
-        _financialProfileRepository = financialProfileRepository;
-        _accountRepository = accountRepository;
+        _userStatusService = userStatusService;
         _subscriptionService = subscriptionService;
         _logger = logger;
     }
@@ -282,41 +273,7 @@ public class AuthController : ControllerBase
             return NotFound();
         }
 
-        // Check if user has AI configured (own key or global key)
-        var aiSettings = await _aiSettingsRepository.GetByUserIdAsync(userId);
-        var globalApiKey = _configuration["LLM:OpenAI:ApiKey"];
-        var hasAiConfigured = (aiSettings != null && !string.IsNullOrEmpty(aiSettings.EncryptedApiKey))
-            || (!string.IsNullOrEmpty(globalApiKey) && globalApiKey != "YOUR_OPENAI_API_KEY");
-
-        // Check onboarding status — also skip for users who already have accounts
-        var financialProfile = await _financialProfileRepository.GetByUserIdAsync(userId);
-        var hasAccounts = (await _accountRepository.GetByUserIdAsync(userId)).Any();
-        var isOnboardingComplete = (financialProfile != null && financialProfile.OnboardingCompleted) || hasAccounts;
-
-        var userDto = new UserDto
-        {
-            Id = user.Id,
-            Email = user.Email ?? "",
-            UserName = user.UserName ?? "",
-            FirstName = user.FirstName ?? "",
-            LastName = user.LastName ?? "",
-            FullName = $"{user.FirstName} {user.LastName}".Trim(),
-            Currency = user.Currency ?? "NZD",
-            TimeZone = user.TimeZone ?? "UTC",
-            Locale = user.Locale ?? "en",
-            AiDescriptionCleaning = user.AiDescriptionCleaning,
-            HasAiConfigured = hasAiConfigured,
-            IsOnboardingComplete = isOnboardingComplete
-        };
-
-        // Subscription tier — drives premium upsells in the frontend. Routed
-        // through the shared helper so a subscription-service outage (Stripe
-        // blip, DB hiccup) doesn't 500 /auth/me and break user bootstrap.
-        // SubscriptionTier is left null on failure; the frontend treats that
-        // as "unknown → hide upsell" until the next refresh.
-        await EnrichSubscriptionFieldsAsync(userDto, HttpContext.RequestAborted);
-
-        return Ok(userDto);
+        return Ok(await BuildUserDtoAsync(user, userId));
     }
 
     [HttpPatch("locale")]
@@ -335,32 +292,43 @@ public class AuthController : ControllerBase
             return NotFound();
         }
 
-        // Validate the locale
-        var supportedLocales = new[] { "en", "pt-BR" };
-        if (!supportedLocales.Contains(request.Locale))
+        // Validate and update locale (only if provided)
+        if (!string.IsNullOrWhiteSpace(request.Locale))
         {
-            return BadRequest(new { Error = $"Unsupported locale. Supported locales: {string.Join(", ", supportedLocales)}" });
+            var supportedLocales = new[] { "en", "pt-BR" };
+            if (!supportedLocales.Contains(request.Locale))
+            {
+                return BadRequest(new { Error = $"Unsupported locale. Supported locales: {string.Join(", ", supportedLocales)}" });
+            }
+            user.Locale = request.Locale;
         }
 
-        user.Locale = request.Locale;
+        // Validate and update currency (ISO 4217 subset)
+        if (!string.IsNullOrWhiteSpace(request.Currency))
+        {
+            var normalizedCurrency = request.Currency.Trim().ToUpperInvariant();
+            var supportedCurrencies = new[] { "USD", "EUR", "GBP", "BRL", "NZD", "AUD", "CAD", "JPY" };
+            if (!supportedCurrencies.Contains(normalizedCurrency))
+            {
+                return BadRequest(new { Error = $"Unsupported currency. Supported: {string.Join(", ", supportedCurrencies)}" });
+            }
+            user.Currency = normalizedCurrency;
+        }
+
+        // Validate and update timezone (must be a recognized IANA/system timezone)
+        if (!string.IsNullOrWhiteSpace(request.TimeZone))
+        {
+            var normalizedTimeZone = request.TimeZone.Trim();
+            try { TimeZoneInfo.FindSystemTimeZoneById(normalizedTimeZone); }
+            catch (TimeZoneNotFoundException)
+            {
+                return BadRequest(new { Error = $"Unrecognized timezone: {normalizedTimeZone}" });
+            }
+            user.TimeZone = normalizedTimeZone;
+        }
         await _userRepository.UpdateAsync(user);
 
-        var userDto = new UserDto
-        {
-            Id = user.Id,
-            Email = user.Email ?? "",
-            UserName = user.UserName ?? "",
-            FirstName = user.FirstName ?? "",
-            LastName = user.LastName ?? "",
-            FullName = $"{user.FirstName} {user.LastName}".Trim(),
-            Currency = user.Currency ?? "NZD",
-            TimeZone = user.TimeZone ?? "UTC",
-            Locale = user.Locale ?? "en",
-            AiDescriptionCleaning = user.AiDescriptionCleaning
-        };
-        await EnrichSubscriptionFieldsAsync(userDto, HttpContext.RequestAborted);
-
-        return Ok(userDto);
+        return Ok(await BuildUserDtoAsync(user, userId));
     }
 
     [HttpPatch("ai-description-cleaning")]
@@ -382,22 +350,7 @@ public class AuthController : ControllerBase
         user.AiDescriptionCleaning = request.Enabled;
         await _userRepository.UpdateAsync(user);
 
-        var userDto = new UserDto
-        {
-            Id = user.Id,
-            Email = user.Email ?? "",
-            UserName = user.UserName ?? "",
-            FirstName = user.FirstName ?? "",
-            LastName = user.LastName ?? "",
-            FullName = $"{user.FirstName} {user.LastName}".Trim(),
-            Currency = user.Currency ?? "NZD",
-            TimeZone = user.TimeZone ?? "UTC",
-            Locale = user.Locale ?? "en",
-            AiDescriptionCleaning = user.AiDescriptionCleaning
-        };
-        await EnrichSubscriptionFieldsAsync(userDto, HttpContext.RequestAborted);
-
-        return Ok(userDto);
+        return Ok(await BuildUserDtoAsync(user, userId));
     }
 
     [HttpPost("refresh")]
@@ -431,20 +384,11 @@ public class AuthController : ControllerBase
             }
 
             // Enrich User with fields the TokenService doesn't populate
-            // (IsOnboardingComplete, HasAiConfigured, Locale, SubscriptionTier)
-            // to match /me response — without SubscriptionTier/IsSelfHosted,
-            // paid users flash the Free-tier upsell banners on every refresh.
             if (result.User != null)
             {
-                var userId = result.User.Id;
-                var aiSettings = await _aiSettingsRepository.GetByUserIdAsync(userId);
-                var globalApiKey = _configuration["LLM:OpenAI:ApiKey"];
-                result.User.HasAiConfigured = (aiSettings != null && !string.IsNullOrEmpty(aiSettings.EncryptedApiKey))
-                    || (!string.IsNullOrEmpty(globalApiKey) && globalApiKey != "YOUR_OPENAI_API_KEY");
-
-                var financialProfile = await _financialProfileRepository.GetByUserIdAsync(userId);
-                var hasAccounts = (await _accountRepository.GetByUserIdAsync(userId)).Any();
-                result.User.IsOnboardingComplete = (financialProfile != null && financialProfile.OnboardingCompleted) || hasAccounts;
+                var (isOnboardingComplete, hasAiConfigured) = await _userStatusService.GetStatusAsync(result.User.Id);
+                result.User.IsOnboardingComplete = isOnboardingComplete;
+                result.User.HasAiConfigured = hasAiConfigured;
 
                 await EnrichSubscriptionFieldsAsync(result.User, HttpContext.RequestAborted);
             }
@@ -903,6 +847,31 @@ public class AuthController : ControllerBase
         });
     }
 
+    private async Task<UserDto> BuildUserDtoAsync(Domain.Entities.User user, Guid userId)
+    {
+        var (isOnboardingComplete, hasAiConfigured) = await _userStatusService.GetStatusAsync(userId);
+
+        var userDto = new UserDto
+        {
+            Id = user.Id,
+            Email = user.Email ?? "",
+            UserName = user.UserName ?? "",
+            FirstName = user.FirstName ?? "",
+            LastName = user.LastName ?? "",
+            FullName = $"{user.FirstName} {user.LastName}".Trim(),
+            Currency = user.Currency ?? "NZD",
+            TimeZone = user.TimeZone ?? "UTC",
+            Locale = user.Locale ?? "en",
+            AiDescriptionCleaning = user.AiDescriptionCleaning,
+            HasAiConfigured = hasAiConfigured,
+            IsOnboardingComplete = isOnboardingComplete
+        };
+
+        await EnrichSubscriptionFieldsAsync(userDto, HttpContext.RequestAborted);
+
+        return userDto;
+    }
+
     private void SetRefreshTokenCookie(string refreshToken, DateTime expires)
     {
         var cookieOptions = new CookieOptions
@@ -1010,7 +979,9 @@ public class GoogleUserInfo
 
 public class UpdateLocaleRequest
 {
-    public string Locale { get; set; } = "en";
+    public string? Locale { get; set; }
+    public string? Currency { get; set; }
+    public string? TimeZone { get; set; }
 }
 
 public class ConfirmEmailRequest

--- a/src/WebAPI/MyMascada.WebAPI/Controllers/AuthController.cs
+++ b/src/WebAPI/MyMascada.WebAPI/Controllers/AuthController.cs
@@ -22,6 +22,12 @@ namespace MyMascada.WebAPI.Controllers;
 [Route("api/latest/[controller]")]
 public class AuthController : ControllerBase
 {
+    private static readonly HashSet<string> SupportedCurrencies = new(StringComparer.OrdinalIgnoreCase)
+    {
+        "USD", "EUR", "GBP", "BRL", "NZD", "AUD", "CAD", "JPY",
+        "ARS", "CLP", "COP", "MXN"
+    };
+
     private readonly IMediator _mediator;
     private readonly IAuthenticationService _authService;
     private readonly IDataProtector _dataProtector;
@@ -273,7 +279,7 @@ public class AuthController : ControllerBase
             return NotFound();
         }
 
-        return Ok(await BuildUserDtoAsync(user, userId));
+        return Ok(await BuildUserDtoAsync(user));
     }
 
     [HttpPatch("locale")]
@@ -303,14 +309,13 @@ public class AuthController : ControllerBase
             user.Locale = request.Locale;
         }
 
-        // Validate and update currency (ISO 4217 subset)
+        // Validate and update currency (ISO 4217 subset — must match countries.ts on the frontend)
         if (!string.IsNullOrWhiteSpace(request.Currency))
         {
             var normalizedCurrency = request.Currency.Trim().ToUpperInvariant();
-            var supportedCurrencies = new[] { "USD", "EUR", "GBP", "BRL", "NZD", "AUD", "CAD", "JPY" };
-            if (!supportedCurrencies.Contains(normalizedCurrency))
+            if (!SupportedCurrencies.Contains(normalizedCurrency))
             {
-                return BadRequest(new { Error = $"Unsupported currency. Supported: {string.Join(", ", supportedCurrencies)}" });
+                return BadRequest(new { Error = $"Unsupported currency. Supported: {string.Join(", ", SupportedCurrencies.Order())}" });
             }
             user.Currency = normalizedCurrency;
         }
@@ -328,7 +333,7 @@ public class AuthController : ControllerBase
         }
         await _userRepository.UpdateAsync(user);
 
-        return Ok(await BuildUserDtoAsync(user, userId));
+        return Ok(await BuildUserDtoAsync(user));
     }
 
     [HttpPatch("ai-description-cleaning")]
@@ -350,7 +355,7 @@ public class AuthController : ControllerBase
         user.AiDescriptionCleaning = request.Enabled;
         await _userRepository.UpdateAsync(user);
 
-        return Ok(await BuildUserDtoAsync(user, userId));
+        return Ok(await BuildUserDtoAsync(user));
     }
 
     [HttpPost("refresh")]
@@ -847,9 +852,9 @@ public class AuthController : ControllerBase
         });
     }
 
-    private async Task<UserDto> BuildUserDtoAsync(Domain.Entities.User user, Guid userId)
+    private async Task<UserDto> BuildUserDtoAsync(Domain.Entities.User user)
     {
-        var (isOnboardingComplete, hasAiConfigured) = await _userStatusService.GetStatusAsync(userId);
+        var (isOnboardingComplete, hasAiConfigured) = await _userStatusService.GetStatusAsync(user.Id);
 
         var userDto = new UserDto
         {

--- a/src/WebAPI/MyMascada.WebAPI/Controllers/AuthController.cs
+++ b/src/WebAPI/MyMascada.WebAPI/Controllers/AuthController.cs
@@ -9,6 +9,7 @@ using System.Text.Json;
 using MyMascada.Application.Features.Authentication.Commands;
 using MyMascada.Application.Features.Authentication.DTOs;
 using MyMascada.Application.Features.Authentication.Queries;
+using MyMascada.Application.Common;
 using MyMascada.Application.Common.Interfaces;
 using Microsoft.AspNetCore.RateLimiting;
 using MyMascada.WebAPI.Constants;
@@ -22,12 +23,6 @@ namespace MyMascada.WebAPI.Controllers;
 [Route("api/latest/[controller]")]
 public class AuthController : ControllerBase
 {
-    private static readonly HashSet<string> SupportedCurrencies = new(StringComparer.OrdinalIgnoreCase)
-    {
-        "USD", "EUR", "GBP", "BRL", "NZD", "AUD", "CAD", "JPY",
-        "ARS", "CLP", "COP", "MXN"
-    };
-
     private readonly IMediator _mediator;
     private readonly IAuthenticationService _authService;
     private readonly IDataProtector _dataProtector;
@@ -298,6 +293,12 @@ public class AuthController : ControllerBase
             return NotFound();
         }
 
+        // Nothing to update — return current state without a DB write
+        if (request.Locale == null && request.Currency == null && request.TimeZone == null)
+        {
+            return Ok(await BuildUserDtoAsync(user));
+        }
+
         // Validate and update locale (only if provided)
         if (!string.IsNullOrWhiteSpace(request.Locale))
         {
@@ -313,9 +314,9 @@ public class AuthController : ControllerBase
         if (!string.IsNullOrWhiteSpace(request.Currency))
         {
             var normalizedCurrency = request.Currency.Trim().ToUpperInvariant();
-            if (!SupportedCurrencies.Contains(normalizedCurrency))
+            if (!CurrencyConstants.Supported.Contains(normalizedCurrency))
             {
-                return BadRequest(new { Error = $"Unsupported currency. Supported: {string.Join(", ", SupportedCurrencies.Order())}" });
+                return BadRequest(new { Error = $"Unsupported currency. Supported: {string.Join(", ", CurrencyConstants.Supported.Order())}" });
             }
             user.Currency = normalizedCurrency;
         }
@@ -391,7 +392,7 @@ public class AuthController : ControllerBase
             // Enrich User with fields the TokenService doesn't populate
             if (result.User != null)
             {
-                var (isOnboardingComplete, hasAiConfigured) = await _userStatusService.GetStatusAsync(result.User.Id);
+                var (isOnboardingComplete, hasAiConfigured) = await _userStatusService.GetStatusAsync(result.User.Id, HttpContext.RequestAborted);
                 result.User.IsOnboardingComplete = isOnboardingComplete;
                 result.User.HasAiConfigured = hasAiConfigured;
 
@@ -854,7 +855,7 @@ public class AuthController : ControllerBase
 
     private async Task<UserDto> BuildUserDtoAsync(Domain.Entities.User user)
     {
-        var (isOnboardingComplete, hasAiConfigured) = await _userStatusService.GetStatusAsync(user.Id);
+        var (isOnboardingComplete, hasAiConfigured) = await _userStatusService.GetStatusAsync(user.Id, HttpContext.RequestAborted);
 
         var userDto = new UserDto
         {

--- a/src/WebAPI/MyMascada.WebAPI/Extensions/ApplicationServiceExtensions.cs
+++ b/src/WebAPI/MyMascada.WebAPI/Extensions/ApplicationServiceExtensions.cs
@@ -39,6 +39,7 @@ public static class ApplicationServiceExtensions
         // Authentication services
         services.AddScoped<IAuthenticationService, AuthenticationService>();
         services.AddScoped<ITokenService, TokenService>();
+        services.AddScoped<IUserStatusService, UserStatusService>();
 
         // Invite code validation service
         services.AddScoped<IInviteCodeValidationService, InviteCodeValidationService>();

--- a/tests/MyMascada.Tests.Unit/Controllers/AuthControllerTests.cs
+++ b/tests/MyMascada.Tests.Unit/Controllers/AuthControllerTests.cs
@@ -40,7 +40,7 @@ public class AuthControllerTests
         _environment = Substitute.For<IWebHostEnvironment>();
         _environment.EnvironmentName.Returns("Development");
         _userStatusService = Substitute.For<IUserStatusService>();
-        _userStatusService.GetStatusAsync(Arg.Any<Guid>()).Returns((false, false));
+        _userStatusService.GetStatusAsync(Arg.Any<Guid>(), Arg.Any<CancellationToken>()).Returns((false, false));
         _subscriptionService = Substitute.For<ISubscriptionService>();
         var logger = Substitute.For<ILogger<AuthController>>();
         _controller = new AuthController(_mediator, _authService, _dataProtectionProvider, _userRepository, _appOptions, _environment, _userStatusService, _subscriptionService, logger);

--- a/tests/MyMascada.Tests.Unit/Controllers/AuthControllerTests.cs
+++ b/tests/MyMascada.Tests.Unit/Controllers/AuthControllerTests.cs
@@ -3,7 +3,6 @@ using Microsoft.AspNetCore.DataProtection;
 using Microsoft.AspNetCore.Hosting;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
-using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
 using MyMascada.Application.Common.Configuration;
@@ -27,10 +26,7 @@ public class AuthControllerTests
     private readonly IUserRepository _userRepository;
     private readonly IOptions<AppOptions> _appOptions;
     private readonly IWebHostEnvironment _environment;
-    private readonly IUserAiSettingsRepository _aiSettingsRepository;
-    private readonly IConfiguration _configuration;
-    private readonly IUserFinancialProfileRepository _financialProfileRepository;
-    private readonly IAccountRepository _accountRepository;
+    private readonly IUserStatusService _userStatusService;
     private readonly ISubscriptionService _subscriptionService;
     private readonly AuthController _controller;
 
@@ -43,13 +39,11 @@ public class AuthControllerTests
         _appOptions = Options.Create(new AppOptions { FrontendUrl = "http://localhost:3000" });
         _environment = Substitute.For<IWebHostEnvironment>();
         _environment.EnvironmentName.Returns("Development");
-        _aiSettingsRepository = Substitute.For<IUserAiSettingsRepository>();
-        _configuration = Substitute.For<IConfiguration>();
-        _financialProfileRepository = Substitute.For<IUserFinancialProfileRepository>();
-        _accountRepository = Substitute.For<IAccountRepository>();
+        _userStatusService = Substitute.For<IUserStatusService>();
+        _userStatusService.GetStatusAsync(Arg.Any<Guid>()).Returns((false, false));
         _subscriptionService = Substitute.For<ISubscriptionService>();
         var logger = Substitute.For<ILogger<AuthController>>();
-        _controller = new AuthController(_mediator, _authService, _dataProtectionProvider, _userRepository, _appOptions, _environment, _aiSettingsRepository, _configuration, _financialProfileRepository, _accountRepository, _subscriptionService, logger);
+        _controller = new AuthController(_mediator, _authService, _dataProtectionProvider, _userRepository, _appOptions, _environment, _userStatusService, _subscriptionService, logger);
 
         // Provide a default HttpContext so methods that access Request.Headers don't throw
         _controller.ControllerContext = new ControllerContext


### PR DESCRIPTION
## Summary
- Backend companion fix for mobile PR #100 (Edit Profile bugs)
- `PATCH /auth/locale` now reads and persists `Currency` and `TimeZone` from the request body (previously silently ignored)
- Response DTO now includes `IsOnboardingComplete` and `HasAiConfigured` to match `/auth/me` response shape, preventing the mobile app's GoRouter from redirecting to onboarding after save

## Test plan
- [ ] Save currency change on mobile Edit Profile → verify it persists after reload
- [ ] Save timezone change → verify it persists
- [ ] Save profile → verify no redirect to onboarding, no error toast

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Responses (login, profile, locale/AI-description updates) now include up-to-date onboarding and AI-configuration status.
* **Bug Fixes / Validation**
  * Currency validated against a central supported list; invalid time zone IDs return Bad Request.
* **Chore**
  * Locale updates accept optional Currency and Time Zone and preserve locale when none provided; request model fields made nullable.
* **Tests**
  * Controller tests updated to use the consolidated status check.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->