### PR TITLE
feat: account-filtered query functions for Alce AI

### DIFF
--- a/src/Infrastructure/MyMascada.Infrastructure/Services/AI/AiChatService.cs
+++ b/src/Infrastructure/MyMascada.Infrastructure/Services/AI/AiChatService.cs
@@ -185,6 +185,14 @@ public class AiChatService : IAiChatService
             - If a user asks about topics outside personal finance, politely decline and offer to help with their finances instead.
             - Never discuss other users' data. You can only see and analyze the current user's financial information.
 
+            ACCOUNT-SPECIFIC QUERIES:
+            - When a user mentions a specific account or card (e.g. 'my Amex', 'checking account', 'savings'), use account-specific tools.
+            - For 'show me my Amex transactions' or 'what did I spend on my checking account', use GetTransactionsByAccount.
+            - For 'what am I spending on with my Amex?' or 'category breakdown for my credit card', use GetAccountSpendingByCategory.
+            - For 'show my Amex transactions from January' or account + date range queries, use GetTransactionsForAccountByDateRange.
+            - For 'what subscriptions are on my Amex?' or 'recurring charges on my checking', use GetRecurringExpensesByAccount.
+            - Account names support partial matching — users can say 'Amex' instead of 'American Express Gold Card'.
+
             TRANSFER RULES:
             - Inter-account transfers (e.g. credit card payments, savings top-ups) are intentionally excluded from the default financial context to keep spending analysis accurate.
             - When the user asks about transfers, money moved between accounts, credit card payments, or transfer history, call GetTransfers to retrieve them on demand.

--- a/src/Infrastructure/MyMascada.Infrastructure/Services/AI/FinancialContextBuilder.cs
+++ b/src/Infrastructure/MyMascada.Infrastructure/Services/AI/FinancialContextBuilder.cs
@@ -52,10 +52,10 @@ public class FinancialContextBuilder : IFinancialContextBuilder
             _transactionRepository.GetByDateRangeAsync(userId, twelveMonthsAgo, now));
         var goals = await SafeExecuteAsync(() => _goalRepository.GetActiveGoalsForUserAsync(userId));
 
-        // Last month transactions for per-account summaries
+        // Filter last-month transactions from the 12-month data (no extra DB query needed)
         var oneMonthAgo = now.AddMonths(-1);
-        var lastMonthTransactions = await SafeExecuteAsync(() =>
-            _transactionRepository.GetByDateRangeAsync(userId, oneMonthAgo, now));
+        var lastMonthTransactions = monthlyTransactions?
+            .Where(t => t.TransactionDate >= oneMonthAgo);
 
         var sb = new StringBuilder();
 

--- a/src/Infrastructure/MyMascada.Infrastructure/Services/AI/FinancialContextBuilder.cs
+++ b/src/Infrastructure/MyMascada.Infrastructure/Services/AI/FinancialContextBuilder.cs
@@ -122,7 +122,7 @@ public class FinancialContextBuilder : IFinancialContextBuilder
                     });
 
                 var topStr = topCategories.Any() ? string.Join(", ", topCategories) : "none";
-                sb.AppendLine($"    Last month: {txnCount} transactions | Top spending: {topStr}");
+                sb.AppendLine($"    Last 30 days: {txnCount} transactions | Top spending: {topStr}");
             }
         }
 

--- a/src/Infrastructure/MyMascada.Infrastructure/Services/AI/FinancialContextBuilder.cs
+++ b/src/Infrastructure/MyMascada.Infrastructure/Services/AI/FinancialContextBuilder.cs
@@ -119,9 +119,10 @@ public class FinancialContextBuilder : IFinancialContextBuilder
                     {
                         var name = categoryLookup?.GetValueOrDefault(x.CategoryId, "Other") ?? "Other";
                         return $"{name} ({x.Total:N0})";
-                    });
+                    })
+                    .ToList();
 
-                var topStr = topCategories.Any() ? string.Join(", ", topCategories) : "none";
+                var topStr = topCategories.Count > 0 ? string.Join(", ", topCategories) : "none";
                 sb.AppendLine($"    Last 30 days: {txnCount} transactions | Top spending: {topStr}");
             }
         }

--- a/src/Infrastructure/MyMascada.Infrastructure/Services/AI/FinancialContextBuilder.cs
+++ b/src/Infrastructure/MyMascada.Infrastructure/Services/AI/FinancialContextBuilder.cs
@@ -52,9 +52,14 @@ public class FinancialContextBuilder : IFinancialContextBuilder
             _transactionRepository.GetByDateRangeAsync(userId, twelveMonthsAgo, now));
         var goals = await SafeExecuteAsync(() => _goalRepository.GetActiveGoalsForUserAsync(userId));
 
+        // Last month transactions for per-account summaries
+        var oneMonthAgo = now.AddMonths(-1);
+        var lastMonthTransactions = await SafeExecuteAsync(() =>
+            _transactionRepository.GetByDateRangeAsync(userId, oneMonthAgo, now));
+
         var sb = new StringBuilder();
 
-        BuildAccountsSection(sb, accounts, balances);
+        BuildAccountsSection(sb, accounts, balances, lastMonthTransactions, categories);
         BuildMonthlySummarySection(sb, monthlyTransactions);
         BuildTopSpendingCategoriesSection(sb, monthlyTransactions, categories);
         BuildBudgetSection(sb, budget);
@@ -68,7 +73,9 @@ public class FinancialContextBuilder : IFinancialContextBuilder
     private static void BuildAccountsSection(
         StringBuilder sb,
         IEnumerable<Domain.Entities.Account>? accounts,
-        Dictionary<int, decimal>? balances)
+        Dictionary<int, decimal>? balances,
+        IEnumerable<Domain.Entities.Transaction>? recentMonthTransactions,
+        IEnumerable<Domain.Entities.Category>? categories)
     {
         sb.AppendLine("=== ACCOUNTS ===");
 
@@ -82,6 +89,14 @@ public class FinancialContextBuilder : IFinancialContextBuilder
         decimal total = 0;
         string? currency = null;
 
+        // Build per-account transaction lookup for last month summary
+        var accountTransactions = recentMonthTransactions?
+            .Where(t => !t.IsExcluded && !t.IsTransfer())
+            .GroupBy(t => t.AccountId)
+            .ToDictionary(g => g.Key, g => g.ToList());
+
+        var categoryLookup = categories?.ToDictionary(c => c.Id, c => c.Name);
+
         foreach (var account in accounts.Where(a => a.IsActive))
         {
             // Use calculated balance (initial + transactions) if available, otherwise fall back to CurrentBalance
@@ -89,6 +104,25 @@ public class FinancialContextBuilder : IFinancialContextBuilder
             sb.AppendLine($"  - {account.Name} ({account.Type}): {balance:N2} {account.Currency}");
             total += balance;
             currency ??= account.Currency;
+
+            // Per-account summary: recent transaction count and top spending categories
+            if (accountTransactions != null && accountTransactions.TryGetValue(account.Id, out var txns))
+            {
+                var txnCount = txns.Count;
+                var topCategories = txns
+                    .Where(t => t.Amount < 0 && t.CategoryId.HasValue)
+                    .GroupBy(t => t.CategoryId!.Value)
+                    .OrderByDescending(g => g.Sum(t => Math.Abs(t.Amount)))
+                    .Take(3)
+                    .Select(g =>
+                    {
+                        var name = categoryLookup?.GetValueOrDefault(g.Key, "Other") ?? "Other";
+                        return $"{name} ({g.Sum(t => Math.Abs(t.Amount)):N0})";
+                    });
+
+                var topStr = topCategories.Any() ? string.Join(", ", topCategories) : "none";
+                sb.AppendLine($"    Last month: {txnCount} transactions | Top spending: {topStr}");
+            }
         }
 
         sb.AppendLine($"  Total: {total:N2} {currency ?? "USD"}");

--- a/src/Infrastructure/MyMascada.Infrastructure/Services/AI/FinancialContextBuilder.cs
+++ b/src/Infrastructure/MyMascada.Infrastructure/Services/AI/FinancialContextBuilder.cs
@@ -112,12 +112,13 @@ public class FinancialContextBuilder : IFinancialContextBuilder
                 var topCategories = txns
                     .Where(t => t.Amount < 0 && t.CategoryId.HasValue)
                     .GroupBy(t => t.CategoryId!.Value)
-                    .OrderByDescending(g => g.Sum(t => Math.Abs(t.Amount)))
+                    .Select(g => new { CategoryId = g.Key, Total = g.Sum(t => Math.Abs(t.Amount)) })
+                    .OrderByDescending(x => x.Total)
                     .Take(3)
-                    .Select(g =>
+                    .Select(x =>
                     {
-                        var name = categoryLookup?.GetValueOrDefault(g.Key, "Other") ?? "Other";
-                        return $"{name} ({g.Sum(t => Math.Abs(t.Amount)):N0})";
+                        var name = categoryLookup?.GetValueOrDefault(x.CategoryId, "Other") ?? "Other";
+                        return $"{name} ({x.Total:N0})";
                     });
 
                 var topStr = topCategories.Any() ? string.Join(", ", topCategories) : "none";

--- a/src/Infrastructure/MyMascada.Infrastructure/Services/AI/FinancialDataPlugin.cs
+++ b/src/Infrastructure/MyMascada.Infrastructure/Services/AI/FinancialDataPlugin.cs
@@ -1,4 +1,5 @@
 using System.ComponentModel;
+using System.Globalization;
 using System.Text;
 using System.Text.Json;
 using Microsoft.SemanticKernel;
@@ -119,12 +120,12 @@ public class FinancialDataPlugin
     {
         try
         {
-            if (!DateTime.TryParse(startDate, out var start))
+            if (!DateTime.TryParseExact(startDate, "yyyy-MM-dd", CultureInfo.InvariantCulture, DateTimeStyles.None, out var start))
             {
                 return $"Invalid start date format: '{startDate}'. Please use YYYY-MM-DD format.";
             }
 
-            if (!DateTime.TryParse(endDate, out var end))
+            if (!DateTime.TryParseExact(endDate, "yyyy-MM-dd", CultureInfo.InvariantCulture, DateTimeStyles.None, out var end))
             {
                 return $"Invalid end date format: '{endDate}'. Please use YYYY-MM-DD format.";
             }
@@ -535,12 +536,12 @@ public class FinancialDataPlugin
             if (matchedAccount == null)
                 return error!;
 
-            if (!DateTime.TryParse(startDate, out var start))
+            if (!DateTime.TryParseExact(startDate, "yyyy-MM-dd", CultureInfo.InvariantCulture, DateTimeStyles.None, out var start))
             {
                 return $"Invalid start date format: '{startDate}'. Please use YYYY-MM-DD format.";
             }
 
-            if (!DateTime.TryParse(endDate, out var end))
+            if (!DateTime.TryParseExact(endDate, "yyyy-MM-dd", CultureInfo.InvariantCulture, DateTimeStyles.None, out var end))
             {
                 return $"Invalid end date format: '{endDate}'. Please use YYYY-MM-DD format.";
             }
@@ -945,13 +946,13 @@ public class FinancialDataPlugin
             DateTime? start = null, end = null;
             if (!string.IsNullOrWhiteSpace(startDate))
             {
-                if (!DateTime.TryParse(startDate, out var s))
+                if (!DateTime.TryParseExact(startDate, "yyyy-MM-dd", CultureInfo.InvariantCulture, DateTimeStyles.None, out var s))
                     return $"Invalid start date format: '{startDate}'. Please use YYYY-MM-DD.";
                 start = DateTimeProvider.ToUtc(s);
             }
             if (!string.IsNullOrWhiteSpace(endDate))
             {
-                if (!DateTime.TryParse(endDate, out var e))
+                if (!DateTime.TryParseExact(endDate, "yyyy-MM-dd", CultureInfo.InvariantCulture, DateTimeStyles.None, out var e))
                     return $"Invalid end date format: '{endDate}'. Please use YYYY-MM-DD.";
                 end = DateTimeProvider.ToUtc(e);
             }

--- a/src/Infrastructure/MyMascada.Infrastructure/Services/AI/FinancialDataPlugin.cs
+++ b/src/Infrastructure/MyMascada.Infrastructure/Services/AI/FinancialDataPlugin.cs
@@ -402,10 +402,12 @@ public class FinancialDataPlugin
     [Description("Get transactions for a specific account. Use when user asks about transactions on a specific card or account like 'show me my Amex transactions' or 'what did I spend on my checking account'.")]
     public async Task<string> GetTransactionsByAccount(
         [Description("Account name to search for (partial match, e.g. 'Amex' for 'American Express Gold Card')")] string accountName,
-        [Description("Number of months to look back (default 3)")] int months = 3)
+        [Description("Number of months to look back (default 3, max 24)")] int months = 3)
     {
         try
         {
+            months = Math.Clamp(months, 1, 24);
+
             var accounts = await _accountRepository.GetByUserIdAsync(_userId);
             var matchedAccount = accounts.FirstOrDefault(a =>
                 a.Name.Contains(accountName, StringComparison.OrdinalIgnoreCase));
@@ -438,8 +440,7 @@ public class FinancialDataPlugin
                 return $"No transactions found for '{matchedAccount.Name}' in the last {months} months.";
             }
 
-            var balances = await _transactionRepository.GetAccountBalancesAsync(_userId);
-            var actualBalance = balances.GetValueOrDefault(matchedAccount.Id, matchedAccount.CurrentBalance);
+            var actualBalance = await _transactionRepository.GetAccountBalanceAsync(matchedAccount.Id, _userId);
 
             var sb = new StringBuilder();
             sb.AppendLine($"Account: {matchedAccount.Name} ({matchedAccount.Type}) | Balance: {actualBalance:N2} {matchedAccount.Currency}");
@@ -480,10 +481,12 @@ public class FinancialDataPlugin
     [Description("Get spending breakdown by category for a specific account. Use when user asks 'what am I spending on with my Amex?' or 'category breakdown for my checking account'.")]
     public async Task<string> GetAccountSpendingByCategory(
         [Description("Account name to search for (partial match)")] string accountName,
-        [Description("Number of months to look back (default 3)")] int months = 3)
+        [Description("Number of months to look back (default 3, max 24)")] int months = 3)
     {
         try
         {
+            months = Math.Clamp(months, 1, 24);
+
             var accounts = await _accountRepository.GetByUserIdAsync(_userId);
             var matchedAccount = accounts.FirstOrDefault(a =>
                 a.Name.Contains(accountName, StringComparison.OrdinalIgnoreCase));
@@ -667,12 +670,17 @@ public class FinancialDataPlugin
             var startDate = endDate.AddMonths(-6);
             var accountTransactions = await _transactionRepository.GetByDateRangeAsync(_userId, matchedAccount.Id, startDate, endDate);
             var accountDescriptions = accountTransactions
-                .Select(t => t.Description.ToLowerInvariant())
+                .Select(t => (t.Description ?? string.Empty).ToLowerInvariant())
                 .Distinct()
                 .ToHashSet();
 
             var matchedPatterns = patternList
-                .Where(p => accountDescriptions.Any(d => d.Contains(p.MerchantName.ToLowerInvariant())))
+                .Where(p =>
+                {
+                    var lowerMerchant = p.MerchantName?.ToLowerInvariant();
+                    return !string.IsNullOrEmpty(lowerMerchant) &&
+                           accountDescriptions.Any(d => d.Contains(lowerMerchant));
+                })
                 .ToList();
 
             if (!matchedPatterns.Any())

--- a/src/Infrastructure/MyMascada.Infrastructure/Services/AI/FinancialDataPlugin.cs
+++ b/src/Infrastructure/MyMascada.Infrastructure/Services/AI/FinancialDataPlugin.cs
@@ -398,6 +398,322 @@ public class FinancialDataPlugin
         }
     }
 
+    [KernelFunction("GetTransactionsByAccount")]
+    [Description("Get transactions for a specific account. Use when user asks about transactions on a specific card or account like 'show me my Amex transactions' or 'what did I spend on my checking account'.")]
+    public async Task<string> GetTransactionsByAccount(
+        [Description("Account name to search for (partial match, e.g. 'Amex' for 'American Express Gold Card')")] string accountName,
+        [Description("Number of months to look back (default 3)")] int months = 3)
+    {
+        try
+        {
+            var accounts = await _accountRepository.GetByUserIdAsync(_userId);
+            var matchedAccount = accounts.FirstOrDefault(a =>
+                a.Name.Contains(accountName, StringComparison.OrdinalIgnoreCase));
+
+            if (matchedAccount == null)
+            {
+                return $"No account found matching '{accountName}'. Available accounts: {string.Join(", ", accounts.Select(a => a.Name))}";
+            }
+
+            var endDate = DateTimeProvider.UtcNow;
+            var startDate = endDate.AddMonths(-months);
+
+            var query = new GetTransactionsQuery
+            {
+                UserId = _userId,
+                AccountId = matchedAccount.Id,
+                StartDate = startDate,
+                EndDate = endDate,
+                PageSize = 50,
+                Page = 1,
+                SortBy = "TransactionDate",
+                SortDirection = "desc"
+            };
+
+            var (transactions, totalCount) = await _transactionRepository.GetFilteredAsync(query);
+            var transactionList = transactions.ToList();
+
+            if (!transactionList.Any())
+            {
+                return $"No transactions found for '{matchedAccount.Name}' in the last {months} months.";
+            }
+
+            var balances = await _transactionRepository.GetAccountBalancesAsync(_userId);
+            var actualBalance = balances.GetValueOrDefault(matchedAccount.Id, matchedAccount.CurrentBalance);
+
+            var sb = new StringBuilder();
+            sb.AppendLine($"Account: {matchedAccount.Name} ({matchedAccount.Type}) | Balance: {actualBalance:N2} {matchedAccount.Currency}");
+            sb.AppendLine($"Transactions (last {months} months) - {totalCount} total:");
+            sb.AppendLine();
+
+            var income = 0m;
+            var expenses = 0m;
+
+            foreach (var t in transactionList)
+            {
+                var categoryName = t.Category?.Name ?? "Uncategorized";
+                var marker = t.IsTransfer() ? " [Transfer]" : t.IsExcluded ? " [Excluded]" : "";
+                sb.AppendLine($"  {t.TransactionDate:yyyy-MM-dd} | {t.GetDisplayDescription()} | {t.Amount:N2} | {categoryName}{marker}");
+
+                if (!t.IsExcluded && !t.IsTransfer())
+                {
+                    if (t.Amount > 0)
+                        income += t.Amount;
+                    else
+                        expenses += Math.Abs(t.Amount);
+                }
+            }
+
+            sb.AppendLine();
+            sb.AppendLine($"Summary (excluding transfers): Income {income:N2} | Expenses {expenses:N2} | Net {income - expenses:N2}");
+            sb.AppendLine($"Showing {transactionList.Count} of {totalCount} transactions.");
+
+            return sb.ToString();
+        }
+        catch (Exception ex)
+        {
+            return $"Error retrieving transactions by account: {ex.Message}";
+        }
+    }
+
+    [KernelFunction("GetAccountSpendingByCategory")]
+    [Description("Get spending breakdown by category for a specific account. Use when user asks 'what am I spending on with my Amex?' or 'category breakdown for my checking account'.")]
+    public async Task<string> GetAccountSpendingByCategory(
+        [Description("Account name to search for (partial match)")] string accountName,
+        [Description("Number of months to look back (default 3)")] int months = 3)
+    {
+        try
+        {
+            var accounts = await _accountRepository.GetByUserIdAsync(_userId);
+            var matchedAccount = accounts.FirstOrDefault(a =>
+                a.Name.Contains(accountName, StringComparison.OrdinalIgnoreCase));
+
+            if (matchedAccount == null)
+            {
+                return $"No account found matching '{accountName}'. Available accounts: {string.Join(", ", accounts.Select(a => a.Name))}";
+            }
+
+            var endDate = DateTimeProvider.UtcNow;
+            var startDate = endDate.AddMonths(-months);
+
+            var transactions = await _transactionRepository.GetByDateRangeAsync(_userId, matchedAccount.Id, startDate, endDate);
+            var transactionList = transactions.ToList();
+
+            if (!transactionList.Any())
+            {
+                return $"No transactions found for '{matchedAccount.Name}' in the last {months} months.";
+            }
+
+            var categories = await _categoryRepository.GetByUserIdAsync(_userId);
+            var categoryLookup = categories.ToDictionary(c => c.Id, c => c.Name);
+
+            var breakdown = transactionList
+                .Where(t => t.Amount < 0 && !t.IsExcluded && !t.IsTransfer())
+                .GroupBy(t => t.CategoryId ?? 0)
+                .Select(g => new
+                {
+                    CategoryName = g.Key == 0
+                        ? "Uncategorized"
+                        : categoryLookup.GetValueOrDefault(g.Key, $"Category #{g.Key}"),
+                    Total = g.Sum(t => Math.Abs(t.Amount)),
+                    Count = g.Count()
+                })
+                .OrderByDescending(x => x.Total)
+                .ToList();
+
+            var totalSpending = breakdown.Sum(b => b.Total);
+
+            var sb = new StringBuilder();
+            sb.AppendLine($"Spending breakdown for '{matchedAccount.Name}' (last {months} months):");
+            sb.AppendLine();
+
+            foreach (var cat in breakdown)
+            {
+                var percentage = totalSpending > 0 ? (cat.Total / totalSpending * 100) : 0;
+                sb.AppendLine($"  {cat.CategoryName}: {cat.Total:N2} ({percentage:N1}%) - {cat.Count} transactions");
+            }
+
+            sb.AppendLine();
+            sb.AppendLine($"Total spending: {totalSpending:N2}");
+
+            var totalIncome = transactionList
+                .Where(t => t.Amount > 0 && !t.IsExcluded && !t.IsTransfer())
+                .Sum(t => t.Amount);
+
+            sb.AppendLine($"Total income: {totalIncome:N2}");
+            sb.AppendLine($"Net: {totalIncome - totalSpending:N2}");
+
+            return sb.ToString();
+        }
+        catch (Exception ex)
+        {
+            return $"Error retrieving account spending by category: {ex.Message}";
+        }
+    }
+
+    [KernelFunction("GetTransactionsForAccountByDateRange")]
+    [Description("Get transactions for a specific account within a date range. Use when user asks for account transactions in a specific period like 'show my Amex transactions from January'.")]
+    public async Task<string> GetTransactionsForAccountByDateRange(
+        [Description("Account name to search for (partial match)")] string accountName,
+        [Description("Start date (YYYY-MM-DD)")] string startDate,
+        [Description("End date (YYYY-MM-DD)")] string endDate)
+    {
+        try
+        {
+            var accounts = await _accountRepository.GetByUserIdAsync(_userId);
+            var matchedAccount = accounts.FirstOrDefault(a =>
+                a.Name.Contains(accountName, StringComparison.OrdinalIgnoreCase));
+
+            if (matchedAccount == null)
+            {
+                return $"No account found matching '{accountName}'. Available accounts: {string.Join(", ", accounts.Select(a => a.Name))}";
+            }
+
+            if (!DateTime.TryParse(startDate, out var start))
+            {
+                return $"Invalid start date format: '{startDate}'. Please use YYYY-MM-DD format.";
+            }
+
+            if (!DateTime.TryParse(endDate, out var end))
+            {
+                return $"Invalid end date format: '{endDate}'. Please use YYYY-MM-DD format.";
+            }
+
+            start = DateTimeProvider.ToUtc(start);
+            end = DateTimeProvider.ToUtc(end);
+
+            var query = new GetTransactionsQuery
+            {
+                UserId = _userId,
+                AccountId = matchedAccount.Id,
+                StartDate = start,
+                EndDate = end,
+                PageSize = 100,
+                Page = 1,
+                SortBy = "TransactionDate",
+                SortDirection = "desc"
+            };
+
+            var (transactions, totalCount) = await _transactionRepository.GetFilteredAsync(query);
+            var transactionList = transactions.ToList();
+
+            if (!transactionList.Any())
+            {
+                return $"No transactions found for '{matchedAccount.Name}' between {start:yyyy-MM-dd} and {end:yyyy-MM-dd}.";
+            }
+
+            var sb = new StringBuilder();
+            sb.AppendLine($"Account: {matchedAccount.Name} ({matchedAccount.Type})");
+            sb.AppendLine($"Transactions from {start:yyyy-MM-dd} to {end:yyyy-MM-dd} ({totalCount} total):");
+            sb.AppendLine();
+
+            var income = 0m;
+            var expenses = 0m;
+
+            foreach (var t in transactionList)
+            {
+                var categoryName = t.Category?.Name ?? "Uncategorized";
+                var marker = t.IsTransfer() ? " [Transfer]" : t.IsExcluded ? " [Excluded]" : "";
+                sb.AppendLine($"  {t.TransactionDate:yyyy-MM-dd} | {t.GetDisplayDescription()} | {t.Amount:N2} | {categoryName}{marker}");
+
+                if (!t.IsExcluded && !t.IsTransfer())
+                {
+                    if (t.Amount > 0)
+                        income += t.Amount;
+                    else
+                        expenses += Math.Abs(t.Amount);
+                }
+            }
+
+            sb.AppendLine();
+            sb.AppendLine($"Summary (excluding transfers): Income {income:N2} | Expenses {expenses:N2} | Net {income - expenses:N2}");
+            sb.AppendLine($"Showing {transactionList.Count} of {totalCount} transactions.");
+
+            return sb.ToString();
+        }
+        catch (Exception ex)
+        {
+            return $"Error retrieving account transactions by date range: {ex.Message}";
+        }
+    }
+
+    [KernelFunction("GetRecurringExpensesByAccount")]
+    [Description("Get recurring expenses and subscriptions that hit a specific account. Use when user asks 'what subscriptions are on my Amex?' or 'recurring charges on my checking account'.")]
+    public async Task<string> GetRecurringExpensesByAccount(
+        [Description("Account name to search for (partial match)")] string accountName)
+    {
+        try
+        {
+            var accounts = await _accountRepository.GetByUserIdAsync(_userId);
+            var matchedAccount = accounts.FirstOrDefault(a =>
+                a.Name.Contains(accountName, StringComparison.OrdinalIgnoreCase));
+
+            if (matchedAccount == null)
+            {
+                return $"No account found matching '{accountName}'. Available accounts: {string.Join(", ", accounts.Select(a => a.Name))}";
+            }
+
+            var patterns = await _recurringPatternRepository.GetActiveAsync(_userId);
+            var patternList = patterns.ToList();
+
+            if (!patternList.Any())
+            {
+                return $"No active recurring expenses detected for any account.";
+            }
+
+            // Find which recurring patterns have transactions in this account
+            // by checking recent transactions for this account and matching merchant names
+            var endDate = DateTimeProvider.UtcNow;
+            var startDate = endDate.AddMonths(-6);
+            var accountTransactions = await _transactionRepository.GetByDateRangeAsync(_userId, matchedAccount.Id, startDate, endDate);
+            var accountDescriptions = accountTransactions
+                .Select(t => t.Description.ToLowerInvariant())
+                .Distinct()
+                .ToHashSet();
+
+            var matchedPatterns = patternList
+                .Where(p => accountDescriptions.Any(d => d.Contains(p.MerchantName.ToLowerInvariant())))
+                .ToList();
+
+            if (!matchedPatterns.Any())
+            {
+                return $"No recurring expenses detected for '{matchedAccount.Name}'. There are {patternList.Count} recurring patterns on other accounts.";
+            }
+
+            var sb = new StringBuilder();
+            sb.AppendLine($"Recurring expenses for '{matchedAccount.Name}':");
+            sb.AppendLine();
+
+            var totalMonthly = 0m;
+
+            foreach (var pattern in matchedPatterns.OrderByDescending(p => p.GetMonthlyCost()))
+            {
+                var monthlyCost = pattern.GetMonthlyCost();
+                totalMonthly += monthlyCost;
+                var daysUntilDue = pattern.GetDaysUntilDue(DateTimeProvider.UtcNow);
+                var dueInfo = daysUntilDue >= 0
+                    ? $"next due in {daysUntilDue} days"
+                    : $"overdue by {Math.Abs(daysUntilDue)} days";
+
+                sb.AppendLine($"  {pattern.MerchantName}:");
+                sb.AppendLine($"    Amount: ~{pattern.AverageAmount:N2} / {pattern.GetIntervalName()}");
+                sb.AppendLine($"    Monthly cost: ~{monthlyCost:N2}");
+                sb.AppendLine($"    Status: {pattern.Status} | {dueInfo}");
+                sb.AppendLine();
+            }
+
+            sb.AppendLine($"Total estimated monthly recurring on this account: ~{totalMonthly:N2}");
+            sb.AppendLine($"Total estimated annual recurring on this account: ~{totalMonthly * 12:N2}");
+            sb.AppendLine($"({matchedPatterns.Count} of {patternList.Count} total recurring patterns)");
+
+            return sb.ToString();
+        }
+        catch (Exception ex)
+        {
+            return $"Error retrieving recurring expenses by account: {ex.Message}";
+        }
+    }
+
     [KernelFunction("GetBudgetStatus")]
     [Description("Get current budget status with spending vs allocated amounts")]
     public async Task<string> GetBudgetStatus()

--- a/src/Infrastructure/MyMascada.Infrastructure/Services/AI/FinancialDataPlugin.cs
+++ b/src/Infrastructure/MyMascada.Infrastructure/Services/AI/FinancialDataPlugin.cs
@@ -1390,11 +1390,22 @@ public class FinancialDataPlugin
     private async Task<(Domain.Entities.Account? account, string? error)> FindAccountByNameAsync(string accountName)
     {
         var accounts = await _accountRepository.GetByUserIdAsync(_userId);
-        var matches = accounts.Where(a =>
-            a.Name.Contains(accountName, StringComparison.OrdinalIgnoreCase)).ToList();
+        var accountList = accounts.ToList();
+
+        // Prefer active accounts; fall back to inactive only if no active match
+        var matches = accountList
+            .Where(a => a.IsActive && a.Name.Contains(accountName, StringComparison.OrdinalIgnoreCase))
+            .ToList();
 
         if (matches.Count == 0)
-            return (null, $"No account found matching '{accountName}'. Available accounts: {string.Join(", ", accounts.Select(a => a.Name))}");
+        {
+            matches = accountList
+                .Where(a => a.Name.Contains(accountName, StringComparison.OrdinalIgnoreCase))
+                .ToList();
+        }
+
+        if (matches.Count == 0)
+            return (null, $"No account found matching '{accountName}'. Available accounts: {string.Join(", ", accountList.Where(a => a.IsActive).Select(a => a.Name))}");
         if (matches.Count > 1)
             return (null, $"Multiple accounts match '{accountName}': {string.Join(", ", matches.Select(a => a.Name))}. Please be more specific.");
 

--- a/src/Infrastructure/MyMascada.Infrastructure/Services/AI/FinancialDataPlugin.cs
+++ b/src/Infrastructure/MyMascada.Infrastructure/Services/AI/FinancialDataPlugin.cs
@@ -354,18 +354,12 @@ public class FinancialDataPlugin
     {
         try
         {
-            var accounts = await _accountRepository.GetByUserIdAsync(_userId);
-            var matchedAccount = accounts.FirstOrDefault(a =>
-                a.Name.Contains(accountName, StringComparison.OrdinalIgnoreCase));
-
+            var (matchedAccount, error) = await FindAccountByNameAsync(accountName);
             if (matchedAccount == null)
-            {
-                return $"No account found matching '{accountName}'. Available accounts: {string.Join(", ", accounts.Select(a => a.Name))}";
-            }
+                return error!;
 
-            // Calculate actual balance (initial balance + sum of transactions)
-            var balances = await _transactionRepository.GetAccountBalancesAsync(_userId);
-            var actualBalance = balances.GetValueOrDefault(matchedAccount.Id, matchedAccount.CurrentBalance);
+            // Calculate actual balance for this specific account
+            var actualBalance = await _transactionRepository.GetAccountBalanceAsync(matchedAccount.Id, _userId);
 
             var sb = new StringBuilder();
             sb.AppendLine($"Account: {matchedAccount.Name}");
@@ -408,66 +402,45 @@ public class FinancialDataPlugin
         {
             months = Math.Clamp(months, 1, 24);
 
-            var accounts = await _accountRepository.GetByUserIdAsync(_userId);
-            var matchedAccount = accounts.FirstOrDefault(a =>
-                a.Name.Contains(accountName, StringComparison.OrdinalIgnoreCase));
-
+            var (matchedAccount, error) = await FindAccountByNameAsync(accountName);
             if (matchedAccount == null)
-            {
-                return $"No account found matching '{accountName}'. Available accounts: {string.Join(", ", accounts.Select(a => a.Name))}";
-            }
+                return error!;
 
             var endDate = DateTimeProvider.UtcNow;
             var startDate = endDate.AddMonths(-months);
 
-            var query = new GetTransactionsQuery
-            {
-                UserId = _userId,
-                AccountId = matchedAccount.Id,
-                StartDate = startDate,
-                EndDate = endDate,
-                PageSize = 50,
-                Page = 1,
-                SortBy = "TransactionDate",
-                SortDirection = "desc"
-            };
+            // Fetch all transactions for accurate summary
+            var allTransactions = (await _transactionRepository.GetByDateRangeAsync(_userId, matchedAccount.Id, startDate, endDate)).ToList();
 
-            var (transactions, totalCount) = await _transactionRepository.GetFilteredAsync(query);
-            var transactionList = transactions.ToList();
-
-            if (!transactionList.Any())
+            if (!allTransactions.Any())
             {
                 return $"No transactions found for '{matchedAccount.Name}' in the last {months} months.";
             }
 
             var actualBalance = await _transactionRepository.GetAccountBalanceAsync(matchedAccount.Id, _userId);
 
+            // Compute summary from the full set
+            var income = allTransactions.Where(t => !t.IsExcluded && !t.IsTransfer() && t.Amount > 0).Sum(t => t.Amount);
+            var expenses = allTransactions.Where(t => !t.IsExcluded && !t.IsTransfer() && t.Amount < 0).Sum(t => Math.Abs(t.Amount));
+
             var sb = new StringBuilder();
             sb.AppendLine($"Account: {matchedAccount.Name} ({matchedAccount.Type}) | Balance: {actualBalance:N2} {matchedAccount.Currency}");
-            sb.AppendLine($"Transactions (last {months} months) - {totalCount} total:");
+            sb.AppendLine($"Transactions (last {months} months) - {allTransactions.Count} total:");
             sb.AppendLine();
 
-            var income = 0m;
-            var expenses = 0m;
-
-            foreach (var t in transactionList)
+            // Display up to 50 most recent
+            var displayLimit = 50;
+            foreach (var t in allTransactions.OrderByDescending(t => t.TransactionDate).Take(displayLimit))
             {
                 var categoryName = t.Category?.Name ?? "Uncategorized";
                 var marker = t.IsTransfer() ? " [Transfer]" : t.IsExcluded ? " [Excluded]" : "";
                 sb.AppendLine($"  {t.TransactionDate:yyyy-MM-dd} | {t.GetDisplayDescription()} | {t.Amount:N2} | {categoryName}{marker}");
-
-                if (!t.IsExcluded && !t.IsTransfer())
-                {
-                    if (t.Amount > 0)
-                        income += t.Amount;
-                    else
-                        expenses += Math.Abs(t.Amount);
-                }
             }
 
             sb.AppendLine();
             sb.AppendLine($"Summary (excluding transfers): Income {income:N2} | Expenses {expenses:N2} | Net {income - expenses:N2}");
-            sb.AppendLine($"Showing {transactionList.Count} of {totalCount} transactions.");
+            if (allTransactions.Count > displayLimit)
+                sb.AppendLine($"Showing {displayLimit} of {allTransactions.Count} transactions.");
 
             return sb.ToString();
         }
@@ -487,14 +460,9 @@ public class FinancialDataPlugin
         {
             months = Math.Clamp(months, 1, 24);
 
-            var accounts = await _accountRepository.GetByUserIdAsync(_userId);
-            var matchedAccount = accounts.FirstOrDefault(a =>
-                a.Name.Contains(accountName, StringComparison.OrdinalIgnoreCase));
-
+            var (matchedAccount, error) = await FindAccountByNameAsync(accountName);
             if (matchedAccount == null)
-            {
-                return $"No account found matching '{accountName}'. Available accounts: {string.Join(", ", accounts.Select(a => a.Name))}";
-            }
+                return error!;
 
             var endDate = DateTimeProvider.UtcNow;
             var startDate = endDate.AddMonths(-months);
@@ -563,14 +531,9 @@ public class FinancialDataPlugin
     {
         try
         {
-            var accounts = await _accountRepository.GetByUserIdAsync(_userId);
-            var matchedAccount = accounts.FirstOrDefault(a =>
-                a.Name.Contains(accountName, StringComparison.OrdinalIgnoreCase));
-
+            var (matchedAccount, error) = await FindAccountByNameAsync(accountName);
             if (matchedAccount == null)
-            {
-                return $"No account found matching '{accountName}'. Available accounts: {string.Join(", ", accounts.Select(a => a.Name))}";
-            }
+                return error!;
 
             if (!DateTime.TryParse(startDate, out var start))
             {
@@ -583,54 +546,41 @@ public class FinancialDataPlugin
             }
 
             start = DateTimeProvider.ToUtc(start);
+            // Normalize end date to end-of-day so date-only inputs include the full final day
             end = DateTimeProvider.ToUtc(end);
+            if (end.TimeOfDay == TimeSpan.Zero)
+                end = end.AddDays(1).AddTicks(-1);
 
-            var query = new GetTransactionsQuery
-            {
-                UserId = _userId,
-                AccountId = matchedAccount.Id,
-                StartDate = start,
-                EndDate = end,
-                PageSize = 100,
-                Page = 1,
-                SortBy = "TransactionDate",
-                SortDirection = "desc"
-            };
+            // Fetch all transactions for accurate summary
+            var allTransactions = (await _transactionRepository.GetByDateRangeAsync(_userId, matchedAccount.Id, start, end)).ToList();
 
-            var (transactions, totalCount) = await _transactionRepository.GetFilteredAsync(query);
-            var transactionList = transactions.ToList();
-
-            if (!transactionList.Any())
+            if (!allTransactions.Any())
             {
                 return $"No transactions found for '{matchedAccount.Name}' between {start:yyyy-MM-dd} and {end:yyyy-MM-dd}.";
             }
 
+            // Compute summary from the full set
+            var income = allTransactions.Where(t => !t.IsExcluded && !t.IsTransfer() && t.Amount > 0).Sum(t => t.Amount);
+            var expenses = allTransactions.Where(t => !t.IsExcluded && !t.IsTransfer() && t.Amount < 0).Sum(t => Math.Abs(t.Amount));
+
             var sb = new StringBuilder();
             sb.AppendLine($"Account: {matchedAccount.Name} ({matchedAccount.Type})");
-            sb.AppendLine($"Transactions from {start:yyyy-MM-dd} to {end:yyyy-MM-dd} ({totalCount} total):");
+            sb.AppendLine($"Transactions from {start:yyyy-MM-dd} to {end:yyyy-MM-dd} ({allTransactions.Count} total):");
             sb.AppendLine();
 
-            var income = 0m;
-            var expenses = 0m;
-
-            foreach (var t in transactionList)
+            // Display up to 100 most recent
+            var displayLimit = 100;
+            foreach (var t in allTransactions.OrderByDescending(t => t.TransactionDate).Take(displayLimit))
             {
                 var categoryName = t.Category?.Name ?? "Uncategorized";
                 var marker = t.IsTransfer() ? " [Transfer]" : t.IsExcluded ? " [Excluded]" : "";
                 sb.AppendLine($"  {t.TransactionDate:yyyy-MM-dd} | {t.GetDisplayDescription()} | {t.Amount:N2} | {categoryName}{marker}");
-
-                if (!t.IsExcluded && !t.IsTransfer())
-                {
-                    if (t.Amount > 0)
-                        income += t.Amount;
-                    else
-                        expenses += Math.Abs(t.Amount);
-                }
             }
 
             sb.AppendLine();
             sb.AppendLine($"Summary (excluding transfers): Income {income:N2} | Expenses {expenses:N2} | Net {income - expenses:N2}");
-            sb.AppendLine($"Showing {transactionList.Count} of {totalCount} transactions.");
+            if (allTransactions.Count > displayLimit)
+                sb.AppendLine($"Showing {displayLimit} of {allTransactions.Count} transactions.");
 
             return sb.ToString();
         }
@@ -647,14 +597,9 @@ public class FinancialDataPlugin
     {
         try
         {
-            var accounts = await _accountRepository.GetByUserIdAsync(_userId);
-            var matchedAccount = accounts.FirstOrDefault(a =>
-                a.Name.Contains(accountName, StringComparison.OrdinalIgnoreCase));
-
+            var (matchedAccount, error) = await FindAccountByNameAsync(accountName);
             if (matchedAccount == null)
-            {
-                return $"No account found matching '{accountName}'. Available accounts: {string.Join(", ", accounts.Select(a => a.Name))}";
-            }
+                return error!;
 
             var patterns = await _recurringPatternRepository.GetActiveAsync(_userId);
             var patternList = patterns.ToList();
@@ -664,8 +609,8 @@ public class FinancialDataPlugin
                 return $"No active recurring expenses detected for any account.";
             }
 
-            // Find which recurring patterns have transactions in this account
-            // by checking recent transactions for this account and matching merchant names
+            // Match recurring patterns to this account using NormalizedMerchantKey
+            // against transaction descriptions for more reliable matching
             var endDate = DateTimeProvider.UtcNow;
             var startDate = endDate.AddMonths(-6);
             var accountTransactions = await _transactionRepository.GetByDateRangeAsync(_userId, matchedAccount.Id, startDate, endDate);
@@ -677,9 +622,10 @@ public class FinancialDataPlugin
             var matchedPatterns = patternList
                 .Where(p =>
                 {
-                    var lowerMerchant = p.MerchantName?.ToLowerInvariant();
-                    return !string.IsNullOrEmpty(lowerMerchant) &&
-                           accountDescriptions.Any(d => d.Contains(lowerMerchant));
+                    var key = p.NormalizedMerchantKey;
+                    if (string.IsNullOrEmpty(key)) return false;
+                    // NormalizedMerchantKey is already lowered; require minimum length to avoid false positives
+                    return key.Length >= 3 && accountDescriptions.Any(d => d.Contains(key));
                 })
                 .ToList();
 
@@ -1438,6 +1384,20 @@ public class FinancialDataPlugin
         {
             return $"Error retrieving goal details: {ex.Message}";
         }
+    }
+
+    private async Task<(Domain.Entities.Account? account, string? error)> FindAccountByNameAsync(string accountName)
+    {
+        var accounts = await _accountRepository.GetByUserIdAsync(_userId);
+        var matches = accounts.Where(a =>
+            a.Name.Contains(accountName, StringComparison.OrdinalIgnoreCase)).ToList();
+
+        if (matches.Count == 0)
+            return (null, $"No account found matching '{accountName}'. Available accounts: {string.Join(", ", accounts.Select(a => a.Name))}");
+        if (matches.Count > 1)
+            return (null, $"Multiple accounts match '{accountName}': {string.Join(", ", matches.Select(a => a.Name))}. Please be more specific.");
+
+        return (matches[0], null);
     }
 
     private class CategorizationItem


### PR DESCRIPTION
## Summary
- Add 4 new `[KernelFunction]` methods to `FinancialDataPlugin` enabling Alce to filter transactions, spending breakdowns, and recurring expenses by account (e.g. "show my Amex transactions", "what subscriptions are on my checking?")
- Enhance `FinancialContextBuilder` with per-account summaries (transaction count + top spending categories for last month)
- Update Alce's system prompt with guidance on when to use account-specific tools vs general tools

## New Functions
| Function | Purpose |
|---|---|
| `GetTransactionsByAccount` | List transactions for a specific account with income/expense totals |
| `GetAccountSpendingByCategory` | Category spending breakdown with percentages for one account |
| `GetTransactionsForAccountByDateRange` | Account + date range combined filter |
| `GetRecurringExpensesByAccount` | Recurring expenses/subscriptions hitting a specific account |

## Test plan
- [x] `dotnet build` — 0 errors
- [x] `dotnet test` — 1041 tests passing
- [ ] Manual test: ask Alce "show me my [account] transactions"
- [ ] Manual test: ask Alce "what am I spending on with my [account]?"
- [ ] Manual test: ask Alce "what subscriptions are on my [account]?"
- [ ] Verify existing 17 functions still work unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)