### PR TITLE
fix: notification bell localization — resolve raw keys (#291)

### DIFF
--- a/frontend/messages/en.json
+++ b/frontend/messages/en.json
@@ -3642,12 +3642,18 @@
     "hoursAgo": "{count, plural, one {1 hour ago} other {# hours ago}}",
     "daysAgo": "{count, plural, one {1 day ago} other {# days ago}}",
     "templates": {
-      "CategorizationReminder": "Transactions to categorize",
-      "CategorizationReminder.body": "{count, plural, one {You have 1 uncategorized transaction} other {You have # uncategorized transactions}}",
-      "TransactionReminder": "Upcoming transaction",
-      "TransactionReminder.body": "{merchantName} — {amount} due on {date}",
-      "RuleSuggestionsAvailable": "New rule suggestions",
-      "RuleSuggestionsAvailable.body": "{count, plural, one {1 new categorization rule suggestion is available} other {# new categorization rule suggestions are available}}"
+      "CategorizationReminder": {
+        "title": "Transactions to categorize",
+        "body": "{count, plural, one {You have 1 uncategorized transaction} other {You have # uncategorized transactions}}"
+      },
+      "TransactionReminder": {
+        "title": "Upcoming transaction",
+        "body": "{merchantName} — {amount} due on {date}"
+      },
+      "RuleSuggestionsAvailable": {
+        "title": "New rule suggestions",
+        "body": "{count, plural, one {1 new categorization rule suggestion is available} other {# new categorization rule suggestions are available}}"
+      }
     }
   },
   "upsell": {

--- a/frontend/messages/pt-BR.json
+++ b/frontend/messages/pt-BR.json
@@ -3642,12 +3642,18 @@
     "hoursAgo": "{count, plural, one {1 hora atrás} other {# horas atrás}}",
     "daysAgo": "{count, plural, one {1 dia atrás} other {# dias atrás}}",
     "templates": {
-      "CategorizationReminder": "Transações para categorizar",
-      "CategorizationReminder.body": "{count, plural, one {Você tem 1 transação sem categoria} other {Você tem # transações sem categoria}}",
-      "TransactionReminder": "Transação próxima",
-      "TransactionReminder.body": "{merchantName} — {amount} vence em {date}",
-      "RuleSuggestionsAvailable": "Novas sugestões de regras",
-      "RuleSuggestionsAvailable.body": "{count, plural, one {1 nova sugestão de regra de categorização disponível} other {# novas sugestões de regras de categorização disponíveis}}"
+      "CategorizationReminder": {
+        "title": "Transações para categorizar",
+        "body": "{count, plural, one {Você tem 1 transação sem categoria} other {Você tem # transações sem categoria}}"
+      },
+      "TransactionReminder": {
+        "title": "Transação próxima",
+        "body": "{merchantName} — {amount} vence em {date}"
+      },
+      "RuleSuggestionsAvailable": {
+        "title": "Novas sugestões de regras",
+        "body": "{count, plural, one {1 nova sugestão de regra de categorização disponível} other {# novas sugestões de regras de categorização disponíveis}}"
+      }
     }
   },
   "upsell": {

--- a/frontend/src/components/notifications/notification-bell.tsx
+++ b/frontend/src/components/notifications/notification-bell.tsx
@@ -358,70 +358,70 @@ export function NotificationBell() {
                 {notifications.map((notification) => {
                   const dataArgs = parseDataArgs(notification.data);
                   return (
-                  <div
-                    key={notification.id}
-                    className={cn(
-                      'flex items-start border-b border-ink-50 transition-colors hover:bg-ink-50',
-                      !notification.isRead && 'bg-primary-50/50'
-                    )}
-                  >
-                    {/* Row button — keyboard-accessible, covers dot + content */}
-                    <button
-                      type="button"
-                      onClick={() => handleNotificationClick(notification)}
-                      className="flex items-start gap-3 px-4 py-3 flex-1 min-w-0 text-left cursor-pointer"
-                      aria-label={resolveText(notification.title, dataArgs)}
-                    >
-                      {/* Unread dot */}
-                      <div className="pt-1.5 shrink-0">
-                        <div
-                          className={cn(
-                            'w-2 h-2 rounded-full',
-                            notification.isRead
-                              ? 'bg-transparent'
-                              : 'bg-primary-500'
-                          )}
-                        />
-                      </div>
-
-                      {/* Content */}
-                      <div className="flex-1 min-w-0">
-                        <p className="text-sm font-medium text-ink-900 truncate">
-                          {resolveText(notification.title, dataArgs)}
-                        </p>
-                        <p className="text-xs text-ink-500 mt-0.5 line-clamp-2">
-                          {resolveText(notification.body, dataArgs)}
-                        </p>
-                        <p className="text-[11px] text-ink-400 mt-1">
-                          {formatTime(notification.createdAt)}
-                        </p>
-                      </div>
-                    </button>
-
-                    {/* Actions — sibling of row button to avoid nested interactive elements */}
-                    <div className="flex items-center gap-1 shrink-0 pt-4 pr-4">
-                      {!notification.isRead && (
-                        <button
-                          type="button"
-                          onClick={(e) => handleMarkAsRead(notification.id, e)}
-                          className="p-1 rounded-md hover:bg-ink-100 text-ink-400 hover:text-primary-600 cursor-pointer"
-                          aria-label={t('markRead')}
-                          title={t('markRead')}
-                        >
-                          <CheckIcon className="w-3.5 h-3.5" />
-                        </button>
+                    <div
+                      key={notification.id}
+                      className={cn(
+                        'flex items-start border-b border-ink-50 transition-colors hover:bg-ink-50',
+                        !notification.isRead && 'bg-primary-50/50'
                       )}
+                    >
+                      {/* Row button — keyboard-accessible, covers dot + content */}
                       <button
                         type="button"
-                        onClick={(e) => handleDelete(notification.id, e)}
-                        className="p-1 rounded-md hover:bg-ink-100 text-ink-400 hover:text-danger cursor-pointer"
-                        aria-label={t('dismiss')}
-                        title={t('dismiss')}
+                        onClick={() => handleNotificationClick(notification)}
+                        className="flex items-start gap-3 px-4 py-3 flex-1 min-w-0 text-left cursor-pointer"
+                        aria-label={resolveText(notification.title, dataArgs)}
                       >
-                        <TrashIcon className="w-3.5 h-3.5" />
+                        {/* Unread dot */}
+                        <div className="pt-1.5 shrink-0">
+                          <div
+                            className={cn(
+                              'w-2 h-2 rounded-full',
+                              notification.isRead
+                                ? 'bg-transparent'
+                                : 'bg-primary-500'
+                            )}
+                          />
+                        </div>
+
+                        {/* Content */}
+                        <div className="flex-1 min-w-0">
+                          <p className="text-sm font-medium text-ink-900 truncate">
+                            {resolveText(notification.title, dataArgs)}
+                          </p>
+                          <p className="text-xs text-ink-500 mt-0.5 line-clamp-2">
+                            {resolveText(notification.body, dataArgs)}
+                          </p>
+                          <p className="text-[11px] text-ink-400 mt-1">
+                            {formatTime(notification.createdAt)}
+                          </p>
+                        </div>
                       </button>
+
+                      {/* Actions — sibling of row button to avoid nested interactive elements */}
+                      <div className="flex items-center gap-1 shrink-0 pt-4 pr-4">
+                        {!notification.isRead && (
+                          <button
+                            type="button"
+                            onClick={(e) => handleMarkAsRead(notification.id, e)}
+                            className="p-1 rounded-md hover:bg-ink-100 text-ink-400 hover:text-primary-600 cursor-pointer"
+                            aria-label={t('markRead')}
+                            title={t('markRead')}
+                          >
+                            <CheckIcon className="w-3.5 h-3.5" />
+                          </button>
+                        )}
+                        <button
+                          type="button"
+                          onClick={(e) => handleDelete(notification.id, e)}
+                          className="p-1 rounded-md hover:bg-ink-100 text-ink-400 hover:text-danger cursor-pointer"
+                          aria-label={t('dismiss')}
+                          title={t('dismiss')}
+                        >
+                          <TrashIcon className="w-3.5 h-3.5" />
+                        </button>
+                      </div>
                     </div>
-                  </div>
                   );
                 })}
               </div>

--- a/frontend/src/components/notifications/notification-bell.tsx
+++ b/frontend/src/components/notifications/notification-bell.tsx
@@ -222,7 +222,7 @@ export function NotificationBell() {
   // (e.g. title="CategorizationReminder", body="CategorizationReminder.body").
   // Templates are nested objects: templates.CategorizationReminder.title / .body
   // so we map the backend key to the correct nested path.
-  const resolveText = (key: string, dataJson: string | null): string => {
+  const resolveText = (key: string, args: Record<string, string | number>): string => {
     try {
       let templateKey: string;
       if (key.endsWith('.body')) {
@@ -232,7 +232,7 @@ export function NotificationBell() {
       }
       const typedKey = templateKey as Parameters<typeof t>[0];
       if (t.has(typedKey)) {
-        return t(typedKey, parseDataArgs(dataJson));
+        return t(typedKey, args);
       }
       return key;
     } catch {
@@ -355,7 +355,9 @@ export function NotificationBell() {
               </div>
             ) : (
               <div>
-                {notifications.map((notification) => (
+                {notifications.map((notification) => {
+                  const dataArgs = parseDataArgs(notification.data);
+                  return (
                   <div
                     key={notification.id}
                     className={cn(
@@ -368,7 +370,7 @@ export function NotificationBell() {
                       type="button"
                       onClick={() => handleNotificationClick(notification)}
                       className="flex items-start gap-3 px-4 py-3 flex-1 min-w-0 text-left cursor-pointer"
-                      aria-label={resolveText(notification.title, notification.data)}
+                      aria-label={resolveText(notification.title, dataArgs)}
                     >
                       {/* Unread dot */}
                       <div className="pt-1.5 shrink-0">
@@ -385,10 +387,10 @@ export function NotificationBell() {
                       {/* Content */}
                       <div className="flex-1 min-w-0">
                         <p className="text-sm font-medium text-ink-900 truncate">
-                          {resolveText(notification.title, notification.data)}
+                          {resolveText(notification.title, dataArgs)}
                         </p>
                         <p className="text-xs text-ink-500 mt-0.5 line-clamp-2">
-                          {resolveText(notification.body, notification.data)}
+                          {resolveText(notification.body, dataArgs)}
                         </p>
                         <p className="text-[11px] text-ink-400 mt-1">
                           {formatTime(notification.createdAt)}
@@ -420,7 +422,8 @@ export function NotificationBell() {
                       </button>
                     </div>
                   </div>
-                ))}
+                  );
+                })}
               </div>
             )}
           </div>

--- a/frontend/src/components/notifications/notification-bell.tsx
+++ b/frontend/src/components/notifications/notification-bell.tsx
@@ -218,14 +218,21 @@ export function NotificationBell() {
     setIsOpen(false);
   };
 
-  // Resolve notification title/body: the backend stores template keys (e.g. "CategorizationReminder").
-  // Try to look up a translation under notifications.templates.<key>; fall back to the raw string.
+  // Resolve notification title/body: the backend stores template keys
+  // (e.g. title="CategorizationReminder", body="CategorizationReminder.body").
+  // Templates are nested objects: templates.CategorizationReminder.title / .body
+  // so we map the backend key to the correct nested path.
   const resolveText = (key: string, dataJson: string | null): string => {
     try {
-      // next-intl returns the key itself when the message is missing; use t.has() to avoid that.
-      const templateKey = `templates.${key}` as Parameters<typeof t>[0];
-      if (t.has(templateKey)) {
-        return t(templateKey, parseDataArgs(dataJson));
+      let templateKey: string;
+      if (key.endsWith('.body')) {
+        templateKey = `templates.${key.slice(0, -5)}.body`;
+      } else {
+        templateKey = `templates.${key}.title`;
+      }
+      const typedKey = templateKey as Parameters<typeof t>[0];
+      if (t.has(typedKey)) {
+        return t(typedKey, parseDataArgs(dataJson));
       }
       return key;
     } catch {


### PR DESCRIPTION
## Summary

- **Root cause**: next-intl v4 uses dots as path separators. Template keys like `"CategorizationReminder.body"` were stored as flat sibling keys in the JSON, but `t.has('templates.CategorizationReminder.body')` tried to traverse into the string value of `CategorizationReminder` rather than finding the flat key — so `t.has()` returned `false` and the raw key was displayed.
- **Fix**: Restructured notification templates from flat dotted keys to proper nested objects (`title`/`body`) in both `en.json` and `pt-BR.json`, and updated `resolveText()` in `notification-bell.tsx` to map backend keys (`"Foo"` → `templates.Foo.title`, `"Foo.body"` → `templates.Foo.body`) to the nested paths.
- All three notification types fixed: `CategorizationReminder`, `TransactionReminder`, `RuleSuggestionsAvailable`

## Test plan

- [ ] Trigger a `CategorizationReminder` notification (have uncategorized transactions) — verify title and body render in English
- [ ] Switch locale to pt-BR — verify Portuguese translations render
- [ ] Trigger a `RuleSuggestionsAvailable` notification — verify translated text with correct count interpolation
- [ ] Verify `TransactionReminder` notification shows merchant name, formatted amount, and date
- [ ] Confirm no raw keys like `"CategorizationReminder.body"` appear in the bell dropdown

Closes #291

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Reorganized notification template structure for improved maintainability. Notification content and functionality remain unchanged for users.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->