### PR TITLE
fix: increase Wallets.Icon column size so wallet creation works

### DIFF
--- a/src/Core/MyMascada.Application/Features/Wallets/Validators/CreateWalletCommandValidator.cs
+++ b/src/Core/MyMascada.Application/Features/Wallets/Validators/CreateWalletCommandValidator.cs
@@ -27,9 +27,9 @@ public class CreateWalletCommandValidator : AbstractValidator<CreateWalletComman
             .WithMessage("Currency must be letters only");
 
         RuleFor(x => x.Icon)
-            .MaximumLength(10)
+            .MaximumLength(50)
             .When(x => x.Icon != null)
-            .WithMessage("Icon cannot exceed 10 characters");
+            .WithMessage("Icon cannot exceed 50 characters");
 
         RuleFor(x => x.TargetAmount)
             .GreaterThan(0)

--- a/src/Core/MyMascada.Application/Features/Wallets/Validators/UpdateWalletCommandValidator.cs
+++ b/src/Core/MyMascada.Application/Features/Wallets/Validators/UpdateWalletCommandValidator.cs
@@ -7,6 +7,10 @@ public class UpdateWalletCommandValidator : AbstractValidator<UpdateWalletComman
 {
     public UpdateWalletCommandValidator()
     {
+        RuleFor(x => x.WalletId)
+            .GreaterThan(0)
+            .WithMessage("Wallet ID must be greater than 0");
+
         RuleFor(x => x.Name)
             .NotEmpty()
             .WithMessage("Wallet name cannot be empty")

--- a/src/Core/MyMascada.Application/Features/Wallets/Validators/UpdateWalletCommandValidator.cs
+++ b/src/Core/MyMascada.Application/Features/Wallets/Validators/UpdateWalletCommandValidator.cs
@@ -1,0 +1,43 @@
+using FluentValidation;
+using MyMascada.Application.Features.Wallets.Commands;
+
+namespace MyMascada.Application.Features.Wallets.Validators;
+
+public class UpdateWalletCommandValidator : AbstractValidator<UpdateWalletCommand>
+{
+    public UpdateWalletCommandValidator()
+    {
+        RuleFor(x => x.Name)
+            .NotEmpty()
+            .WithMessage("Wallet name cannot be empty")
+            .MaximumLength(100)
+            .WithMessage("Wallet name cannot exceed 100 characters")
+            .When(x => x.Name != null);
+
+        RuleFor(x => x.Icon)
+            .MaximumLength(50)
+            .When(x => x.Icon != null)
+            .WithMessage("Icon cannot exceed 50 characters");
+
+        RuleFor(x => x.Color)
+            .Matches(@"^#[0-9A-Fa-f]{6}$")
+            .When(x => !string.IsNullOrEmpty(x.Color))
+            .WithMessage("Color must be a valid hex color (e.g., #FF5733)");
+
+        RuleFor(x => x.Currency)
+            .Length(3)
+            .WithMessage("Currency must be a 3-character code (e.g., NZD)")
+            .Matches("^[A-Za-z]{3}$")
+            .WithMessage("Currency must be letters only")
+            .When(x => x.Currency != null);
+
+        RuleFor(x => x.TargetAmount)
+            .GreaterThan(0)
+            .When(x => x.TargetAmount.HasValue)
+            .WithMessage("Target amount must be greater than 0 when specified");
+
+        RuleFor(x => x.UserId)
+            .NotEmpty()
+            .WithMessage("User ID is required");
+    }
+}

--- a/src/Core/MyMascada.Application/Features/Wallets/Validators/UpdateWalletCommandValidator.cs
+++ b/src/Core/MyMascada.Application/Features/Wallets/Validators/UpdateWalletCommandValidator.cs
@@ -37,7 +37,7 @@ public class UpdateWalletCommandValidator : AbstractValidator<UpdateWalletComman
 
         RuleFor(x => x.TargetAmount)
             .GreaterThan(0)
-            .When(x => x.TargetAmount.HasValue)
+            .When(x => x.TargetAmount.HasValue && !x.ClearTargetAmount)
             .WithMessage("Target amount must be greater than 0 when specified");
 
         RuleFor(x => x.UserId)

--- a/src/Core/MyMascada.Domain/Entities/Wallet.cs
+++ b/src/Core/MyMascada.Domain/Entities/Wallet.cs
@@ -12,7 +12,7 @@ public class Wallet : BaseEntity
     [MaxLength(100)]
     public string Name { get; set; } = string.Empty;
 
-    [MaxLength(10)]
+    [MaxLength(50)]
     public string? Icon { get; set; }
 
     [MaxLength(7)]

--- a/src/Infrastructure/MyMascada.Infrastructure/Data/ApplicationDbContext.cs
+++ b/src/Infrastructure/MyMascada.Infrastructure/Data/ApplicationDbContext.cs
@@ -811,7 +811,7 @@ public class ApplicationDbContext : DbContext
         {
             entity.HasKey(e => e.Id);
             entity.Property(e => e.Name).IsRequired().HasMaxLength(100);
-            entity.Property(e => e.Icon).HasMaxLength(10);
+            entity.Property(e => e.Icon).HasMaxLength(50);
             entity.Property(e => e.Color).HasMaxLength(7);
             entity.Property(e => e.Currency).IsRequired().HasMaxLength(3);
             entity.Property(e => e.TargetAmount).HasPrecision(18, 2);

--- a/src/WebAPI/MyMascada.WebAPI/Migrations/20260425120000_IncreaseWalletIconMaxLength.Designer.cs
+++ b/src/WebAPI/MyMascada.WebAPI/Migrations/20260425120000_IncreaseWalletIconMaxLength.Designer.cs
@@ -2,6 +2,7 @@
 using System;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using MyMascada.Infrastructure.Data;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
@@ -11,9 +12,11 @@ using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 namespace MyMascada.WebAPI.Migrations
 {
     [DbContext(typeof(ApplicationDbContext))]
-    partial class ApplicationDbContextModelSnapshot : ModelSnapshot
+    [Migration("20260425120000_IncreaseWalletIconMaxLength")]
+    partial class IncreaseWalletIconMaxLength
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/src/WebAPI/MyMascada.WebAPI/Migrations/20260425120000_IncreaseWalletIconMaxLength.cs
+++ b/src/WebAPI/MyMascada.WebAPI/Migrations/20260425120000_IncreaseWalletIconMaxLength.cs
@@ -1,0 +1,45 @@
+using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace MyMascada.WebAPI.Migrations
+{
+    /// <inheritdoc />
+    /// <summary>
+    /// Increases Wallets.Icon column from varchar(10) to varchar(50). The frontend uses
+    /// heroicon slug ids (e.g. "currency-dollar", "device-phone-mobile") that exceed the
+    /// previous 10-char limit, which caused wallet creation to fail validation.
+    /// </summary>
+    public partial class IncreaseWalletIconMaxLength : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AlterColumn<string>(
+                name: "Icon",
+                table: "Wallets",
+                type: "character varying(50)",
+                maxLength: 50,
+                nullable: true,
+                oldClrType: typeof(string),
+                oldType: "character varying(10)",
+                oldMaxLength: 10,
+                oldNullable: true);
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AlterColumn<string>(
+                name: "Icon",
+                table: "Wallets",
+                type: "character varying(10)",
+                maxLength: 10,
+                nullable: true,
+                oldClrType: typeof(string),
+                oldType: "character varying(50)",
+                oldMaxLength: 50,
+                oldNullable: true);
+        }
+    }
+}


### PR DESCRIPTION
The frontend wallet picker uses heroicon slug ids (e.g. the default
"currency-dollar" is 15 chars and "device-phone-mobile" is 19) but the
Wallet.Icon column, EF MaxLength attribute, and FluentValidation rule
were all capped at 10 characters. As a result every "Create wallet"
attempt with the default icon was rejected by the validator with
"Icon cannot exceed 10 characters" and surfaced as a generic save
failure in the UI.

Bumps the limit to 50 chars in the entity, EF model configuration,
validator, and snapshot, and adds a migration to ALTER the column
from varchar(10) to varchar(50).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Improvements**
  * Increased maximum length for wallet icon identifiers from 10 to 50 characters (database and validation aligned).
* **New Features**
  * Added stronger update-wallet validation: requires non-empty name (max 100 chars), icon ≤50 chars when present, color in #RRGGBB format when provided, currency as three letters when provided, target amount > 0 when provided, and a required user identifier.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->