### PR TITLE
feat: Akahu classic→official open banking migration support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -228,3 +228,7 @@ output/
 
 # TypeScript build info
 *.tsbuildinfo
+
+# Akahu dev credentials (never commit)
+akahu-dev-cred*
+.env.akahu*

--- a/docs/plans/akahu-accreditation-pack.md
+++ b/docs/plans/akahu-accreditation-pack.md
@@ -1,0 +1,329 @@
+# Akahu Accreditation Evidence Pack — MyMascada
+
+> **Purpose:** Assembly guide and evidence index for Akahu app accreditation submission.
+> **Date prepared:** 2026-05-15
+> **Prepared by:** Rodrigo Leote
+> **Authentication bar confirmed:** Read-only (confirmed by Josh at Akahu, 2026-04-03)
+>
+> Each section maps directly to the Akahu app-review checklist at
+> https://developers.akahu.nz/docs/app-accreditation.
+
+---
+
+## 1. Architecture and Data Flow Overview
+
+### What Akahu asks for
+A clear explanation of how the application is built, how data flows from Akahu to the end user, and what happens to that data.
+
+### What MyMascada has today
+MyMascada is a hosted SaaS personal finance application deployed on Fly.io (API) and Fly.io (Next.js frontend) backed by a managed PostgreSQL database and Redis cache.
+
+**Data flow summary:**
+1. A user initiates the Akahu connection from **Settings → Bank Connections** (`/settings/bank-connections`).
+2. In hosted OAuth mode the backend generates a cryptographically random state token, stores it server-side via `IOAuthStateStore`, and redirects the user to Akahu's OAuth consent page.
+3. After user consent, Akahu returns an authorization code to `GET /settings/bank-connections/callback`. The frontend validates the `state` parameter against the stored value (CSRF protection), then POSTs the code to the backend.
+4. The backend (`ExchangeAkahuCodeQuery`) exchanges the code for a user access token via Akahu's token endpoint using HTTP Basic auth (app credentials). The token is **never returned to the browser**. It is encrypted with ASP.NET Data Protection and stored in `AkahuUserCredential` in the database.
+5. Subsequent sync operations (manual or webhook-triggered) are executed server-side: the API decrypts the user token, calls Akahu REST endpoints, and writes the resulting transactions and balances into the database.
+6. The frontend only ever receives normalized `BankConnection` and `Transaction` DTOs — no Akahu tokens, account IDs, or raw bank data are exposed.
+7. Akahu webhooks arrive at `POST /api/webhooks/akahu`. The endpoint verifies the RSA signature before processing any payload.
+
+**Key source files:**
+- Backend OAuth flow: `src/Core/MyMascada.Application/Features/BankConnections/Commands/InitiateAkahuConnectionCommand.cs`
+- Token exchange: `src/Core/MyMascada.Application/Features/BankConnections/Queries/ExchangeAkahuCodeQuery.cs`
+- Token storage model: `src/Core/MyMascada.Domain/Entities/AkahuUserCredential.cs`
+- API client (server-side only): `src/Infrastructure/MyMascada.Infrastructure/Services/BankIntegration/Providers/AkahuApiClient.cs`
+- Architecture decision (personal vs OAuth modes): `docs/banking-integration-modes.md`
+
+### Gap
+No formal architecture diagram has been produced for submission. A one-page diagram showing the request/response path from user browser → MyMascada API → Akahu API should be created.
+
+### Owner / next step
+Rodrigo to draw a simple architecture diagram (draw.io or Excalidraw) and export as PDF or PNG. Attach as `docs/plans/architecture-diagram.pdf`.
+
+---
+
+## 2. OAuth / Token Handling Summary
+
+### What Akahu asks for
+Evidence that Akahu user access tokens are handled securely — specifically that they are not exposed to the client browser.
+
+### What MyMascada has today
+- **Security issue #223 (closed):** "Akahu access token exposed to frontend browser" — remediated and closed.
+- The token exchange is performed entirely server-side. The raw user token is encrypted immediately on receipt using ASP.NET Data Protection (`ISettingsEncryptionService`) and stored in `AkahuUserCredential.EncryptedUserToken`. It is never written to any API response or log.
+- Request authentication to Akahu uses `Authorization: Bearer <user_token>` and `X-Akahu-Id: <app_token>` headers, added by `AkahuApiClient.CreateAuthenticatedRequest()`. These headers are constructed server-side per request.
+- The OAuth `state` parameter is validated strictly: the callback page checks both that the URL parameter is present AND that it matches the server-stored state before forwarding the code to the backend. If either check fails, the flow is aborted. See `frontend/src/app/settings/bank-connections/callback/page.tsx`.
+- Scope is configured via `AkahuOptions.DefaultScopes` (defaults to `ENDURING_CONSENT`). Scope value is logged and stored in `AkahuUserCredential.ConsentScope` for audit.
+
+**Key source files:**
+- `src/Infrastructure/MyMascada.Infrastructure/Services/BankIntegration/Providers/AkahuApiClient.cs` — `CreateAuthenticatedRequest()`, `RevokeTokenAsync()`
+- `src/Core/MyMascada.Domain/Entities/AkahuUserCredential.cs` — encrypted storage model
+- `frontend/src/app/settings/bank-connections/callback/page.tsx` — state validation
+
+### Gap
+A brief regression test confirming the token never appears in browser network traffic has not yet been formally documented. The readiness tracker notes this as a remaining step.
+
+### Owner / next step
+Rodrigo to run the hosted OAuth flow in browser dev tools (Network tab), capture a screenshot showing no token in any response, and attach as evidence. Document result in `docs/plans/token-regression-evidence.md`.
+
+---
+
+## 3. Disconnect / Account-Deletion Revoke Behavior
+
+### What Akahu asks for
+- The user can disconnect (revoke) their bank connection at any time.
+- When a user deletes their account, their Akahu access token is revoked.
+
+### What MyMascada has today
+
+**User-initiated disconnect:**
+- Security issue #224 (closed): "No Akahu token revocation on user account deletion" — remediated.
+- `DisconnectBankConnectionCommand` (`src/Core/MyMascada.Application/Features/BankConnections/Commands/DisconnectBankConnectionCommand.cs`) calls `IAkahuApiClient.RevokeTokenAsync()` before removing the connection record.
+- If revocation fails (e.g., network error), the credential is flagged `IsRevocationPending = true` and queued for background retry via `TokenRevocationRetryJobService`.
+- Consent revocation timestamp is recorded in `AkahuUserCredential.ConsentRevokedAt` for compliance audit trail.
+- The UI disconnect path: **Settings → Bank Connections → [connection card] → Disconnect**.
+
+**Account deletion:**
+- `UserDataDeletionService` (`src/Infrastructure/MyMascada.Infrastructure/Services/UserData/UserDataDeletionService.cs`) runs inside a database transaction and calls `IAkahuApiClient.RevokeTokenAsync()` before deleting `AkahuUserCredentials`. Even if revocation fails, deletion of the stored credentials proceeds, and a warning is logged.
+- All bank connections, sync logs, and credentials are deleted as part of the account deletion cascade (steps 9–11 and 32 in `DeleteAllUserDataAsync`).
+- Data retention policy: `DATA_RETENTION.md` — "Akahu credentials: Retained while connected; revoked and deleted on disconnect or account deletion."
+
+**Key source files:**
+- `src/Core/MyMascada.Application/Features/BankConnections/Commands/DisconnectBankConnectionCommand.cs`
+- `src/Infrastructure/MyMascada.Infrastructure/Services/UserData/UserDataDeletionService.cs`
+- `src/Infrastructure/MyMascada.Infrastructure/BackgroundJobs/TokenRevocationRetryJobService.cs`
+
+### Gap
+End-to-end deletion and disconnect tests have not been formally run and documented for the evidence pack.
+
+### Owner / next step
+Rodrigo to run a full delete-account flow in staging, confirm the Akahu token is revoked (check Akahu dashboard or verify subsequent API calls return 401), and document the test result with screenshots in `docs/plans/deletion-revoke-evidence.md`.
+
+---
+
+## 4. Webhook Security and Replay Protection
+
+### What Akahu asks for
+Evidence that incoming Akahu webhooks are authenticated and that replay attacks are prevented.
+
+### What MyMascada has today
+- Security issue #228 (closed): "No replay protection for Akahu webhooks" — remediated.
+- `AkahuWebhookController` (`src/WebAPI/MyMascada.WebAPI/Controllers/AkahuWebhookController.cs`) implements a two-layer protection:
+  1. **Signature verification:** Every incoming webhook must carry `X-Akahu-Signature` and `X-Akahu-Signing-Key` headers. The controller calls `IAkahuWebhookSignatureService.VerifySignatureAsync()`, which fetches Akahu's RSA public key from `api.akahu.io/v1/keys/{keyId}` (cached 24 hours by default), reconstructs the expected signature, and returns `false` for any mismatch. Invalid requests receive HTTP 400 before processing.
+  2. **Replay protection:** The raw webhook body is SHA-256 hashed. The hash is checked against an in-memory cache keyed by `akahu_webhook_{hash}` with a 24-hour window. A duplicate hash returns HTTP 200 (idempotent) without re-processing.
+- Raw response bodies are never logged to prevent incidental exposure of account/transaction data in logs.
+- Key ID is validated against a strict format regex before use (max 64 chars, alphanumeric + `-_` only).
+
+**Key source files:**
+- `src/WebAPI/MyMascada.WebAPI/Controllers/AkahuWebhookController.cs`
+- `src/Infrastructure/MyMascada.Infrastructure/Services/BankIntegration/Providers/AkahuWebhookSignatureService.cs`
+- `src/Core/MyMascada.Application/Common/Interfaces/IAkahuWebhookSignatureService.cs`
+
+### Gap
+None identified for the evidence pack. The mechanism is implemented and documented in code. A short plain-English summary suitable for Akahu's reviewer is included above.
+
+### Owner / next step
+Include the summary above in the submission. Optionally include a log snippet showing a verified webhook event.
+
+---
+
+## 5. Authentication Model Summary
+
+### What Akahu asks for
+A description of the application's authentication model, specifically whether it satisfies the authentication bar for the applicable category (read-only confirmed).
+
+### What MyMascada has today
+MyMascada uses JWT-based authentication with HTTP-only refresh tokens. The authentication model:
+
+- **Registration / login:** Email + password (bcrypt hashed) or Google OAuth. No social-only account without password recovery fallback.
+- **Sessions:** Short-lived JWT access tokens (Bearer) + long-lived HTTP-only `Secure` refresh tokens. The `Secure` flag issue was addressed in security issue #231 (closed).
+- **Password policy:** Strong password requirements enforced at registration. Account lockout after repeated failed attempts.
+- **MFA:** Removed from the mandatory path after Akahu confirmed that MyMascada qualifies for the read-only authentication bar (Josh, 2026-04-03). The `TwoFactorEnabled` column was removed in migration `20260326061051_RemoveTwoFactorEnabled`.
+- **Rate limiting:** API rate limiting is implemented. CORS policy was hardened in security issue #232 (closed).
+- **HTTPS:** All production traffic is served over HTTPS. The refresh token `Secure` flag condition was corrected to always set `Secure` in non-development environments (security issue #231).
+
+**Confirmation needed from Akahu:**
+Josh's reply (2026-04-03) invited Rodrigo to send the current authentication process details so Akahu can confirm the design satisfies the read-only bar. This send has not yet been completed (see readiness tracker, section C).
+
+**Key source files / migrations:**
+- `src/WebAPI/MyMascada.WebAPI/Migrations/20260326061051_RemoveTwoFactorEnabled.cs`
+- Auth middleware and JWT configuration in `src/WebAPI/MyMascada.WebAPI/`
+
+### Gap
+Formal confirmation from Akahu that the current auth design satisfies the read-only bar has not been received.
+
+### Owner / next step
+Rodrigo to draft a 1-page auth description email to Josh and send. Track response in the readiness tracker.
+
+---
+
+## 6. Privacy Notice
+
+### What Akahu asks for
+A public privacy notice that covers Akahu-related data usage — what data is collected via Akahu, how it is used, and reference to Akahu's own privacy policy.
+
+### What MyMascada has today
+- **Live privacy page:** `frontend/src/app/privacy/page.tsx` — rendered at `https://mymascada.com/privacy` (last updated February 2026).
+- The Akahu section states:
+  - _"What is shared: Bank account information and transaction data are synced through Akahu's API."_
+  - _"When: Only when you connect a bank account via Akahu."_
+  - Links to [Akahu Privacy Policy](https://www.akahu.nz/privacy).
+- **Repo policy:** `PRIVACY.md` — mirrors the above for self-hosters.
+
+### Gap
+The current privacy notice covers Akahu at a basic level. It does not explicitly mention:
+- The read-only access scope (accounts + transactions, 365 days retroactive).
+- The duration of access (enduring consent until revoked by the user).
+- The user's right to revoke access from within MyMascada settings.
+
+These are details Akahu expects users to understand before granting consent. The privacy notice should be updated with this additional specificity, or the Consumer Information Page (section 8) can carry this detail and be cross-linked from the privacy notice.
+
+### Owner / next step
+Update `frontend/src/app/privacy/page.tsx` Akahu section to add scope, duration, and revocation instructions. Update `last updated` date. Link to the Consumer Information Page once it is live.
+
+---
+
+## 7. Data Retention and Deletion Approach
+
+### What Akahu asks for
+Evidence that the application has a clear and implemented data retention policy, particularly covering what happens to Akahu-sourced data when a user disconnects or deletes their account.
+
+### What MyMascada has today
+- **`DATA_RETENTION.md`** (repo root): formal policy covering all data classes.
+  - Akahu credentials: "Retained while connected; revoked and deleted on disconnect or account deletion."
+  - Financial transactions: "Retained while account is active; deleted on account deletion."
+- **Implementation:** `UserDataDeletionService` performs a full cascade delete of all user data including Akahu credentials in a single database transaction (41 steps). See section 3 above.
+- **Automated jobs:**
+  - `cleanup-expired-refresh-tokens` — daily at 3:00 AM
+  - `cleanup-expired-chat-messages` — daily at 3:30 AM
+  - `cleanup-expired-password-reset-tokens` — daily at 3:15 AM
+- **Backup retention:** Operator-managed, recommended 30 days. Database backups may contain Akahu-sourced transaction data until the backup window expires.
+- **Incident response:** `docs/INCIDENT_RESPONSE.md` covers the scenario of a potential Akahu token compromise and includes NZ Privacy Act 2020 notification obligations.
+
+### Gap
+No gap for the evidence pack. The policy and implementation are in place and documented.
+
+### Owner / next step
+Include the `DATA_RETENTION.md` link in the submission package. Confirm the 30-day backup window is disclosed in the consumer-facing privacy notice.
+
+---
+
+## 8. Consumer Information Page
+
+### What Akahu asks for
+A dedicated public page explaining to users:
+- How MyMascada uses their financial account access
+- What value they get
+- Access scope (what data is read, and for how long retroactively)
+- Duration of access
+- Akahu's role — with clear Akahu branding/logo
+
+### What MyMascada has today
+No dedicated Consumer Information Page exists. The current privacy notice at `/privacy` partially covers Akahu but does not meet the above requirements in full.
+
+### Gap
+This page is entirely missing. It is a mandatory accreditation requirement.
+
+### Owner / next step
+1. Use the draft content in `docs/plans/akahu-consumer-info-page-draft.md` as the starting point.
+2. Build the page at `frontend/src/app/open-banking/page.tsx` (or `/akahu` — confirm URL with Akahu at submission).
+3. Obtain the official Akahu logo asset from Akahu for placement where `[INSERT AKAHU LOGO HERE]` is marked in the draft.
+4. Link the page from the bank connections settings page and from the privacy notice.
+5. The page should be publicly accessible (no login required).
+
+---
+
+## 9. Pen Test Report or Assurance Material
+
+### What Akahu asks for
+A recent penetration test report, or an accepted substitute such as SOC 2 Type II or ISO 27001 certification. Akahu explicitly requested the pen test report as part of the submission.
+
+### What MyMascada has today
+A formal third-party pen test was conducted (the 10-issue findings set, tracked as GitHub issues #223–#232). All 10 issues are now closed. The audit findings and remediation are evidenced by the closed GitHub issues in the `digaomatias/mymascada` repository.
+
+What is available:
+- Closed GitHub security issues: #223, #224, #225, #226, #227, #228, #229, #230, #231, #232
+- Summary issue: #233 (informational posture summary)
+- `SECURITY.md` — vulnerability disclosure policy
+- `docs/INCIDENT_RESPONSE.md` — incident response posture
+
+### Gap
+The formal pen test report (the written document produced by the auditor, not just the GitHub issue set) has not been located or attached to this pack. Akahu specifically asked for this document to be sent.
+
+### Owner / next step
+Rodrigo to locate the pen test report PDF from the auditor and attach it to the submission. If only the GitHub issue set is available (no separate report document), confirm with Josh whether the issue set plus a written remediation summary satisfies the requirement. Draft a remediation summary covering all 10 issues if needed.
+
+---
+
+## 10. Staging / Test Access Instructions for Akahu Reviewers
+
+### What Akahu asks for
+Review access to the application — either a staging environment or a controlled production account — so Akahu's team can verify the user experience end to end.
+
+### What MyMascada has today
+- A test user account exists: `test-user@mymascada.local` / `TestPassword123!` (auto-seeded in dev; a parallel test account in staging/production needs to be created).
+- The application is reachable at `https://mymascada.com`.
+- The bank connections flow is at `/settings/bank-connections`.
+- The Hangfire admin dashboard is available at `/hangfire` (requires admin auth).
+
+### Gap
+No formal reviewer access package has been prepared. The staging test user would need:
+- A pre-configured Akahu connection (or instructions to connect one using Akahu's sandbox).
+- Confirmation of the production URL.
+- Instructions for the full connect → sync → disconnect → delete flow.
+
+### Owner / next step
+Rodrigo to:
+1. Create a dedicated `akahu-reviewer@mymascada.com` test account in staging or production.
+2. Pre-connect a bank account using Akahu sandbox credentials (if available) or provide step-by-step instructions.
+3. Write a one-page "Reviewer Access Guide" covering: login URL, credentials, how to connect a bank, how to disconnect, how to delete the account.
+4. Store the guide in `docs/plans/reviewer-access-guide.md`.
+
+---
+
+## 11. INACTIVE / Revoked Account UX
+
+### What Akahu asks for
+Users should be alerted when a connected account becomes `INACTIVE` (as reported by Akahu), with a clear path back into the consent flow to re-authorise.
+
+### What MyMascada has today
+Partial implementation:
+- `SyncStatusIndicator` component (`frontend/src/components/bank-connections/sync-status-indicator.tsx`) renders an "inactive" badge when `connection.isActive === false`. The sync button is disabled for inactive connections.
+- `LinkAccountDialog` filters out inactive accounts before presenting them for selection (`accounts.filter(a => a.isActive)`).
+- When Akahu sends a `TOKEN/DELETE` webhook, `ProcessAkahuWebhookCommandHandler` marks all the user's Akahu connections as `IsActive = false` and deletes the stored credentials.
+- When Akahu sends an `ACCOUNT/DELETE` webhook, the specific connection is marked `IsActive = false`.
+
+What is **not yet confirmed** as implemented:
+- A proactive in-app notification or prompt that appears on the dashboard or bank connections page when a connection becomes inactive, prompting the user to re-authorise. The current UX surfaces the "inactive" state on the bank connections settings page, but there is no push notification or dashboard nudge.
+
+### Gap
+The INACTIVE state is surfaced in the settings page but there is no proactive alert (notification, dashboard nudge, or email) prompting the user to re-connect. Josh confirmed Akahu does not prescribe exact UX, but expects the controls to be clear and intuitive.
+
+### Owner / next step
+1. Confirm whether the existing "inactive" badge on the bank connections page, combined with a re-authorise button, is sufficient for Akahu's reviewers.
+2. If not, add a dashboard nudge (the nudge dismissal system already exists in the codebase — `DashboardNudgeDismissals`) for users with inactive connections.
+3. Document the final UX decision and include a screenshot in the submission.
+
+---
+
+## Submission-Ready Checklist
+
+| Item | Status | Pointer / Action |
+|---|---|---|
+| Signed Developer Terms | Unchecked | Rodrigo to complete the Akahu Developer Terms sign-up at https://developers.akahu.nz. Attach signed copy or confirmation email. |
+| Privacy Notice (covers Akahu scope + duration + revocation) | Partial | `frontend/src/app/privacy/page.tsx` exists but needs Akahu-specific scope/duration/revocation detail added. |
+| Consumer Information Page | Unchecked | Draft in `docs/plans/akahu-consumer-info-page-draft.md`. Needs to be built and deployed at a public URL. |
+| Pen test report | Partial | 10 findings all closed (#223–#232). Formal report PDF needs to be located and attached. |
+| Architecture diagram | Unchecked | Not yet produced. See section 1. |
+| OAuth / token handling evidence | Partial | Code is in place. Token-not-in-browser regression test not yet documented. See section 2. |
+| Disconnect revoke evidence | Partial | Code is in place. End-to-end test not yet documented. See section 3. |
+| Account deletion revoke evidence | Partial | Code is in place. End-to-end test not yet documented. See section 3. |
+| Webhook security summary | Checked | Implementation complete. See section 4. RSA signature verification + 24-hour replay window. |
+| Auth model description (for Akahu confirmation) | Unchecked | Draft not yet sent to Josh. See section 5. |
+| Data retention policy | Checked | `DATA_RETENTION.md` — policy and implementation complete. |
+| Staging / reviewer access package | Unchecked | Not yet prepared. See section 10. |
+| INACTIVE account UX | Partial | Badge exists in settings page. No proactive dashboard nudge. Confirm with Akahu whether current coverage is sufficient. |
+| HTTPS / transport security | Checked | Production deployment on Fly.io with managed TLS. |
+| CORS hardening | Checked | Security issue #232 closed. |
+| Dependency vulnerability remediation | Checked | Security issue #225 closed. Ongoing maintenance required. |
+| Revocation retry on failure | Checked | `TokenRevocationRetryJobService` — background retry if revoke call fails. |
+| Consent audit trail | Checked | `ConsentGrantedAt`, `ConsentRevokedAt`, `ConsentScope` stored in `AkahuUserCredential`. |

--- a/docs/plans/akahu-accreditation-pack.md
+++ b/docs/plans/akahu-accreditation-pack.md
@@ -142,7 +142,7 @@ MyMascada uses JWT-based authentication with HTTP-only refresh tokens. The authe
 - **HTTPS:** All production traffic is served over HTTPS. The refresh token `Secure` flag condition was corrected to always set `Secure` in non-development environments (security issue #231).
 
 **Confirmation needed from Akahu:**
-Josh's reply (2026-04-03) invited Rodrigo to send the current authentication process details so Akahu can confirm the design satisfies the read-only bar. This send has not yet been completed (see readiness tracker, section C).
+Josh's reply (2026-04-03) invited Rodrigo to send the current authentication process details so Akahu can confirm the design satisfies the read-only bar. This send has not yet been completed and is tracked separately in the Obsidian readiness note `Projects/MyMascada/Integrations/Akahu Accreditation Readiness.md`.
 
 **Key source files / migrations:**
 - `src/WebAPI/MyMascada.WebAPI/Migrations/20260326061051_RemoveTwoFactorEnabled.cs`

--- a/docs/plans/akahu-consumer-info-page-draft.md
+++ b/docs/plans/akahu-consumer-info-page-draft.md
@@ -1,0 +1,105 @@
+# Consumer Information Page — Draft Content
+
+> **File purpose:** Draft content for the mandatory Akahu Consumer Information Page.
+> Build this as a publicly accessible Next.js page at `frontend/src/app/open-banking/page.tsx`
+> (or a URL confirmed with Akahu at submission).
+>
+> Design note: The page should be clean and readable — same visual style as `/privacy`.
+> Replace all `[INSERT AKAHU LOGO HERE]` markers with the official Akahu logo asset
+> obtained from Akahu before launch. Akahu branding guidelines apply.
+>
+> Audience: New Zealand users connecting their bank accounts to MyMascada.
+> Tone: Plain English. No legalese. Approx. 450–550 words of body content.
+
+---
+
+## Page title
+
+**How MyMascada connects to your bank**
+
+_Powered by_  [INSERT AKAHU LOGO HERE]
+
+---
+
+## Body content
+
+### What is bank connection?
+
+When you connect a bank account to MyMascada, the app reads your account information and transaction history automatically — so you don't have to import CSV files or enter transactions by hand. Your spending is categorised, your budgets stay up to date, and your financial picture stays current.
+
+This connection is read-only. MyMascada can never move money, make payments, or change anything at your bank. It can only see what's there.
+
+---
+
+### Who provides the connection?
+
+MyMascada uses **Akahu** to connect to New Zealand banks and financial institutions.
+
+[INSERT AKAHU LOGO HERE]
+
+Akahu is a New Zealand open-finance platform that facilitates secure, consent-based access to financial data. When you connect your bank, you are granting consent directly through Akahu's secure authorisation flow — not entering your bank credentials into MyMascada.
+
+Akahu's role is to act as the intermediary between your bank and MyMascada. They hold your authorisation on your behalf and can relay account and transaction data to MyMascada only while you have an active, consented connection.
+
+For more about how Akahu handles your data, see the [Akahu Privacy Policy](https://www.akahu.nz/privacy).
+
+---
+
+### What data does MyMascada access?
+
+When you connect a bank account, MyMascada requests access to:
+
+- **Account information** — account name, type, and current balance.
+- **Transaction history** — up to 365 days of past transactions at the time of connection, and new transactions as they occur while the connection is active.
+
+MyMascada does **not** request access to payments, transfers, account management, or any other bank functionality. Access is strictly read-only.
+
+---
+
+### How long does the access last?
+
+Your connection remains active until you choose to end it. This is called an enduring consent — it does not expire automatically.
+
+You are in control. You can disconnect a bank account at any time from **Settings → Bank Connections** inside MyMascada. When you disconnect, your authorisation is immediately revoked through Akahu, and no further data is retrieved from that account.
+
+If you delete your MyMascada account, all bank connections are disconnected and all stored data is permanently deleted.
+
+---
+
+### What happens to your data?
+
+Transaction and account data synced through Akahu is stored securely in MyMascada's database and is used solely to power the features you see in the app — your dashboard, transaction list, budgets, and spending insights.
+
+MyMascada does not sell your financial data. It is not shared with third parties except as described in the [Privacy Policy](/privacy).
+
+---
+
+### How do I connect my bank?
+
+1. Go to **Settings → Bank Connections** in MyMascada.
+2. Click **Connect bank account**.
+3. You will be taken to Akahu's secure authorisation page, where you log in to your bank and approve access.
+4. Once authorised, your accounts and recent transactions will appear in MyMascada automatically.
+
+---
+
+### Questions?
+
+If you have questions about how MyMascada uses your bank data, contact us at [support@mymascada.com](mailto:support@mymascada.com).
+
+For questions about Akahu's role in this process, visit [akahu.nz](https://www.akahu.nz) or review the [Akahu Privacy Policy](https://www.akahu.nz/privacy).
+
+[INSERT AKAHU LOGO HERE]
+
+---
+
+## Implementation notes (for developer — remove before launch)
+
+- Place the page at `frontend/src/app/open-banking/page.tsx` (no auth required — `allowAnonymous`).
+- The page should be linked from:
+  - The bank connections settings page (`/settings/bank-connections`) — add a "Learn how this works" link near the info banner.
+  - The privacy policy page (`/privacy`) — add a sentence in the Akahu section linking here.
+  - Akahu's consent screen will display the URL as part of the application review — confirm the exact URL with Akahu before submission.
+- Replace `[INSERT AKAHU LOGO HERE]` with `<Image src="/akahu-logo.svg" alt="Akahu" ... />`. Obtain the official logo SVG from Akahu.
+- Add the page URL to the Akahu Developer Console under "Consumer Information Page URL" when submitting the accreditation application.
+- Localise the page content via `frontend/messages/en.json` and `frontend/messages/pt-BR.json` if Brazilian Portuguese support is required (PT-BR users are unlikely to be NZ bank users, but maintain consistency with the i18n setup).

--- a/docs/plans/akahu-migration-impact.md
+++ b/docs/plans/akahu-migration-impact.md
@@ -1,0 +1,437 @@
+# Akahu Classic → Official Connection Migration: Impact Analysis & Remediation Plan
+
+**Date:** 2026-05-15 — **9 days** until ANZ/ASB/BNZ/Westpac classic connections are revoked (EOD 2026-05-24).
+
+---
+
+## 1. Executive summary
+
+Akahu has migrated to "official open banking" connections for ANZ, ASB, BNZ, and Westpac (launched 2025-12-01; Akahu accredited as an intermediary 2025-12-19). On **end-of-day 2026-05-24** classic connections for those four banks will be revoked. After that, any MyMascada user with an Akahu-linked big-4 account that has not re-authorised will see sync break with `401 Unauthorized` and (eventually) `404 Not Found` on the persisted `acc_xxx` IDs.
+
+The single sentence that drives almost the entire remediation is from Akahu's migration docs:
+
+> "All account and transaction identifiers will change due to the migration. […] Akahu will create a new record for each account; these account records will each receive a new `_id`. For each account that is migrated, Akahu will copy a maximum of 1 year's transaction history. Each copied transaction is assigned a new `_id` and a `_migrated` field that references the `_id` of the original transaction."
+
+What that means concretely for MyMascada:
+
+1. The `acc_xxx` value MyMascada has stored in `BankConnection.ExternalAccountId` (and in the encrypted `AkahuConnectionSettings.AkahuAccountId` blob inside `BankConnection.EncryptedSettings`) will no longer resolve. Every `GET /accounts/{id}` and `GET /accounts/{id}/transactions` call for a big-4 account will 404 once the classic connection is revoked.
+2. Every Akahu-sourced transaction MyMascada has imported has `Transaction.ExternalId = trans_xxx` (classic). The dedup pipeline in `ImportAnalysisService.DetectConflictsAsync` looks up duplicates by `candidate.ExternalReferenceId == existing.ExternalId`. When Akahu re-emits the same transaction with a new `_id` after migration, this exact-match check will not match — every imported transaction within the 1-year window risks being treated as new, producing massive duplication unless we either (a) pre-migrate stored IDs using Akahu's `_migrated` field or (b) reinforce the secondary date+amount duplicate detection.
+3. The OAuth/Personal-App tokens themselves remain valid (the docs imply re-authorisation is required only to upgrade a classic connection to official — the user has to "re-select which of their accounts they wish to share"). However, until they perform that upgrade flow per-user, MyMascada has no way to obtain the new `acc_xxx`/`trans_xxx` IDs. So both code work (correlation logic) AND user action (re-auth) are required.
+4. The `AkahuUserCredential` model is per-user not per-bank. Akahu's official open-banking model still appears to be per-user (one user access token covers all migrated `conn_xxx`), so the entity model can stay; only the contents (re-auth metadata, possibly new scope strings) and consent timestamps need updating.
+
+Rodrigo's own dev/test connections will also need re-authorisation in the dev environment (5-user cap; provided by Josh on 2026-03-10) before he can validate the migration code path. Plan accordingly: do not deploy correlation code without first being able to compare a real before/after `GET /connections` and `GET /accounts` response.
+
+---
+
+## 2. What Akahu's docs actually say
+
+Sources read with WebFetch:
+- https://developers.akahu.nz/docs/official-open-banking-migration (primary)
+- https://developers.akahu.nz/docs/official-open-banking
+- https://developers.akahu.nz/docs/official-open-banking-feature-support-accounts
+- https://developers.akahu.nz/docs/authorizing-with-oauth2
+- https://developers.akahu.nz/docs/scopes
+
+### 2.1 Connection-level migration shape
+
+The migration doc describes a transition mode in which `GET /connections` returns both the classic and the official entry for each big-4 bank. The official entry carries a `_classic` attribute that points back to the old `conn_xxx`:
+
+> "`_classic`: `conn_cjgaaozdo000001mrnqmkl1m0` (the classic connection's ID)"
+
+There is also a table comparing "Classic ID" vs "Official ID" behaviour across "Current, Strict, Migration, and Developer modes" — the explicit `connection=conn_xxx` query parameter on the authorisation URL lets the developer direct the user to one or the other.
+
+**Implication:** during the migration window, MyMascada can call `GET /connections` for any user and detect whether a given user has a classic-vs-official pair for ANZ/ASB/BNZ/Westpac. That's how we drive an in-product "Upgrade required" UX.
+
+### 2.2 Account-level migration
+
+> "Match each new account with its predecessor and assign a special `_migrated` parameter to the new account record containing the `_id` of the account's predecessor."
+
+So a migrated account looks like:
+
+```json
+{
+  "_id": "acc_NEWxxxxxxxxxxxxxxxxxx",
+  "_connection": "conn_OFFICIAL_xxx",
+  "_migrated": "acc_OLDxxxxxxxxxxxxxxxx",
+  "name": "Everyday",
+  "formatted_account": "01-0000-0000000-00",
+  "type": "CHECKING",
+  "status": "ACTIVE",
+  "balance": {...}
+}
+```
+
+**Implication:** after the user re-auths, MyMascada can call `GET /accounts` once and build a `{old_acc_id -> new_acc_id}` mapping from the `_migrated` field. That's the per-user migration step that updates `BankConnection.ExternalAccountId` and `AkahuConnectionSettings.AkahuAccountId`.
+
+### 2.3 Transaction-level migration
+
+> "For each account that is migrated, Akahu will copy a maximum of 1 year's transaction history. Each copied transaction is assigned a new `_id` and a `_migrated` field that references the `_id` of the original transaction."
+
+For removed transactions during migration:
+> "This webhook event will include both the transaction's `_id` and `_migrated` in the `removed_transactions` array."
+
+**Implication:** if MyMascada wants to preserve transaction history continuity (recommended — otherwise budgets, reconciliations, categorisation history all break) we have two options:
+
+- **Option A (preferred): in-place ExternalId rewrite.** Iterate transactions on the migrated account, fetch the new transactions (which carry `_migrated`), build a `{old_trans_id -> new_trans_id}` map, and `UPDATE Transactions SET ExternalId = new WHERE ExternalId = old`. After this, the existing dedup pipeline keeps working.
+- **Option B (lazy/eventual): leave old IDs; rely on date+amount duplicate detection.** Cheap to implement but `ImportAnalysisService.DetectConflictsAsync` currently uses `DateToleranceDays = 0` and `AmountTolerance = 0` for bank-API imports (see `BankSyncService.cs:138-143`), and Akahu's docs warn:
+> "It is possible that there will be some changes in transaction data sourced using official connections. You may notice differences in the `date`, `type`, and format of `description`."
+  So zero-tolerance won't catch them. Option B as-is = duplicates everywhere.
+
+We will recommend **Option A**, with Option B's tolerance loosened as a safety net during the migration window.
+
+### 2.4 The MIGRATE webhook
+
+> "A single `MIGRATE` event will be emitted, containing the `previous_item_id` and `new_item_id` for the migrated account."
+
+The docs do not fully specify the JSON envelope shape, but inferring from existing Akahu webhook conventions (cf. `AkahuWebhookPayload.cs`), expect something like:
+
+```json
+{
+  "webhook_type": "ACCOUNT" or "MIGRATE",
+  "webhook_code": "MIGRATE",
+  "item_id":  /* see below */,
+  "previous_item_id": "acc_OLDxxxx",
+  "new_item_id":  "acc_NEWxxxx",
+  "state":    "<user-guid-we-set-at-subscription>"
+}
+```
+
+**Open question for Akahu (Q1):** confirm the exact `webhook_type` / `webhook_code` strings and whether `state` is delivered as set during the user's webhook subscription.
+
+### 2.5 Re-auth flow
+
+> "[Users] will be given the option to upgrade … This upgrade requires that the user … completes a new authorisation using the official open banking connection for their bank. […] re-select which of their accounts they wish to share."
+
+So the developer-side flow is:
+1. Send the user through `GET https://oauth.akahu.nz/?response_type=code&client_id={app}&redirect_uri=...&scope=ENDURING_CONSENT&state=...&connection=conn_OFFICIAL_xxx` (the `connection` param targets a specific bank).
+2. Receive code at the existing redirect URI.
+3. Exchange via `POST /v1/token` — same shape MyMascada already uses (`AkahuApiClient.ExchangeCodeForTokenInternalAsync`).
+4. Persist the new access token; old token can be revoked or left to expire.
+5. Call `GET /accounts` to receive migrated accounts with `_migrated`.
+
+Crucially: the `ENDURING_CONSENT` scope is the same. Per https://developers.akahu.nz/docs/scopes, there's no special "official" scope — `ENDURING_CONSENT`, `ACCOUNTS`, `TRANSACTIONS` are still the relevant ones, plus optionally identity scopes. So the existing `AkahuOptions.DefaultScopes = ["ENDURING_CONSENT"]` is correct.
+
+### 2.6 Per-user vs per-bank consent
+
+Akahu's official open-banking model under their intermediary accreditation still issues a single user-access-token. The user re-selects accounts at each official-bank authorisation, but the resulting token shape (returned at `/v1/token`) is the same. So **MyMascada does not need to migrate `AkahuUserCredential` to per-bank-connection**. We can leave the entity as one-row-per-user.
+
+What we DO need is per-bank-connection consent metadata (`ConsentGrantedAt`, `ConsentCorrelationId`, `ConsentScope`) for each bank a user has officially authorised — because a user could end up with one official connection at ANZ on day X and another at ASB on day Y. The current `AkahuUserCredential` writes those columns at the *user* level which is incorrect once we have multiple official connections per user. (See section 4.6.)
+
+### 2.7 Feature parity
+
+From the feature-support page, ANZ/ASB/Westpac support transactional, savings, loans, credit cards, term deposits; BNZ matches except for term deposits. None support managed funds / KiwiSaver / FX. **Credit cards: ANZ/ASB/BNZ restrict data sharing to the account holder** — a meaningful regression if any MyMascada user was using a joint-cardholder Akahu link before.
+
+### 2.8 What the docs DO NOT say (open questions for Akahu — Q2-Q8)
+
+- **Q2:** Exact `webhook_type` and `webhook_code` strings for the `MIGRATE` event.
+- **Q3:** Will `GET /connections` continue to return BOTH classic and official entries between now and the deadline, and what does it return after 2026-05-25 (only official? official with `_classic` still populated?)
+- **Q4:** Will the old `acc_xxx`/`trans_xxx` resolve to the new IDs server-side after revocation, or is `GET /accounts/{old}` going to 404 immediately?
+- **Q5:** Is the per-connection authorisation URL parameter `connection=conn_xxx` or is it the classic connection ID that triggers the upgrade prompt?
+- **Q6:** When a user upgrades for one bank but not another, do they retain access to both via the same user-access-token, or is the previously-issued token invalidated and a new one issued per-upgrade?
+- **Q7:** What is the maximum overlap window — can MyMascada perform a sync against BOTH classic and official for the same user during a 24-48h transition to verify the `_migrated` mapping before deleting old IDs?
+- **Q8:** Is the dev-environment (Josh's 5-user-cap sandbox) wired up for "official" connections for all four banks already, or only some? (Needed before we can test the code in section 4.)
+
+We should send these to hello@akahu.nz today, copying Josh, and ask for written confirmation by Tue 2026-05-19 latest so we have a buffer.
+
+---
+
+## 3. Code audit — every place that persists or matches on Akahu IDs
+
+All paths are absolute under `/Volumes/SabrentSSD/Source/source/mymascada`.
+
+### 3.1 Persisted identifiers (database)
+
+| Field | Entity | File | Concern |
+|---|---|---|---|
+| `BankConnection.ExternalAccountId` (varchar(100), indexed) | `BankConnection` | `src/Core/MyMascada.Domain/Entities/BankConnection.cs:40` | Stores `acc_xxx`. Used for webhook routing (`GetByExternalAccountIdAsync` in `ProcessAkahuWebhookCommand.cs:128, 140, 177, 201`) and dedup of "already linked" Akahu accounts (`CompleteAkahuConnectionCommand.cs:92`). Must be rewritten to new `acc_xxx` per user. Index defined in `src/Infrastructure/MyMascada.Infrastructure/Data/ApplicationDbContext.cs:419-420`. |
+| `BankConnection.EncryptedSettings` (encrypted JSON of `AkahuConnectionSettings`) | `BankConnection` | `src/Core/MyMascada.Domain/Entities/BankConnection.cs:34`; settings class at `src/Infrastructure/MyMascada.Infrastructure/Services/BankIntegration/Providers/AkahuSettings.cs:8-24` | Stores `AkahuAccountId` (same `acc_xxx` redundantly) and `LastSyncedTransactionId` (a `trans_xxx` for incremental sync — currently appears unused, but worth confirming). Decrypted and consumed in `AkahuBankProvider.GetSettings` (`AkahuBankProvider.cs:233-240`) and `AkahuBankProvider` uses `settings.AkahuAccountId` as fallback for the `ExternalAccountId` (`AkahuBankProvider.cs:46, 92, 135, 179`). Must be rewritten alongside `ExternalAccountId`. |
+| `Transaction.ExternalId` (varchar(100)) | `Transaction` | `src/Core/MyMascada.Domain/Entities/Transaction.cs:50` | Stores `trans_xxx` for every Akahu-imported transaction. Used by `ImportAnalysisService.DetectConflictsAsync` exact-duplicate path (`src/Core/MyMascada.Application/Features/ImportReview/Services/ImportAnalysisService.cs:381-382`), by `ImportUnmatchedTransactionsCommand` (`...:204-225, 266`), by `BulkApproveMatchesCommand` (`...:126-130`), and by the webhook DELETE handler (`ProcessAkahuWebhookCommand.cs:198` → `ITransactionRepository.DeleteByExternalIdsAsync`). All matching breaks post-migration unless we rewrite. |
+| `ReconciliationItem.BankReferenceData` (JSON blob) | `ReconciliationItem` | populated in `src/Core/MyMascada.Application/Features/Reconciliation/Services/AkahuTransactionMapper.cs:41-65` | Embeds `BankTransactionId = source.ExternalId` (the old `trans_xxx`). Re-parsed in `ImportUnmatchedTransactionsCommand.cs:192-225` and `BulkApproveMatchesCommand.cs:184` to dedup imports. Open reconciliations that span the migration cut-over will have stale IDs in their item JSON. Either (a) close out reconciliations before re-auth, or (b) rewrite the embedded JSON too. |
+| `AkahuUserCredential.EncryptedAppToken`, `EncryptedUserToken` | `AkahuUserCredential` | `src/Core/MyMascada.Domain/Entities/AkahuUserCredential.cs:29, 36` | OAuth/Personal access tokens are *not* invalidated by the migration per se (docs imply tokens persist; only the underlying classic connection inside Akahu is revoked). But the user MUST go through a fresh authorisation to migrate accounts. After re-auth, `ExchangeAkahuCodeQuery` rewrites these tokens (`ExchangeAkahuCodeQuery.cs:96-129`). |
+| `AkahuUserCredential.ConsentScope`, `ConsentGrantedAt`, `ConsentCorrelationId`, `ConsentRevokedAt` | `AkahuUserCredential` | same file, lines 53-69 | Currently one row per user; once a user has multiple official connections, the semantics get muddled. (See 4.6.) |
+
+### 3.2 Code paths that produce or compare Akahu IDs
+
+These are the call sites that will silently break or misbehave the moment a user's classic connection is revoked.
+
+**Sync — main hot path:**
+- `BankSyncService.SyncAccountAsync` (`src/Infrastructure/MyMascada.Infrastructure/Services/BankIntegration/BankSyncService.cs:60-266`) → calls `provider.FetchTransactionsAsync(config, from, to, ct)` where `config.ExternalAccountId` is the old `acc_xxx`. `AkahuBankProvider.FetchTransactionsAsync` then calls `GET /accounts/{accountId}/transactions` (`AkahuApiClient.cs:247`). Post-revocation → 404 from Akahu, mapped to `AkahuApiException` (`AkahuApiClient.cs:411`), surfaced in sync log as `LastSyncError`.
+- The dedup pipeline (`BankSyncService.cs:139-143`) uses `DateToleranceDays = 0` and `AmountTolerance = 0` — meaning if a user re-auths and we keep the old `Transaction.ExternalId`s, every freshly re-imported transaction within the migration's 1-year copy window will be inserted again. **This is the primary data-corruption risk.**
+
+**Reconciliation:**
+- `CreateAkahuReconciliationCommand` (`src/Core/MyMascada.Application/Features/Reconciliation/Commands/CreateAkahuReconciliationCommand.cs:66-346`) builds a `BankConnectionConfig` with `connection.ExternalAccountId` (line 363) and calls `provider.FetchTransactionsAsync`. Same failure mode.
+- `AkahuTransactionMapper.CreateBankReferenceData` (`...:41-65`) embeds the old `trans_xxx` into the JSON stored on `ReconciliationItem.BankReferenceData`.
+- `ImportUnmatchedTransactionsCommand` (`...:204-225`) reads `bankData.ExternalId` from that JSON and looks it up in `Transaction.ExternalId` via `_transactionRepository.GetByExternalIdAsync(bankData.ExternalId)` — works against pre-migration data; the moment we rewrite ExternalIds, in-flight reconciliations with stale embedded IDs break.
+
+**Webhooks:**
+- `ProcessAkahuWebhookCommand.HandleAccountUpdateAsync` (`...:120-136`) looks up the connection by `payload.ItemId` (the Akahu `acc_xxx`). If Akahu sends webhooks against the new account ID and we haven't migrated `BankConnection.ExternalAccountId`, every webhook-driven sync silently drops with "No bank connection found for Akahu account…".
+- `HandleAccountDeleteAsync` (`...:138-150`) marks the connection inactive on `DELETE`. We should verify Akahu does NOT send a spurious DELETE for the classic account when it auto-migrates (per docs, the classic account "stops syncing" rather than being deleted — but worth confirming with Q3).
+- `HandleTransactionDeleteAsync` (`...:188-199`) deletes by `payload.RemovedTransactions`. The docs say the array will contain both `_id` and `_migrated` so MyMascada will receive old `trans_xxx` values for transactions removed. The current code passes the whole array to `DeleteByExternalIdsAsync` — which is correct (it will delete any matching), but if we've already rewritten ExternalIds to the new values, the old IDs won't match and the delete is a no-op. Likely harmless, but worth thinking about ordering.
+- **No `MIGRATE` webhook handler exists.** `AkahuWebhookTypes` (`src/Core/MyMascada.Application/Features/BankConnections/DTOs/AkahuWebhookModels.cs:56-61`) declares only `TOKEN`, `ACCOUNT`, `TRANSACTION`. `ProcessAkahuWebhookCommand.Handle` (`...:49-67`) defaults to "Unknown webhook type" for anything else. **This is one of the few must-add code changes.**
+
+**OAuth/connection flow:**
+- `InitiateAkahuConnectionCommand` (`src/Core/MyMascada.Application/Features/BankConnections/Commands/InitiateAkahuConnectionCommand.cs:48-169`) currently builds an authorisation URL via `_akahuApiClient.GetAuthorizationUrl(state, email)`. The URL builder (`AkahuApiClient.cs:44-72`) does NOT pass a `connection` query param. For the migration upgrade flow we likely want to pass `connection=<official-conn-id>` (Q5) to deep-link the user straight to the bank that needs upgrading. Open question whether passing the classic `conn_xxx` works (the docs mention this but aren't precise).
+- `ExchangeAkahuCodeQuery` (`src/Core/MyMascada.Application/Features/BankConnections/Queries/ExchangeAkahuCodeQuery.cs:60-162`) overwrites `EncryptedAppToken`/`EncryptedUserToken`. Works for the upgrade case as written, but does NOT trigger the post-upgrade re-key of `BankConnection.ExternalAccountId` for that user's existing connections.
+- `CompleteAkahuConnectionCommand` (`...Commands/CompleteAkahuConnectionCommand.cs:51-183`) creates a *new* bank connection. It does not know how to update an existing one to point at a new `acc_xxx`. We need a sibling command `MigrateAkahuConnectionCommand` (section 4.3) that updates rather than inserts.
+
+**Personal App mode (the path Rodrigo uses today):**
+- `SaveAkahuCredentialsCommand` (`...Commands/SaveAkahuCredentialsCommand.cs:53-145`) only validates and stores tokens. No interaction with migration. The Personal App tokens themselves should keep working — but the account IDs they see will change after the user upgrades within `my.akahu.nz`. So the same per-user re-mapping logic in section 4.4 applies.
+
+**Reconciliation availability gate:**
+- `GetAkahuReconciliationAvailabilityQuery` (`...Queries/GetAkahuReconciliationAvailabilityQuery.cs:40-121`) checks `bankConnection.ExternalAccountId` is non-empty. After migration but before re-auth + re-key, this still passes (the column is non-empty, just stale). The user is allowed to start a reconciliation; the fetch then fails with 404. Cosmetically poor — see section 4.7 for the "migration required" gate.
+
+**Frontend:**
+- `frontend/src/app/settings/bank-connections/page.tsx` (the bank-connections settings page). No knowledge of migration state. Needs a banner.
+- `frontend/src/app/settings/bank-connections/callback/page.tsx` (OAuth callback handler). Works for upgrade-by-OAuth.
+- `frontend/src/components/bank-connections/akahu-setup-dialog.tsx` (Personal token entry). Unchanged.
+
+**Health & background jobs:**
+- `src/Infrastructure/MyMascada.Infrastructure/Services/Health/AkahuHealthCheck.cs` — likely calls the API with a configured token. Doesn't reference IDs directly but post-cutover failures may surface here. Sanity check.
+- `src/Infrastructure/MyMascada.Infrastructure/BackgroundJobs/TokenRevocationRetryJobService.cs` — retries token revocation; unaffected.
+
+### 3.3 Database indexes & FK considerations
+
+The unique-ish index on `BankConnection.ExternalAccountId` (`ApplicationDbContext.cs:419-420`) is non-unique, which is correct — we don't want to enforce uniqueness while two connections (classic + official) might transiently exist. Good. No schema change required for the ID rewrite itself.
+
+For the migration-time data-fix we'll want a single SQL transaction per user that:
+- updates `BankConnection.ExternalAccountId` for each acc-id
+- rewrites the encrypted `AkahuConnectionSettings.AkahuAccountId` (re-encrypt with new value)
+- updates `Transaction.ExternalId` for every `trans_xxx` whose new equivalent we have from the `_migrated` map
+
+EF Core can do this in-memory but for the transaction set (potentially thousands per user) a raw SQL `UPDATE Transactions SET ExternalId = CASE … END WHERE ExternalId IN (…)` would be cleaner. See section 4.4.
+
+---
+
+## 4. Concrete remediation strategy
+
+### 4.1 Strategy overview
+
+Two operational paths, both required:
+
+**Path A — Server-side correlation (engineer):** code that, given an old account ID and a user, can:
+1. Fetch `GET /accounts` with current credentials
+2. Identify migrated accounts via `_migrated`
+3. Rewrite stored `acc_xxx` in `BankConnection` and `AkahuConnectionSettings`
+4. Fetch `GET /accounts/{new}/transactions?start=<oldest-imported-date>` and build `_migrated` map for transactions
+5. Rewrite `Transaction.ExternalId` for the user's transactions on that account
+6. Mark the connection's "migration complete" timestamp
+
+**Path B — User-driven re-OAuth (UI + UX):** a banner / dialog that:
+1. Detects classic big-4 connections that haven't been migrated
+2. Surfaces the per-bank "Upgrade" button
+3. Drives the user through the existing OAuth flow with `connection=<classic-conn-id>` query param
+4. On callback, kicks off Path A automatically for the relevant connection
+
+### 4.2 Add MIGRATE webhook handling
+
+**File:** `src/Core/MyMascada.Application/Features/BankConnections/DTOs/AkahuWebhookModels.cs`
+
+Add `Migrate` (or extend `AkahuWebhookCodes` with `MIGRATE` depending on what Q2 confirms). Add fields:
+
+```csharp
+[JsonPropertyName("previous_item_id")]
+public string? PreviousItemId { get; init; }
+
+[JsonPropertyName("new_item_id")]
+public string? NewItemId { get; init; }
+```
+
+**File:** `src/Core/MyMascada.Application/Features/BankConnections/Commands/ProcessAkahuWebhookCommand.cs`
+
+Add a `HandleMigrateEventAsync` branch:
+
+1. Look up `BankConnection` by `previous_item_id` (`GetByExternalAccountIdAsync`).
+2. If found, queue a `MigrateAkahuConnectionCommand` (section 4.3) for that connection. Do NOT do the heavy `Transaction` rewrite inside the webhook handler — webhooks should complete quickly. Use Hangfire / the existing background sync job infrastructure.
+3. If not found, log and accept the webhook (it'll get picked up on next user-initiated sync).
+
+### 4.3 New command: `MigrateAkahuConnectionCommand`
+
+**Path:** `src/Core/MyMascada.Application/Features/BankConnections/Commands/MigrateAkahuConnectionCommand.cs` (new file)
+
+Inputs: `UserId`, `BankConnectionId` (or `OldExternalAccountId`).
+Behaviour:
+1. Load `BankConnection`, `AkahuUserCredential`.
+2. Decrypt tokens (`appIdToken`, `userToken`).
+3. Call `_apiClient.GetAccountsWithCredentialsAsync(appIdToken, userToken, ct)` → list of `AkahuAccountInfo`.
+4. Find the account whose `_migrated` equals `connection.ExternalAccountId`. (Requires plumbing `_migrated` through `AkahuAccount` and `AkahuAccountInfo` — see 4.5.)
+5. If not found, mark connection with `LastSyncError = "Awaiting re-authorisation"` and bail.
+6. If found, compute `newAccountId = account._id`.
+7. Update `BankConnection.ExternalAccountId = newAccountId`; re-encrypt `AkahuConnectionSettings` with `AkahuAccountId = newAccountId`.
+8. For the transaction set: call `_apiClient.GetTransactionsAsync(appIdToken, userToken, newAccountId, oldestImportedDate, today, ct)`. Each `AkahuTransaction` carries `_migrated` (need to add field on the model — section 4.5). Build `{old_trans_id -> new_trans_id}` map.
+9. In a single transaction, `UPDATE Transactions SET ExternalId = newMap[ExternalId] WHERE AccountId = connection.AccountId AND ExternalId IN (oldIds)`.
+10. Walk open `ReconciliationItem`s for this account whose `BankReferenceData` JSON contains an old `trans_xxx` and rewrite the JSON. (Optional — see 4.7 for the simpler "force-close open reconciliations" alternative.)
+11. Trigger a normal `BankSyncService.SyncAccountAsync(connection.Id, BankSyncType.Initial, ct)` to pick up the post-migration delta.
+12. Audit-log the migration with old/new IDs, count of transactions remapped, timestamp.
+
+This command is also the unit that gets invoked from:
+- `MIGRATE` webhook handler
+- Post-OAuth-callback in `ExchangeAkahuCodeQuery` (after a successful upgrade re-auth, iterate all of this user's active big-4 connections and call `MigrateAkahuConnectionCommand` for each)
+- A new admin/debug REST endpoint `POST /api/bankconnections/{id}/migrate-akahu` so Rodrigo can manually trigger it during testing
+- A best-effort background job that scans for any big-4 `BankConnection` where the next sync returns 404 and tries the migration
+
+### 4.4 Update `AkahuAccountInfo` / `AkahuTransaction` / `AkahuConnection` to expose `_migrated` and `_classic`
+
+**File:** `src/Infrastructure/MyMascada.Infrastructure/Services/BankIntegration/Providers/AkahuApiClient.cs`
+
+Add to `AkahuAccount` (line 459):
+```csharp
+[JsonPropertyName("_migrated")]
+public string? Migrated { get; init; }
+```
+
+Add to `AkahuConnection` (line 482):
+```csharp
+[JsonPropertyName("_classic")]
+public string? Classic { get; init; }
+```
+
+Add to `AkahuTransaction` (line 490):
+```csharp
+[JsonPropertyName("_migrated")]
+public string? Migrated { get; init; }
+```
+
+Add `Migrated`/`Connection.Classic` to `AkahuAccountInfo` and `BankTransactionDto` so `AkahuBankProvider.MapTransaction` and `MapToAccountInfo` can pass them up the stack.
+
+**File:** `src/Core/MyMascada.Application/Common/Interfaces/IAkahuApiClient.cs` — extend `AkahuAccountInfo` with `Migrated` / `Classic` properties.
+
+Add a new method to `IAkahuApiClient` that calls `GET /connections` (currently MyMascada has no wrapper). Used to detect which big-4 banks the user has classic-vs-official pairs for:
+```csharp
+Task<IReadOnlyList<AkahuConnectionInfo>> GetConnectionsWithCredentialsAsync(
+    string appIdToken, string userToken, CancellationToken ct = default);
+```
+The response shape from `GET /connections` includes `_id`, `name`, `logo`, `_classic` (when applicable).
+
+### 4.5 Loosen dedup tolerance during the migration window
+
+**File:** `src/Infrastructure/MyMascada.Infrastructure/Services/BankIntegration/BankSyncService.cs:139-143`
+
+Add a config option (e.g. `AkahuOptions.MigrationFallbackEnabled = true`) that, when set, runs sync with `DateToleranceDays = 2`, `AmountTolerance = 0.005m`, and bumps `DescriptionSimilarityThreshold` to 0.7. This catches cases where Akahu's stated date/type/description drift produces near-duplicates that the exact-match dedup misses.
+
+Apply this only to `ProviderId == "akahu"` and only when the connection has a `LastMigratedAt` within the last 30 days, to avoid permanently weakening dedup on the well-tested classic path.
+
+### 4.6 Per-bank consent metadata
+
+`AkahuUserCredential` currently has one set of consent timestamps per user. Once a user does two upgrades on different days (ANZ now, ASB next week), only the most recent will be reflected — which is misleading for audit/compliance.
+
+Two options:
+
+- **(a) Move consent metadata to `BankConnection`** — most correct. Add `ConsentGrantedAt`, `ConsentScope`, `ConsentCorrelationId`, `ConsentRevokedAt`, `OfficialConnectionId` (the `conn_xxx`), `IsMigrated`, `MigratedAt` to `BankConnection`. New EF migration. Backfill: set `ConsentGrantedAt = AkahuUserCredential.ConsentGrantedAt`, `OfficialConnectionId = NULL` for all existing rows.
+- **(b) Keep on `AkahuUserCredential`, accept the limitation** — cheaper but degrades the compliance story.
+
+Recommend (a) but it is **not blocking for May 24**. Ship the migration logic first, do this rename in a follow-up PR.
+
+### 4.7 UI/UX for the user-driven upgrade
+
+**File:** `frontend/src/app/settings/bank-connections/page.tsx`
+
+Add a top-of-page banner (`MigrationBanner` component) that:
+- Calls a new query `GET /api/bankconnections/akahu/migration-status` which returns:
+  - `pendingConnections: [{ bankName, classicConnectionId, officialConnectionId, externalAccountId }]`
+  - `deadline: "2026-05-24T23:59:59+12:00"`
+  - `daysRemaining: 9`
+- For each pending connection, shows a row with bank name, "Last synced X days ago", and an "Upgrade" CTA.
+- The Upgrade CTA fires `apiClient.initiateAkahuConnection({ connectionId: classicConnectionId })` — requires extending the `InitiateAkahuRequest` DTO with an optional `connection` param (the Akahu `conn_xxx`) that the backend appends to the OAuth URL via `AkahuApiClient.GetAuthorizationUrl`.
+- After the OAuth callback returns success, automatically kicks off `MigrateAkahuConnectionCommand` for each of the user's affected connections.
+
+**Files modified:**
+- `frontend/src/components/bank-connections/migration-banner.tsx` (new)
+- `frontend/src/lib/api-client.ts` — add `getAkahuMigrationStatus()` and extend `initiateAkahuConnection()` signature.
+- `frontend/src/types/bank-connections.ts` — add `AkahuMigrationStatus`, extend `BankConnection` with `isMigrated`, `migrationDeadline`.
+- `src/Core/MyMascada.Application/Features/BankConnections/Queries/GetAkahuMigrationStatusQuery.cs` (new)
+- `src/WebAPI/MyMascada.WebAPI/Controllers/BankConnectionsController.cs` — add GET endpoint.
+
+Bonus: surface the banner on the dashboard for ~7 days before the deadline, dismissable per-user but capped (the post-revocation state is destructive — better to nag).
+
+### 4.8 Personal-App-mode users
+
+For users who configured Personal Tokens (the existing primary path), the migration still requires them to log into `my.akahu.nz` and re-authorise the big-4 banks. That happens OUTSIDE MyMascada. Once done, their existing User Token continues to work and will return new `acc_xxx` IDs.
+
+Detection: when `BankSyncService.SyncAccountAsync` fails for an active big-4 connection with `UnauthorizedAccessException` or `AkahuApiException(404)`, check (via `GET /accounts` for that user) whether a new account with `_migrated == connection.ExternalAccountId` exists. If yes, run `MigrateAkahuConnectionCommand` automatically. If no, leave the connection in an "Awaiting re-authorisation" state and surface in the UI.
+
+This means **the same `MigrateAkahuConnectionCommand` handles both OAuth-driven and Personal-App-driven upgrades**, which keeps the surface area small.
+
+### 4.9 Rodrigo's own dev/test connections
+
+The 5-user-cap dev environment (Josh's Bitwarden share, expires 7 days from 2026-03-10 — so the token is already expired; Rodrigo needs to ping Josh for a new one) is the only place we can validate the migration code end-to-end. Before deploying anything to production we need:
+
+- A confirmed dev account whose `GET /connections` returns at least one big-4 official connection with `_classic` set.
+- An ability to seed a few transactions on the old account so the rewrite logic has something to chew on.
+- A second dev test where we revoke the classic connection manually and verify the sync gracefully transitions to "Awaiting re-authorisation".
+
+If Josh can't provide a same-day classic-vs-official side-by-side dev account, fall back to a unit-test-driven approach: mock `IAkahuApiClient.GetAccountsWithCredentialsAsync` to return a hand-crafted account list including `_migrated` and unit-test `MigrateAkahuConnectionCommand` against it. The webhook handler can be tested with a hand-crafted JSON payload using `AkahuWebhookController` + a real signature from a test key.
+
+---
+
+## 5. Risk-ordered punch list (what ships when)
+
+### MUST ship before EOD 2026-05-24 (P0 — blocks revocation)
+
+1. **(P0-1)** Communicate to all users with active Akahu big-4 connections: in-app banner (4.7) + email blast. Without this, users won't know they need to re-auth. Lead time: 2 days for copy + email plumbing. **Day 1-2.**
+2. **(P0-2)** Implement `MigrateAkahuConnectionCommand` (4.3) + the model field additions in 4.4 (`_migrated`, `_classic`). This is the core remediation; it must exist before any user re-auths or we lose history. **Day 2-5.**
+3. **(P0-3)** Wire `MigrateAkahuConnectionCommand` into the `ExchangeAkahuCodeQuery` post-callback path so an OAuth-driven re-auth automatically migrates the connection. **Day 5.**
+4. **(P0-4)** Add `MIGRATE` webhook handling (4.2) so users on autosync who re-auth via `my.akahu.nz` also get migrated automatically. **Day 5-6.**
+5. **(P0-5)** Loosen dedup tolerance during migration (4.5) — small change, big safety net against the data-corruption risk. **Day 6.**
+6. **(P0-6)** Add migration-status banner UI (4.7). **Day 6-8.**
+7. **(P0-7)** Test against dev environment end-to-end (need Josh's renewed dev token; section 4.9). **Day 7-8.**
+8. **(P0-8)** Production smoke test with Rodrigo's own connections (after he migrates them). **Day 8-9.**
+
+### SHOULD ship but can wait until post-24 May (P1 — degraded but not broken)
+
+9. **(P1-1)** Move consent metadata to `BankConnection` (4.6). Better audit story but not user-visible.
+10. **(P1-2)** Rewrite stale `trans_xxx` inside `ReconciliationItem.BankReferenceData` JSON during `MigrateAkahuConnectionCommand` (instead of leaving them as zombie pointers). Alternative: force-close any open reconciliation for a big-4 account before its `MigrateAkahuConnectionCommand` runs, with a clear UI message.
+11. **(P1-3)** Add `GET /api/bankconnections/akahu/connections` listing the user's classic-vs-official conn objects (helps UI explain *why* the user needs to upgrade).
+12. **(P1-4)** Backfill `BankConnection.IsMigrated = true` for all existing classic connections once they're confirmed migrated (so the banner stops appearing).
+13. **(P1-5)** Update `docs/banking-integration-modes.md` and the Obsidian `Akahu Bank API.md` to document migration handling.
+
+### NICE-TO-HAVE (P2 — only if time permits, or only for Rodrigo's own use)
+
+14. **(P2-1)** Admin endpoint `POST /api/admin/bankconnections/migrate-akahu-all` that scans for unmigrated big-4 connections and runs `MigrateAkahuConnectionCommand` on each. Useful for forcibly cleaning up post-24-May stragglers.
+15. **(P2-2)** Telegram/email notification when a `MIGRATE` webhook fires for a user.
+16. **(P2-3)** Metrics: count of pending vs migrated big-4 connections, exposed on the `/health` endpoint.
+17. **(P2-4)** Confirmation dialog that previews what's going to happen before running `MigrateAkahuConnectionCommand` (probably overkill).
+
+### ROLLBACK / SAFETY
+
+- Keep classic IDs in a sidecar table (`BankConnectionMigrationLog`) for 90 days post-migration so we can reverse if Akahu has a bug.
+- Don't delete the old `Transaction.ExternalId` values — UPDATE them, do not store the old value separately unless we want to track. Decision: store old IDs in `Transaction.Notes` field (already a free-text column) as `[migrated_from:trans_xxx]` so support can trace.
+
+---
+
+## 6. Open questions for Akahu (send today, copy Josh)
+
+In addition to Q1-Q8 in section 2.8, also:
+
+- **Q9:** Is there any way to do a "dry-run" `GET /accounts` against the official connection without the user upgrading? I.e. can we pre-compute the `_migrated` map server-side and rewrite IDs in advance of the user clicking Upgrade?
+- **Q10:** When a Personal-App user goes to `my.akahu.nz` and upgrades a connection there, is the existing User Token preserved or invalidated?
+- **Q11:** Are webhooks subscribed under the classic connection automatically re-pointed to the official connection post-migration, or do we need to resubscribe?
+- **Q12:** For credit-card accounts where the cardholder restriction kicks in, what does `GET /accounts` return for a non-account-holder user — an empty list, an explicit error, or the account with a restricted-data flag?
+- **Q13:** Does Akahu emit a single `MIGRATE` event per account or one per `conn_xxx`? If per-account, we may receive many events for a multi-account user.
+
+---
+
+## 7. Acceptance criteria
+
+The migration is "done" when:
+
+- [ ] All four banks (ANZ/ASB/BNZ/Westpac) have `MIGRATE` webhook handling exercised by an end-to-end test using a sandbox account.
+- [ ] A simulated `BankSyncService.SyncAccountAsync` call for a pre-migration `acc_xxx` returns a clear `LastSyncError = "Awaiting re-authorisation"` and surfaces in the UI.
+- [ ] A simulated re-OAuth flow correctly invokes `MigrateAkahuConnectionCommand`, which (verified in DB) rewrites both `BankConnection.ExternalAccountId` and at least 5 sample `Transaction.ExternalId` rows.
+- [ ] A second sync after migration imports zero new transactions for the previously-imported window (no duplicates).
+- [ ] The migration banner is present and dismissable in the bank-connections settings page.
+- [ ] Email blast to existing big-4-connected users has been sent at least 5 days before the deadline.
+- [ ] Rodrigo has personally migrated his own ANZ test connection and confirmed his historical transaction view is intact.
+
+---
+
+## 8. Critical files for implementation
+
+These are the files an implementer will spend ~80% of their time in:
+
+- `src/Infrastructure/MyMascada.Infrastructure/Services/BankIntegration/Providers/AkahuApiClient.cs` — add `_migrated`/`_classic` to response models, add `GetConnectionsWithCredentialsAsync` method.
+- `src/Core/MyMascada.Application/Features/BankConnections/Commands/ProcessAkahuWebhookCommand.cs` — add `HandleMigrateEventAsync` branch and update `AkahuWebhookModels.cs` alongside.
+- `src/Infrastructure/MyMascada.Infrastructure/Services/BankIntegration/BankSyncService.cs` — loosen dedup tolerance during migration window, plus surface re-auth-required errors.
+- `src/Core/MyMascada.Application/Features/BankConnections/Queries/ExchangeAkahuCodeQuery.cs` — chain `MigrateAkahuConnectionCommand` into the post-OAuth flow.
+- `frontend/src/app/settings/bank-connections/page.tsx` — add migration banner and per-connection upgrade CTA.
+
+(Secondary but important: `AkahuBankProvider.cs`, the new `MigrateAkahuConnectionCommand.cs`, `AkahuWebhookModels.cs`, `BankConnection.cs` if we go with the consent-metadata move in 4.6, and the new GET migration-status query handler.)

--- a/docs/plans/akahu-migration-impact.md
+++ b/docs/plans/akahu-migration-impact.md
@@ -137,7 +137,7 @@ We should send these to hello@akahu.nz today, copying Josh, and ask for written 
 
 ## 3. Code audit — every place that persists or matches on Akahu IDs
 
-All paths are absolute under `/Volumes/SabrentSSD/Source/source/mymascada`.
+All paths below are relative to the repository root.
 
 ### 3.1 Persisted identifiers (database)
 

--- a/docs/plans/akahu-webhook-subscription-wiring.md
+++ b/docs/plans/akahu-webhook-subscription-wiring.md
@@ -1,0 +1,398 @@
+# Akahu Webhook Subscription Wiring — Design Doc
+
+**Status:** Proposed
+**Date:** 2026-05-15
+**Hard deadline context:** Akahu Official Open Banking migration on 24 May 2026 (9 days out).
+
+---
+
+## 1. Current state
+
+### 1.1 Webhook receive path (already in production)
+
+| Component | File | Notes |
+|---|---|---|
+| HTTP endpoint | `src/WebAPI/MyMascada.WebAPI/Controllers/AkahuWebhookController.cs` | `POST /api/webhooks/akahu`, `[AllowAnonymous]`. Reads raw body (line 51-54), checks `X-Akahu-Signature` + `X-Akahu-Signing-Key` (lines 57-72), enforces replay protection via SHA-256 of body cached for 24 h (lines 75-102), dispatches `ProcessAkahuWebhookCommand` (line 99). Always returns 200 to suppress Akahu retries. |
+| Signature verification | `src/Infrastructure/MyMascada.Infrastructure/Services/BankIntegration/Providers/AkahuWebhookSignatureService.cs` | Registered via typed `HttpClient` at `BankProviderServiceExtensions.cs:56`. |
+| Payload DTO | `src/Core/MyMascada.Application/Features/BankConnections/DTOs/AkahuWebhookModels.cs` | `AkahuWebhookPayload` carries `webhook_type`, `webhook_code`, `state`, `item_id`, `updated_fields`, `new_transactions[_ids]`, `removed_transactions`. Constants `AkahuWebhookTypes` and `AkahuWebhookCodes`. **Missing:** no `MIGRATE` or `WEBHOOK_CANCELLED` codes; no `previous_item_id`/`new_item_id` fields. |
+| Handler | `src/Core/MyMascada.Application/Features/BankConnections/Commands/ProcessAkahuWebhookCommand.cs` | Dispatches by `webhook_type`. `TryParseUserId(payload.State)` (line 217) already assumes `state` is the user GUID — confirms the contract this doc adopts. Hands off transaction events to `IBankSyncService.SyncAccountAsync` (line 135, 185); marks connections inactive on `TOKEN/DELETE` and `ACCOUNT/DELETE`. |
+
+### 1.2 Subscription client (built, never invoked)
+
+| Method | File | Lines |
+|---|---|---|
+| `SubscribeToWebhookAsync(appIdToken, userToken, webhookType, state, ct)` | `src/Infrastructure/MyMascada.Infrastructure/Services/BankIntegration/Providers/AkahuApiClient.cs` | 336-346 — `POST /webhooks` with `{ webhook_type, state }`. **Does not return the created `webhook_id` to the caller.** |
+| `UnsubscribeFromWebhookAsync(appIdToken, userToken, webhookId, ct)` | same | 351-358 — `DELETE /webhooks/{webhookId}`. |
+| `ListWebhooksAsync(appIdToken, userToken, ct)` | same | 363-378 — returns `AkahuWebhookSubscriptionInfo` records with `Id`, `WebhookType`, `State`. |
+| Interface | `src/Core/MyMascada.Application/Common/Interfaces/IAkahuApiClient.cs` | 78-102. |
+
+A repo-wide grep confirms `SubscribeToWebhookAsync` is **only referenced from `AkahuApiClient.cs` and its interface** — no production caller. That is the gap this design closes.
+
+### 1.3 OAuth completion flow
+
+The flow that yields a usable user token (the only time we have what's needed to subscribe) is:
+
+1. `InitiateAkahuConnectionCommand` — generates state, returns auth URL.
+2. User consents at Akahu, redirected back with `code` + `state`.
+3. **`ExchangeAkahuCodeQuery`** (`src/Core/MyMascada.Application/Features/BankConnections/Queries/ExchangeAkahuCodeQuery.cs`) — exchanges code for token (line 89), upserts `AkahuUserCredential` with the encrypted `app_token + user_token` (lines 100-129), returns the list of selectable accounts. **This is the moment we receive a fresh user token tied to a known `UserId`.** This is the natural anchor for subscription creation.
+4. `CompleteAkahuConnectionCommand` — runs once *per Akahu account the user maps to a MyMascada account*. It uses the already-stored credentials; it can be invoked 0, 1, or N times after step 3 (e.g. user has ANZ + Amex behind the same Akahu token and links them in two separate clicks). **Subscribing here would either over-subscribe per account or, if guarded, depend on user reaching this step at all.**
+
+The same `AkahuUserCredential` is also written by `SaveAkahuCredentialsCommand` (Personal-App mode, `src/Core/MyMascada.Application/Features/BankConnections/Commands/SaveAkahuCredentialsCommand.cs`) — credentials supplied directly, no OAuth round-trip. Webhooks should be subscribed here too, since this is the other on-ramp.
+
+### 1.4 Disconnect / delete paths (need updates)
+
+- `DisconnectBankConnectionCommandHandler` (`src/Core/MyMascada.Application/Features/BankConnections/Commands/DisconnectBankConnectionCommand.cs`) — revokes the user token at lines 72-131. **Note:** it revokes the *entire user-level token*, killing every Akahu connection for that user. That is consistent with the per-user (not per-connection) token model documented at `AkahuUserCredential.cs:11-15`. After revocation, all Akahu-side webhook subscriptions for that user are effectively dead, but the rows are still in the local DB unless we clean up.
+- `UserDataDeletionService` (`src/Infrastructure/MyMascada.Infrastructure/Services/UserData/UserDataDeletionService.cs`) — revokes the Akahu token at lines 337-361 then deletes `AkahuUserCredentials` (line 364). Same observation: cleanup of webhook subscription records on our side is missing.
+
+### 1.5 Schema state
+
+`AkahuUserCredential` (`src/Core/MyMascada.Domain/Entities/AkahuUserCredential.cs`) holds tokens, consent metadata, revocation-retry tracking. **No webhook-subscription columns or related entity exists.** DbContext mapping at `src/Infrastructure/MyMascada.Infrastructure/Data/ApplicationDbContext.cs:450-465` (unique index on UserId, soft-delete query filter). Latest migration to that table: `20260326062213_AddTokenRevocationTracking.cs`.
+
+### 1.6 Akahu webhook API behaviour (confirmed via Akahu reference)
+
+The `developers.akahu.nz` reference for `POST /webhooks` confirms:
+
+- Required body: `webhook_type` + `state`; auth via `X-Akahu-Id` + `Bearer user_token` (matches `AkahuApiClient.CreateAuthenticatedRequest` already used at line 338).
+- Valid `webhook_type` values: **`TOKEN`, `ACCOUNT`, `TRANSACTION`, `PAYMENT`, `TRANSFER`** (latter two not in scope today).
+- The `state` field is echoed back verbatim — Akahu explicitly recommends putting "a unique identifier related to your end user" there.
+- The reference enumerates these `(webhook_type, webhook_code)` combinations:
+  - `TOKEN/DELETE`
+  - `ACCOUNT/CREATE`, `ACCOUNT/UPDATE`, `ACCOUNT/DELETE`, `ACCOUNT/MIGRATE`, `ACCOUNT/WEBHOOK_CANCELLED`
+  - `TRANSACTION/INITIAL_UPDATE`, `TRANSACTION/DEFAULT_UPDATE`, `TRANSACTION/DELETE`, `TRANSACTION/WEBHOOK_CANCELLED`
+- **`ACCOUNT/MIGRATE`** — emitted when an account is migrated from classic to "official open banking" — payload includes `previous_item_id` and `new_item_id`. This is migration-critical (see §4).
+- The reference does **not** document idempotency of POST /webhooks. The conservative assumption is that POSTing the same `(webhook_type, state)` again creates a duplicate subscription. The design treats it as non-idempotent and reconciles via `GET /webhooks` (`ListWebhooksAsync` is already implemented).
+- Akahu's "Official Open Banking" landing page is silent on whether the webhook subscription set persists across the migration. **Assumption:** subscriptions persist (the API surface is unchanged), but the design includes a reconciliation job that would heal a wipe scenario.
+
+---
+
+## 2. Target state
+
+After **any** path that successfully establishes a valid `AkahuUserCredential` for a user (OAuth exchange in `ExchangeAkahuCodeQueryHandler` OR Personal-App save in `SaveAkahuCredentialsCommandHandler`), the user has exactly one active Akahu subscription per type:
+
+| `webhook_type` | Why we need it | Handled by `ProcessAkahuWebhookCommand` today? |
+|---|---|---|
+| `TRANSACTION` | DEFAULT_UPDATE = new/changed transactions, INITIAL_UPDATE = first historical pull, DELETE = removals | yes (lines 152-199) |
+| `ACCOUNT` | CREATE/UPDATE/DELETE/MIGRATE for balance and lifecycle. Need to add MIGRATE handling. | partially — adds: MIGRATE |
+| `TOKEN` | DELETE = user revoked at Akahu side, must mark connections inactive | yes (lines 69-96) |
+
+For each subscription we persist:
+- the returned **`webhook_id`** (currently thrown away by `AkahuApiClient.SubscribeToWebhookAsync`),
+- the `webhook_type`,
+- linkage to `AkahuUserCredential.UserId` (1:N relationship: one credential → up to ~3 subscriptions).
+
+The `state` value we register is **always the user GUID in `"N"` format** (`UserId.ToString("N")`) — matching `ProcessAkahuWebhookCommand.TryParseUserId` (which accepts any `Guid.TryParse`-compatible form).
+
+Disconnect / data-deletion paths tear down the stored subscriptions by calling `UnsubscribeFromWebhookAsync` for each `webhook_id`, then deleting the rows.
+
+A reconciliation job heals drift between MyMascada's stored subscription rows and Akahu's authoritative list (`GET /webhooks`).
+
+---
+
+## 3. Design decisions
+
+### 3.1 Where the subscribe call lives
+
+**Decision:** introduce a dedicated `IAkahuWebhookSubscriptionService` in the Application layer.
+
+- Interface: `src/Core/MyMascada.Application/Common/Interfaces/IAkahuWebhookSubscriptionService.cs`
+- Implementation: `src/Infrastructure/MyMascada.Infrastructure/Services/BankIntegration/Providers/AkahuWebhookSubscriptionService.cs`
+- Public surface:
+  - `Task EnsureSubscriptionsAsync(Guid userId, CancellationToken ct)` — idempotent: looks up the user's credential, computes required types minus already-persisted-and-confirmed types, calls `Subscribe…` for the missing ones, persists the returned IDs.
+  - `Task TearDownSubscriptionsAsync(Guid userId, CancellationToken ct)` — for disconnect/delete; iterates over persisted rows, calls `Unsubscribe…`, deletes rows. Tolerates 404s and HTTP failures.
+  - `Task<ReconcileResult> ReconcileAsync(Guid userId, CancellationToken ct)` — calls `ListWebhooksAsync`, compares to local rows, fixes drift.
+
+**Where it's called from:**
+
+| Caller | When |
+|---|---|
+| `ExchangeAkahuCodeQueryHandler` | After `_credentialRepository.AddAsync/UpdateAsync` succeeds (currently `ExchangeAkahuCodeQuery.cs:101-129`), **before** the accounts list is fetched on line 132. |
+| `SaveAkahuCredentialsCommandHandler` | After Add/Update at `SaveAkahuCredentialsCommand.cs:100-117`. |
+| `DisconnectBankConnectionCommandHandler` | Right before `RevokeTokenAsync` at `DisconnectBankConnectionCommand.cs:85`, and only when **this disconnect is the user's last active Akahu connection** (because subscriptions are user-scoped, not per-MyMascada-connection). Add a guard: `if (otherActiveAkahuConnectionsCount == 0) await TearDownSubscriptionsAsync(...)`. |
+| `UserDataDeletionService` | New step between current step 31 (revoke token) and step 32 (delete `AkahuUserCredentials`) at `UserDataDeletionService.cs:337-364`. Call `TearDownSubscriptionsAsync` first; tolerate errors (subscriptions die when the token is revoked anyway, so this is best-effort cleanup at Akahu). |
+
+**Why not put it directly inline in the OAuth handler?** Three reasons:
+1. The same logic is needed from at least four call sites — a service avoids duplication.
+2. Easier to unit-test failure modes (3 subscribe calls × success/transient/permanent failure).
+3. Lets the reconciliation Hangfire job reuse the same code path.
+
+**Why not a MediatR `INotification` raised after credential save?** Considered but rejected:
+- The codebase doesn't currently publish domain events from these handlers — adding the pattern just for this is more disruptive than a single new service.
+- The fire-and-forget feel of a notification handler obscures the explicit failure-handling decisions documented in §3.3.
+- We want the subscription work to occur inside the same `CancellationToken` and transactional scope as the credential save.
+
+### 3.2 Where the `webhook_id`s get persisted
+
+Three options were considered:
+
+| Option | Pros | Cons | Verdict |
+|---|---|---|---|
+| New JSONB column on `AkahuUserCredential` storing `{ TRANSACTION: "wh_...", ACCOUNT: "wh_...", TOKEN: "wh_..." }` | No new table, smallest migration | JSONB queries are awkward in EF; can't easily query "all subscriptions of type X"; can't model per-subscription metadata (last-confirmed-at, status); doesn't extend if Akahu adds new types | Reject |
+| Columns on `BankConnection` | Co-located with existing connection record | Subscriptions are **user-scoped** in Akahu, not per `BankConnection`. Storing on each `BankConnection` would either duplicate or require designating a "primary" connection — both ugly | Reject |
+| **New entity `AkahuWebhookSubscription`** | Models the relationship correctly (`AkahuUserCredentialId` FK, one row per `(userId, webhookType)`); easy to add per-row fields (last_seen, status); reconciliation is a straightforward LEFT JOIN | New table, EF migration | **Adopt** |
+
+**Schema** (`src/Core/MyMascada.Domain/Entities/AkahuWebhookSubscription.cs`):
+
+```
+class AkahuWebhookSubscription : BaseEntity (int id, soft-delete inherited)
+    Guid     UserId               (FK semantics; also indexed on AkahuUserCredentialId)
+    int      AkahuUserCredentialId
+    string   WebhookId            (Akahu "_id", e.g. "whk_xxx") — MaxLength(100), Required
+    string   WebhookType          (TOKEN | ACCOUNT | TRANSACTION) — MaxLength(40), Required
+    string?  State                (echo of what we registered = user GUID in "N" form)
+    DateTime SubscribedAt
+    DateTime? LastReconciledAt
+    string?  LastReconcileError   MaxLength(500)
+```
+
+- Unique index on `(UserId, WebhookType)` (filtered `WHERE IsDeleted = false`) so re-OAuth doesn't silently create duplicates.
+- Unique index on `WebhookId`.
+- Soft-delete (consistent with the rest of the codebase, e.g. `AkahuUserCredential`).
+
+**DbContext** — add `DbSet<AkahuWebhookSubscription>` plus a configuration block in `ApplicationDbContext.cs` immediately after the existing `AkahuUserCredential` block (around line 466).
+
+**Repository:**
+- Interface `IAkahuWebhookSubscriptionRepository` at `src/Core/MyMascada.Application/Common/Interfaces/IAkahuWebhookSubscriptionRepository.cs`.
+- Impl `AkahuWebhookSubscriptionRepository` at `src/Infrastructure/MyMascada.Infrastructure/Repositories/AkahuWebhookSubscriptionRepository.cs`.
+- Methods: `GetByUserIdAsync`, `GetByWebhookIdAsync`, `AddAsync`, `UpdateAsync`, `DeleteByIdAsync`, `DeleteByUserIdAsync`.
+
+**Required `IAkahuApiClient` change:** `SubscribeToWebhookAsync` currently returns `Task` and discards the response body. It must return the created `webhook_id`. Change signature to:
+
+```csharp
+Task<AkahuWebhookSubscriptionInfo> SubscribeToWebhookAsync(
+    string appIdToken, string userToken, string webhookType, string? state = null, CancellationToken ct = default);
+```
+
+(The response shape `AkahuWebhookSubscriptionResponse` is already parsed on the LIST path at `AkahuApiClient.cs:567-574` — the POST endpoint returns the same envelope, so the implementation change is minimal: parse and return.)
+
+### 3.3 Failure handling during subscription creation
+
+Decision matrix:
+
+| Outcome | OAuth flow visible behaviour | Background remediation |
+|---|---|---|
+| All 3 subscribes succeed | normal | none |
+| 1-2 of 3 fail with a transient error (5xx / 429 / network) | **OAuth completion still succeeds** (user sees their accounts list). Persisted subscription rows reflect what worked. | Reconciliation job (§3.7) retries the missing ones on next run. |
+| All 3 fail | **OAuth completion still succeeds.** Log an `Error` with the user GUID. | Reconciliation job retries. |
+| Subscribe returns 401/403 (token rejected) | OAuth completion still succeeds (no point failing the OAuth flow after we already got valid accounts back — token must work for `/accounts`; if it doesn't work for `/webhooks` there's an Akahu-side glitch). | Reconciliation job will fail too; record `LastReconcileError`; surface in admin dashboard later. |
+
+**Rationale:** webhooks accelerate freshness — they are not a hard requirement for the product. Polling/manual sync remains a fallback. Failing OAuth completion because a webhook subscription POST timed out would be a UX disaster, and the reconciliation job catches the gap within a day.
+
+**Implementation:** the `EnsureSubscriptionsAsync` method wraps each individual `SubscribeToWebhookAsync` in its own try/catch, logs warnings, never throws. Returns a small result describing successes/failures for observability, but the caller (OAuth handler) does **not** propagate the failures.
+
+### 3.4 Teardown on disconnect / account-delete
+
+`DisconnectBankConnectionCommand` disconnects **one MyMascada↔Akahu mapping**, not the user-level credential. Today it always revokes the user-level token (lines 85-95), implicitly killing all Akahu connections. Given that, the teardown rule is:
+
+- Before revoking the token, call `IAkahuWebhookSubscriptionService.TearDownSubscriptionsAsync(userId, ct)` — this performs `DELETE /webhooks/{id}` for each persisted row, then deletes the rows.
+- Tolerate 404 from Akahu (subscription already gone) and transient errors (the token revoke that follows kills the subscription server-side anyway).
+- After the local rows are gone, the existing `DeleteByUserIdAsync` call on the credential repository at `ProcessAkahuWebhookCommand.cs:95` (for the `TOKEN/DELETE` webhook path) needs an equivalent purge — the webhook handler should also tear down sub rows when Akahu informs us the token is revoked.
+
+> **Refinement worth surfacing:** the broad "revoke token kills all of this user's Akahu" semantics in `DisconnectBankConnectionCommand` is preexisting. Per-connection-only disconnect would need a more elaborate redesign — out of scope (§6).
+
+`UserDataDeletionService`:
+
+- Insert a new step between step 31 (revoke token) and step 32 (delete `AkahuUserCredentials`):
+  ```
+  31b. Delete AkahuWebhookSubscriptions (best-effort unsubscribe at Akahu, then ExecuteDeleteAsync local rows)
+  ```
+- Schema-level: the delete of `AkahuUserCredentials` cascades to `AkahuWebhookSubscription` via the FK — but we do the explicit pass first so we can call Akahu's unsubscribe endpoint while the tokens are still decryptable. After the loop, `ExecuteDeleteAsync` covers anything that survived.
+
+Webhook-driven teardown (`TOKEN/DELETE`): `ProcessAkahuWebhookCommandHandler.HandleTokenEventAsync` (line 69) currently calls `_credentialRepository.DeleteByUserIdAsync(userId, ct)` at line 95. Add a sibling call to delete local subscription rows (Akahu has already cancelled them upstream, so no need to call DELETE /webhooks).
+
+### 3.5 Idempotency on re-OAuth
+
+Multiple ways a user can land on the same path with existing subscriptions:
+
+1. Re-OAuth flow — user clicks "Connect Akahu" again to add another bank network. `ExchangeAkahuCodeQueryHandler` upserts the credential.
+2. User saves new Personal-App tokens via `SaveAkahuCredentialsCommandHandler`.
+3. Hangfire reconciliation job runs.
+
+`EnsureSubscriptionsAsync` rules:
+
+1. Fetch local `AkahuWebhookSubscription` rows for `(userId)`.
+2. Optionally call `ListWebhooksAsync` once (for sanity) — cache result locally.
+3. For each of `{TOKEN, ACCOUNT, TRANSACTION}`:
+   - **Local row exists AND Akahu list contains a matching `_id`:** skip (already healthy).
+   - **Local row exists, Akahu list does NOT contain it:** Akahu lost the subscription (or migration wiped it). Delete the stale local row, then re-subscribe and persist the new row.
+   - **No local row, Akahu has a matching `(webhook_type, state)`:** adopt — persist the Akahu `_id` as our row without POSTing again.
+   - **No local row, no Akahu row:** POST `/webhooks`, persist.
+
+The `ListWebhooksAsync` call on every OAuth completion adds one extra Akahu request; the trade-off is correctness in the face of token rotation / partial-failure states. This is acceptable — OAuth completion is rare.
+
+When the user has multiple Akahu connections and re-OAuths to add a third, the subscriptions stay scoped to the (single) `AkahuUserCredential`, which is exactly the right shape.
+
+### 3.6 New `ACCOUNT/MIGRATE` handling
+
+Mandatory for the migration deadline. In `ProcessAkahuWebhookCommandHandler.HandleAccountEventAsync` (file `ProcessAkahuWebhookCommand.cs:98-118`), add a `MIGRATE` case:
+
+- Required new payload fields: extend `AkahuWebhookPayload` with `PreviousItemId` (`previous_item_id`) and `NewItemId` (`new_item_id`).
+- New `AkahuWebhookCodes.Migrate = "MIGRATE"` constant in `AkahuWebhookModels.cs`.
+- Handler: look up `BankConnection` by `(previous_item_id, "akahu")`; update `ExternalAccountId = new_item_id`. Persist. Optionally trigger a sync.
+- Also handle `WEBHOOK_CANCELLED` — log and delete the local `AkahuWebhookSubscription` row matching the `state` (so the reconciliation job re-creates it next pass).
+
+> **Cross-reference:** the sibling doc `docs/plans/akahu-migration-impact.md` §4.2-4.3 describes a heavier `MigrateAkahuConnectionCommand` that also rewrites `Transaction.ExternalId`. The webhook handler should enqueue that command rather than do the heavy work inline.
+
+### 3.7 Reconciliation Hangfire job
+
+`AkahuWebhookSubscriptionReconciliationJobService` modeled after `TokenRevocationRetryJobService.cs`:
+
+- Interface: `src/Core/MyMascada.Application/BackgroundJobs/IAkahuWebhookSubscriptionReconciliationJobService.cs`.
+- Impl: `src/Infrastructure/MyMascada.Infrastructure/BackgroundJobs/AkahuWebhookSubscriptionReconciliationJobService.cs`.
+- DI: register in `BackgroundJobServiceExtensions.cs` alongside the other revocation services (line 47-49).
+- Schedule: in `Program.cs` next to the other `recurringJobManager.AddOrUpdate` calls (around line 461) — daily at 04:00 NZ time-equivalent UTC.
+- Iterates: every active, non-soft-deleted `AkahuUserCredential` whose `ConsentRevokedAt is null`. For each, call `EnsureSubscriptionsAsync`.
+
+This is the safety net for §3.3 failures.
+
+---
+
+## 4. Migration compatibility (24 May 2026)
+
+| Concern | Impact on this design |
+|---|---|
+| Webhook subscription API (`POST/DELETE/GET /webhooks`) | Documented as unchanged — auth via `X-Akahu-Id` + `Bearer user_token` still applies. Our `AkahuApiClient` request-building works against both classic and official tokens. |
+| OAuth flow shape | A parallel agent is analysing OAuth changes (see `docs/plans/akahu-migration-impact.md`). Our subscription wiring is decoupled — it triggers off `ExchangeAkahuCodeQueryHandler` (the post-token-exchange step) which is the same regardless of whether the upstream auth is "classic" or "official". |
+| `state` echo | Confirmed by Akahu docs to remain. We anchor on user-GUID-as-state — survives the migration. |
+| `ACCOUNT/MIGRATE` event | **Critical** — must ship before migration day. Without it, every account that migrates from classic to official will keep its old `item_id` locally while Akahu re-emits transactions under the new `item_id`, causing silent sync breakage. Adding the handler (§3.6) covers this. |
+| Webhook subscription persistence across migration | Akahu's public docs don't promise persistence. The reconciliation job (§3.7) heals any wipe within 24 h. We can also enqueue a one-time job to run shortly after midnight 24 May to force reconciliation across all users — see implementation plan step F.4. |
+| `webhook_type = PAYMENT` / `TRANSFER` | Not used today (we don't initiate payments). Out of scope. |
+
+**Conclusion:** the design is migration-safe **provided** `ACCOUNT/MIGRATE` handling and the reconciliation job ship together.
+
+---
+
+## 5. Step-by-step implementation plan
+
+### Phase A — Schema & domain (single EF migration)
+
+**A.1** Create entity `AkahuWebhookSubscription` at `src/Core/MyMascada.Domain/Entities/AkahuWebhookSubscription.cs` per §3.2 schema.
+
+**A.2** Add `DbSet<AkahuWebhookSubscription>` to `src/Infrastructure/MyMascada.Infrastructure/Data/ApplicationDbContext.cs` (after line 58) and the modelBuilder config block (after the `AkahuUserCredential` block at line 465). Include:
+- HasKey on `Id`.
+- Required properties.
+- Unique index on `WebhookId`.
+- Unique filtered index on `(UserId, WebhookType)` where `IsDeleted = false`.
+- FK to `AkahuUserCredential` via `AkahuUserCredentialId` with `DeleteBehavior.Cascade` (so user-data deletion cleans up).
+- `entity.HasQueryFilter(e => !e.IsDeleted)`.
+
+**A.3** Generate EF migration: `dotnet ef migrations add AddAkahuWebhookSubscription -p src/WebAPI/MyMascada.WebAPI`. New files: `Migrations/202605xx_AddAkahuWebhookSubscription.cs` + `.Designer.cs` and updated `ApplicationDbContextModelSnapshot.cs`.
+
+### Phase B — Repository
+
+**B.1** Interface `src/Core/MyMascada.Application/Common/Interfaces/IAkahuWebhookSubscriptionRepository.cs`:
+`GetByUserIdAsync`, `GetByWebhookIdAsync`, `AddAsync`, `UpdateAsync`, `DeleteByIdAsync`, `DeleteByUserIdAsync`. Soft-delete semantics matching `AkahuUserCredentialRepository`.
+
+**B.2** Impl `src/Infrastructure/MyMascada.Infrastructure/Repositories/AkahuWebhookSubscriptionRepository.cs`.
+
+**B.3** DI registration in `src/WebAPI/MyMascada.WebAPI/Extensions/BankProviderServiceExtensions.cs` next to line 40 (`AkahuUserCredentialRepository`).
+
+### Phase C — API client adjustments
+
+**C.1** Update `IAkahuApiClient.SubscribeToWebhookAsync` signature to return `Task<AkahuWebhookSubscriptionInfo>` (file: `src/Core/MyMascada.Application/Common/Interfaces/IAkahuApiClient.cs` lines 78-84).
+
+**C.2** Update implementation in `src/Infrastructure/MyMascada.Infrastructure/Services/BankIntegration/Providers/AkahuApiClient.cs` (lines 336-346) to parse and return the `AkahuWebhookSubscriptionResponse` envelope (same shape used at LIST endpoint, lines 363-378).
+
+### Phase D — Subscription service
+
+**D.1** Interface `src/Core/MyMascada.Application/Common/Interfaces/IAkahuWebhookSubscriptionService.cs`:
+- `Task<EnsureSubscriptionsResult> EnsureSubscriptionsAsync(Guid userId, CancellationToken ct)`
+- `Task TearDownSubscriptionsAsync(Guid userId, CancellationToken ct)`
+- `Task<ReconcileResult> ReconcileAsync(Guid userId, CancellationToken ct)`
+
+**D.2** Impl `src/Infrastructure/MyMascada.Infrastructure/Services/BankIntegration/Providers/AkahuWebhookSubscriptionService.cs`. Decrypts credentials (via `ISettingsEncryptionService`), iterates required types `{ Transaction, Account, Token }`, calls `IAkahuApiClient.SubscribeToWebhookAsync(appToken, userToken, type, state: userId.ToString("N"))`, persists via repo. Wrap each subscribe call in its own try/catch per §3.3.
+
+**D.3** DI registration in `BankProviderServiceExtensions.cs`.
+
+### Phase E — Call site wiring
+
+**E.1** Inject `IAkahuWebhookSubscriptionService` into `ExchangeAkahuCodeQueryHandler` (file `src/Core/MyMascada.Application/Features/BankConnections/Queries/ExchangeAkahuCodeQuery.cs`). After the credential upsert at line 129, call `EnsureSubscriptionsAsync(request.UserId, cancellationToken)` (fire and continue — failures already swallowed inside the service).
+
+**E.2** Same wiring in `SaveAkahuCredentialsCommandHandler` (`src/Core/MyMascada.Application/Features/BankConnections/Commands/SaveAkahuCredentialsCommand.cs`) after line 117.
+
+**E.3** `DisconnectBankConnectionCommandHandler` (`src/Core/MyMascada.Application/Features/BankConnections/Commands/DisconnectBankConnectionCommand.cs`): before line 85's `RevokeTokenAsync` call, run `TearDownSubscriptionsAsync(request.UserId, cancellationToken)`. Wrap in try/catch — never block disconnect.
+
+**E.4** `UserDataDeletionService` (`src/Infrastructure/MyMascada.Infrastructure/Services/UserData/UserDataDeletionService.cs`): insert call between current line 354 (successful token revocation) and line 363 (delete credentials). Same swallowing pattern.
+
+**E.5** `ProcessAkahuWebhookCommandHandler.HandleTokenEventAsync` (file `src/Core/MyMascada.Application/Features/BankConnections/Commands/ProcessAkahuWebhookCommand.cs`): after `_credentialRepository.DeleteByUserIdAsync(userId, ct)` on line 95, call the subscription repo `DeleteByUserIdAsync(userId, ct)` to purge stale local rows. (No Akahu DELETE call needed — Akahu cancels its end when revoking the token.)
+
+### Phase F — Webhook handler additions for migration
+
+**F.1** Extend `AkahuWebhookModels.cs`:
+- Add `[JsonPropertyName("previous_item_id")] string? PreviousItemId` and `[JsonPropertyName("new_item_id")] string? NewItemId` to `AkahuWebhookPayload`.
+- Add `AkahuWebhookCodes.Migrate = "MIGRATE"` and `AkahuWebhookCodes.WebhookCancelled = "WEBHOOK_CANCELLED"`.
+
+**F.2** Add a `case AkahuWebhookCodes.Migrate:` branch in `HandleAccountEventAsync` (after line 110). New private `HandleAccountMigrateAsync` looks up connection by `previous_item_id`, updates `ExternalAccountId = new_item_id`, persists. Enqueues `MigrateAkahuConnectionCommand` (see sibling doc) for the heavy transaction rewrite.
+
+**F.3** Add `WEBHOOK_CANCELLED` handling — log + delete the matching `AkahuWebhookSubscription` row by `(userId, webhookType)`. Reconciliation job will re-create on next pass.
+
+**F.4** Optional one-time backfill: in `Program.cs`, after the existing recurring registrations (around line 470), enqueue a one-time job before/around 2026-05-24 to call `ReconcileAsync` for every active Akahu user. Documented as a deploy-time toggle; do not commit the job-trigger inside the main path.
+
+### Phase G — Reconciliation background job
+
+**G.1** Interface `src/Core/MyMascada.Application/BackgroundJobs/IAkahuWebhookSubscriptionReconciliationJobService.cs` with `Task ReconcileAllAsync()`.
+
+**G.2** Impl `src/Infrastructure/MyMascada.Infrastructure/BackgroundJobs/AkahuWebhookSubscriptionReconciliationJobService.cs`. Pattern after `TokenRevocationRetryJobService` (file `src/Infrastructure/MyMascada.Infrastructure/BackgroundJobs/TokenRevocationRetryJobService.cs`) — create a scope per credential, swallow per-user errors, track success/fail counts.
+
+**G.3** DI registration in `BackgroundJobServiceExtensions.cs:47-49` block.
+
+**G.4** Schedule in `src/WebAPI/MyMascada.WebAPI/Program.cs` around line 461 — `recurringJobManager.AddOrUpdate(...Daily(4, 0))`. Run at 04:00 server time (after the existing 03:45 revocation retry).
+
+### Phase H — Tests
+
+Place under `tests/MyMascada.Tests.Unit/`.
+
+**H.1** `Services/AkahuWebhookSubscriptionServiceTests.cs` — covers:
+- `EnsureSubscriptionsAsync_NoExistingSubscriptions_SubscribesAllThreeTypes`
+- `EnsureSubscriptionsAsync_OneTypeAlreadySubscribed_SubscribesOnlyMissing`
+- `EnsureSubscriptionsAsync_AllPresentInAkahuButNotLocal_AdoptsRowsWithoutPosting`
+- `EnsureSubscriptionsAsync_TransactionSubscribeFails_OtherTwoStillPersisted`
+- `EnsureSubscriptionsAsync_CredentialNotFound_NoOp`
+- `EnsureSubscriptionsAsync_RegistersStateAsUserGuid`
+- `TearDownSubscriptionsAsync_CallsDeleteForEachRow_Tolerates404`
+- `TearDownSubscriptionsAsync_AkahuUnauthorized_DeletesLocalRowsAnyway`
+- `ReconcileAsync_LocalRowMissingAtAkahu_ReSubscribes`
+
+**H.2** Update `Queries/ExchangeAkahuCodeQueryHandlerTests.cs` (existing file): add assertion that `IAkahuWebhookSubscriptionService.EnsureSubscriptionsAsync` was invoked once with `userId`.
+
+**H.3** New `Commands/SaveAkahuCredentialsCommandHandlerTests.cs` — analogous coverage for Personal-App on-ramp.
+
+**H.4** Update `Commands/DisconnectBankConnectionCommandHandlerTests.cs` (or create if missing) — verify `TearDownSubscriptionsAsync` invoked before `RevokeTokenAsync`.
+
+**H.5** New `Commands/ProcessAkahuWebhookCommandHandlerTests.cs` cases:
+- `AccountMigrate_UpdatesExternalAccountId`
+- `AccountWebhookCancelled_DeletesLocalSubscriptionRow`
+- `TokenDelete_AlsoDeletesSubscriptionRows`
+
+**H.6** Update `Services/AkahuApiClientTests.cs` to cover the new `SubscribeToWebhookAsync` return value parsing — currently no webhook subscribe tests exist.
+
+**H.7** `BackgroundJobs/AkahuWebhookSubscriptionReconciliationJobServiceTests.cs` — one happy-path test mirroring `TokenRevocationRetryJobServiceTests` style if such tests exist.
+
+### Phase I — Documentation
+
+**I.1** Update Obsidian `Projects/MyMascada/Integrations/Akahu Bank API.md` line 53 ("Wire webhook subscription into the OAuth completion flow") — mark complete.
+
+**I.2** Add a section to `docs/banking-integration-modes.md` summarising the subscription-on-credential-save behaviour.
+
+---
+
+## 6. Out of scope (explicitly deferred)
+
+- **Per-MyMascada-connection disconnect that *doesn't* revoke the user-level token.** The user-level token shape means today's disconnect always nukes everything; this design preserves that behaviour. A more granular model needs a separate redesign.
+- **`PAYMENT` and `TRANSFER` webhook types.** Not used in product; will need a separate decision when MyMascada adds initiated-payments support.
+- **Frontend changes.** No UI flow change is required — subscriptions are transparent to the user. The "Connect Akahu" button keeps working as today.
+- **Re-subscribing when a user *only* changes their consent scope** (e.g. adds new bank network without code re-exchange). The reconciliation job covers this within 24 h. If we ever need faster, add a hook on `BankConnection.Add`.
+- **Webhook delivery latency / SLA monitoring.** No new metric or alert is part of this design.
+- **Multi-tenancy of subscriptions** (e.g. shared-account scenarios via `AccountShare`). Each user owns their own credential and subscriptions; sharing only affects view permissions on transactions post-sync.
+- **Replacing `IMemoryCache` replay protection with a distributed cache.** Pre-existing; orthogonal.
+- **Akahu "official open banking" OAuth-flow changes.** See sibling doc — this design depends only on the existing post-credential-save extension point and is decoupled.
+- **Storing per-subscription delivery history.** `AkahuWebhookSubscription.LastReconciledAt` is the minimum needed; a full delivery-log table can come later if observability requires it.
+
+---
+
+## Critical Files for Implementation
+
+- `src/Core/MyMascada.Application/Features/BankConnections/Queries/ExchangeAkahuCodeQuery.cs`
+- `src/Core/MyMascada.Application/Features/BankConnections/Commands/SaveAkahuCredentialsCommand.cs`
+- `src/Infrastructure/MyMascada.Infrastructure/Services/BankIntegration/Providers/AkahuApiClient.cs`
+- `src/Core/MyMascada.Application/Common/Interfaces/IAkahuApiClient.cs`
+- `src/Core/MyMascada.Application/Features/BankConnections/Commands/ProcessAkahuWebhookCommand.cs`

--- a/docs/plans/akahu-webhook-subscription-wiring.md
+++ b/docs/plans/akahu-webhook-subscription-wiring.md
@@ -132,7 +132,7 @@ Three options were considered:
 
 **Schema** (`src/Core/MyMascada.Domain/Entities/AkahuWebhookSubscription.cs`):
 
-```
+```text
 class AkahuWebhookSubscription : BaseEntity (int id, soft-delete inherited)
     Guid     UserId               (FK semantics; also indexed on AkahuUserCredentialId)
     int      AkahuUserCredentialId

--- a/frontend/messages/en.json
+++ b/frontend/messages/en.json
@@ -3067,7 +3067,25 @@
     "appTokenHint": "Starts with \"app_token_\"",
     "userTokenHint": "Starts with \"user_token_\"",
     "verifying": "Verifying...",
-    "saveAndContinue": "Save & Continue"
+    "saveAndContinue": "Save & Continue",
+    "akahuMigration": {
+      "ariaLabel": "Action required: re-authorise your bank connections",
+      "heading": "Action required: re-authorise your bank connections",
+      "body": "Akahu is migrating ANZ, ASB, BNZ and Westpac to official open banking. Re-authorise each connection below to keep your transactions syncing. {daysRemaining, plural, =0 {Deadline is today.} =1 {1 day remaining.} other {# days remaining.}}",
+      "upgrade": "Upgrade",
+      "upgrading": "Opening Akahu...",
+      "dismiss": "Dismiss for today",
+      "row": {
+        "unknownBank": "Bank connection",
+        "lastSynced": "{days, plural, =0 {Last synced today} =1 {Last synced 1 day ago} other {Last synced # days ago}}",
+        "neverSynced": "Never synced"
+      },
+      "toasts": {
+        "initiateFailed": "Could not start the Akahu upgrade. Please try again.",
+        "credentialsMissing": "Set up your Akahu credentials on this page first, then click Upgrade again.",
+        "personalAppFallback": "Open the Connect Bank flow above to relink your migrated account."
+      }
+    }
   },
   "budgets": {
     "title": "Budgets",

--- a/frontend/messages/pt-BR.json
+++ b/frontend/messages/pt-BR.json
@@ -3067,7 +3067,25 @@
     "appTokenHint": "Começa com \"app_token_\"",
     "userTokenHint": "Começa com \"user_token_\"",
     "verifying": "Verificando...",
-    "saveAndContinue": "Salvar e continuar"
+    "saveAndContinue": "Salvar e continuar",
+    "akahuMigration": {
+      "ariaLabel": "Ação necessária: reautorize suas conexões bancárias",
+      "heading": "Ação necessária: reautorize suas conexões bancárias",
+      "body": "O Akahu está migrando ANZ, ASB, BNZ e Westpac para o open banking oficial. Reautorize cada conexão abaixo para continuar sincronizando suas transações. {daysRemaining, plural, =0 {O prazo é hoje.} =1 {Falta 1 dia.} other {Faltam # dias.}}",
+      "upgrade": "Reautorizar",
+      "upgrading": "Abrindo o Akahu...",
+      "dismiss": "Dispensar por hoje",
+      "row": {
+        "unknownBank": "Conexão bancária",
+        "lastSynced": "{days, plural, =0 {Sincronizada hoje} =1 {Sincronizada há 1 dia} other {Sincronizada há # dias}}",
+        "neverSynced": "Nunca sincronizada"
+      },
+      "toasts": {
+        "initiateFailed": "Não foi possível iniciar a atualização do Akahu. Tente novamente.",
+        "credentialsMissing": "Configure suas credenciais do Akahu nesta página primeiro e clique em Reautorizar novamente.",
+        "personalAppFallback": "Abra o fluxo Conectar Banco acima para revincular sua conta migrada."
+      }
+    }
   },
   "budgets": {
     "title": "Orçamentos",

--- a/frontend/src/app/dashboard/page.tsx
+++ b/frontend/src/app/dashboard/page.tsx
@@ -9,6 +9,7 @@ import { apiClient } from '@/lib/api-client';
 import { DashboardProvider } from '@/contexts/dashboard-context';
 import { DashboardHeader } from '@/components/dashboard/dashboard-header';
 import { DashboardTemplateRenderer } from '@/components/dashboard/dashboard-template-renderer';
+import { AkahuMigrationBanner } from '@/components/bank-connections/akahu-migration-banner';
 import { useTranslations } from 'next-intl';
 import { useAuthGuard } from '@/hooks/use-auth-guard';
 import { SkeletonCard, SkeletonPanel } from '@/components/skeletons';
@@ -60,6 +61,11 @@ function DashboardContent() {
     <DashboardProvider>
       <AppLayout mainClassName="relative z-10 flex-1 w-full px-4 py-6 sm:px-5 lg:px-6 lg:py-8">
         <DashboardHeader />
+        {/* TODO(akahu-migration): once a global alerts slot lands, move this
+            into it. The banner returns null on empty/error so it's safe to
+            mount at the top of the dashboard for the migration window
+            (per docs/plans/akahu-migration-impact.md §4.7). */}
+        {isAuthResolved && <AkahuMigrationBanner />}
         {isAuthResolved ? (
           <DashboardTemplateRenderer />
         ) : (

--- a/frontend/src/app/settings/bank-connections/callback/page.tsx
+++ b/frontend/src/app/settings/bank-connections/callback/page.tsx
@@ -51,7 +51,10 @@ function CallbackContent() {
         return;
       }
 
-      if (event && event !== 'ACCEPT') {
+      // Akahu sends event=ACCEPT for new consents and event=UPDATE for re-consent /
+      // migration upgrades; both are successful outcomes. Anything else means the
+      // user denied or cancelled.
+      if (event && event !== 'ACCEPT' && event !== 'UPDATE') {
         setStatus('error');
         setErrorMessage(t('errors.denied'));
         return;

--- a/frontend/src/app/settings/bank-connections/page.tsx
+++ b/frontend/src/app/settings/bank-connections/page.tsx
@@ -9,6 +9,7 @@ import { Button } from '@/components/ui/button';
 import { BankConnectionList } from '@/components/bank-connections/bank-connection-list';
 import { LinkAccountDialog } from '@/components/bank-connections/link-account-dialog';
 import { AkahuSetupDialog } from '@/components/bank-connections/akahu-setup-dialog';
+import { AkahuMigrationBanner } from '@/components/bank-connections/akahu-migration-banner';
 import { apiClient } from '@/lib/api-client';
 import { toast } from 'sonner';
 import {
@@ -391,6 +392,11 @@ export default function BankConnectionsPage() {
             </div>
           </div>
         </div>
+
+        {/* Akahu classic→official migration banner. Renders nothing when the user
+            has no pending migrations, when the fetch fails, or when the user has
+            already dismissed it today (per-day localStorage flag). */}
+        <AkahuMigrationBanner />
 
         {/* Info Banner */}
         <div className="rounded-2xl border border-blue-200/60 bg-blue-50/80 backdrop-blur-xs p-4 mb-6">

--- a/frontend/src/components/bank-connections/akahu-migration-banner.tsx
+++ b/frontend/src/components/bank-connections/akahu-migration-banner.tsx
@@ -72,6 +72,7 @@ export function AkahuMigrationBanner({ className }: AkahuMigrationBannerProps) {
   const [status, setStatus] = useState<AkahuMigrationStatus | null>(null);
   const [dismissed, setDismissed] = useState(false);
   const [upgradingId, setUpgradingId] = useState<number | null>(null);
+  const [isInitiatingAny, setIsInitiatingAny] = useState(false);
 
   // Read dismissal flag on mount. Done in useEffect so the initial server
   // render doesn't mismatch with the client (localStorage is client-only).
@@ -109,6 +110,7 @@ export function AkahuMigrationBanner({ className }: AkahuMigrationBannerProps) {
   }, []);
 
   const handleUpgrade = useCallback(async (connection: PendingMigrationConnection) => {
+    setIsInitiatingAny(true);
     setUpgradingId(connection.connectionId);
     try {
       const result = await apiClient.initiateAkahuConnection();
@@ -138,6 +140,7 @@ export function AkahuMigrationBanner({ className }: AkahuMigrationBannerProps) {
       toast.error(t('toasts.initiateFailed'));
     } finally {
       setUpgradingId(null);
+      setIsInitiatingAny(false);
     }
   }, [t]);
 
@@ -219,7 +222,7 @@ export function AkahuMigrationBanner({ className }: AkahuMigrationBannerProps) {
                     type="button"
                     size="sm"
                     onClick={() => handleUpgrade(connection)}
-                    disabled={upgradingId === connection.connectionId}
+                    disabled={isInitiatingAny}
                     data-testid="akahu-migration-banner-upgrade"
                     className="flex items-center gap-1.5"
                   >

--- a/frontend/src/components/bank-connections/akahu-migration-banner.tsx
+++ b/frontend/src/components/bank-connections/akahu-migration-banner.tsx
@@ -110,6 +110,8 @@ export function AkahuMigrationBanner({ className }: AkahuMigrationBannerProps) {
   }, []);
 
   const handleUpgrade = useCallback(async (connection: PendingMigrationConnection) => {
+    // Defense-in-depth against rapid double-click before React re-renders disabled state.
+    if (isInitiatingAny) return;
     setIsInitiatingAny(true);
     setUpgradingId(connection.connectionId);
     try {
@@ -142,7 +144,7 @@ export function AkahuMigrationBanner({ className }: AkahuMigrationBannerProps) {
       setUpgradingId(null);
       setIsInitiatingAny(false);
     }
-  }, [t]);
+  }, [t, isInitiatingAny]);
 
   if (!status || status.pendingConnections.length === 0 || dismissed) {
     return null;

--- a/frontend/src/components/bank-connections/akahu-migration-banner.tsx
+++ b/frontend/src/components/bank-connections/akahu-migration-banner.tsx
@@ -1,0 +1,239 @@
+'use client';
+
+import { useCallback, useEffect, useState } from 'react';
+import { useTranslations } from 'next-intl';
+import { toast } from 'sonner';
+import { differenceInCalendarDays } from 'date-fns';
+import {
+  ExclamationTriangleIcon,
+  XMarkIcon,
+  ArrowTopRightOnSquareIcon,
+} from '@heroicons/react/24/outline';
+import { apiClient } from '@/lib/api-client';
+import { Button } from '@/components/ui/button';
+import { cn } from '@/lib/utils';
+import type {
+  AkahuMigrationStatus,
+  PendingMigrationConnection,
+} from '@/types/bank-connections';
+
+const DISMISS_KEY_PREFIX = 'akahu-migration-banner-dismissed-';
+
+/**
+ * Returns the dismiss-key for today (local time). The key rolls over each
+ * calendar day so a dismissal silences the banner for the rest of the day
+ * but it reappears tomorrow if the user still has pending connections.
+ */
+function todayDismissKey(now: Date = new Date()): string {
+  const year = now.getFullYear().toString().padStart(4, '0');
+  const month = (now.getMonth() + 1).toString().padStart(2, '0');
+  const day = now.getDate().toString().padStart(2, '0');
+  return `${DISMISS_KEY_PREFIX}${year}-${month}-${day}`;
+}
+
+function isDismissedToday(): boolean {
+  if (typeof window === 'undefined') return false;
+  try {
+    return window.localStorage.getItem(todayDismissKey()) === 'true';
+  } catch {
+    return false;
+  }
+}
+
+function setDismissedToday(): void {
+  if (typeof window === 'undefined') return;
+  try {
+    window.localStorage.setItem(todayDismissKey(), 'true');
+  } catch {
+    // ignore — storage may be unavailable in some browsers
+  }
+}
+
+function lastSyncedDays(connection: PendingMigrationConnection, now: Date): number | null {
+  if (!connection.lastSyncedAt) return null;
+  const parsed = new Date(connection.lastSyncedAt);
+  if (Number.isNaN(parsed.getTime())) return null;
+  const diff = differenceInCalendarDays(now, parsed);
+  return diff >= 0 ? diff : 0;
+}
+
+export interface AkahuMigrationBannerProps {
+  className?: string;
+}
+
+/**
+ * Banner shown on the Bank Connections page (and optionally the dashboard)
+ * when the user still has Akahu classic connections that need to be
+ * re-authorised before the 24 May 2026 cut-over. Fails closed — renders
+ * nothing on fetch errors or empty results.
+ */
+export function AkahuMigrationBanner({ className }: AkahuMigrationBannerProps) {
+  const t = useTranslations('bankConnections.akahuMigration');
+  const [status, setStatus] = useState<AkahuMigrationStatus | null>(null);
+  const [dismissed, setDismissed] = useState(false);
+  const [upgradingId, setUpgradingId] = useState<number | null>(null);
+
+  // Read dismissal flag on mount. Done in useEffect so the initial server
+  // render doesn't mismatch with the client (localStorage is client-only).
+  useEffect(() => {
+    setDismissed(isDismissedToday());
+  }, []);
+
+  useEffect(() => {
+    let cancelled = false;
+
+    const load = async () => {
+      try {
+        const data = await apiClient.getAkahuMigrationStatus();
+        if (!cancelled) {
+          setStatus(data);
+        }
+      } catch (error) {
+        // Quietly graceful — banner stays hidden on failure.
+        console.warn('Failed to load Akahu migration status', error);
+        if (!cancelled) {
+          setStatus(null);
+        }
+      }
+    };
+
+    void load();
+    return () => {
+      cancelled = true;
+    };
+  }, []);
+
+  const handleDismiss = useCallback(() => {
+    setDismissedToday();
+    setDismissed(true);
+  }, []);
+
+  const handleUpgrade = useCallback(async (connection: PendingMigrationConnection) => {
+    setUpgradingId(connection.connectionId);
+    try {
+      const result = await apiClient.initiateAkahuConnection();
+
+      if (result.requiresCredentials) {
+        toast.error(t('toasts.credentialsMissing'));
+        return;
+      }
+
+      // Production App / OAuth mode — redirect to Akahu authorisation page.
+      if (result.authorizationUrl) {
+        if (typeof window !== 'undefined' && result.state) {
+          window.localStorage.setItem('akahu_oauth_state', result.state);
+        }
+        if (typeof window !== 'undefined') {
+          window.location.href = result.authorizationUrl;
+        }
+        return;
+      }
+
+      // Personal App mode returns availableAccounts inline. The actual
+      // re-link UX lives on the bank-connections page; nudge the user to
+      // the standard Connect-Bank flow they already know.
+      toast.info(t('toasts.personalAppFallback'));
+    } catch (error) {
+      console.error('Failed to initiate Akahu upgrade', error);
+      toast.error(t('toasts.initiateFailed'));
+    } finally {
+      setUpgradingId(null);
+    }
+  }, [t]);
+
+  if (!status || status.pendingConnections.length === 0 || dismissed) {
+    return null;
+  }
+
+  const now = new Date();
+  const deadline = new Date(status.deadline);
+  const daysRemainingRaw = Number.isNaN(deadline.getTime())
+    ? 0
+    : differenceInCalendarDays(deadline, now);
+  const daysRemaining = Math.max(0, daysRemainingRaw);
+
+  return (
+    <div
+      role="alert"
+      aria-label={t('ariaLabel')}
+      data-testid="akahu-migration-banner"
+      className={cn(
+        'relative rounded-2xl border border-amber-300/70 bg-gradient-to-br from-amber-50 via-amber-50/60 to-orange-50/50 p-5 shadow-sm mb-6',
+        className,
+      )}
+    >
+      <button
+        type="button"
+        onClick={handleDismiss}
+        aria-label={t('dismiss')}
+        data-testid="akahu-migration-banner-dismiss"
+        className="absolute right-3 top-3 rounded-lg p-1.5 text-amber-700 hover:bg-amber-100 hover:text-amber-900 focus:outline-none focus:ring-2 focus:ring-amber-500"
+      >
+        <XMarkIcon className="h-4 w-4" />
+      </button>
+
+      <div className="flex items-start gap-4 pr-8">
+        <div className="flex h-10 w-10 shrink-0 items-center justify-center rounded-xl bg-amber-100 ring-1 ring-amber-200">
+          <ExclamationTriangleIcon className="h-5 w-5 text-amber-700" />
+        </div>
+
+        <div className="min-w-0 flex-1">
+          <h3
+            data-testid="akahu-migration-banner-heading"
+            className="font-[var(--font-dash-sans)] text-base font-semibold text-amber-900"
+          >
+            {t('heading')}
+          </h3>
+          <p className="mt-1 text-sm text-amber-800">
+            {t('body', { daysRemaining })}
+          </p>
+
+          <ul
+            className="mt-4 space-y-2"
+            data-testid="akahu-migration-banner-list"
+          >
+            {status.pendingConnections.map((connection) => {
+              const daysSinceSync = lastSyncedDays(connection, now);
+              const bankLabel =
+                connection.bankName ?? t('row.unknownBank');
+              const lastSyncedLabel =
+                daysSinceSync === null
+                  ? t('row.neverSynced')
+                  : t('row.lastSynced', { days: daysSinceSync });
+
+              return (
+                <li
+                  key={connection.connectionId}
+                  data-testid="akahu-migration-banner-row"
+                  className="flex flex-col gap-2 rounded-xl border border-amber-200/70 bg-white/70 p-3 sm:flex-row sm:items-center sm:justify-between"
+                >
+                  <div className="min-w-0">
+                    <p className="text-sm font-medium text-ink-900 truncate">
+                      {bankLabel}
+                    </p>
+                    <p className="text-xs text-ink-500 truncate">
+                      {lastSyncedLabel}
+                    </p>
+                  </div>
+                  <Button
+                    type="button"
+                    size="sm"
+                    onClick={() => handleUpgrade(connection)}
+                    disabled={upgradingId === connection.connectionId}
+                    data-testid="akahu-migration-banner-upgrade"
+                    className="flex items-center gap-1.5"
+                  >
+                    <ArrowTopRightOnSquareIcon className="h-4 w-4" />
+                    {upgradingId === connection.connectionId
+                      ? t('upgrading')
+                      : t('upgrade')}
+                  </Button>
+                </li>
+              );
+            })}
+          </ul>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/lib/api-client.ts
+++ b/frontend/src/lib/api-client.ts
@@ -13,6 +13,7 @@ import {
   HasAkahuCredentialsResponse,
   SaveAkahuCredentialsRequest,
   SaveAkahuCredentialsResult,
+  AkahuMigrationStatus,
 } from '@/types/bank-connections';
 import {
   BudgetSummary,
@@ -769,6 +770,7 @@ class ApiClient {
     currentBalance: number;
     currency: string;
     notes?: string;
+    isActive?: boolean;
   }): Promise<unknown> {
     return this.request(`/api/accounts/${id}`, {
       method: 'PUT',
@@ -1627,6 +1629,15 @@ class ApiClient {
 
   async hasAkahuCredentials(): Promise<HasAkahuCredentialsResponse> {
     return this.request('/api/BankConnections/akahu/has-credentials');
+  }
+
+  /**
+   * Returns the user's Akahu connections that still need to be re-authorised
+   * for the classic→official open-banking migration, plus the global deadline.
+   * Backed by GET /api/BankConnections/akahu/migration-status.
+   */
+  async getAkahuMigrationStatus(): Promise<AkahuMigrationStatus> {
+    return this.request('/api/BankConnections/akahu/migration-status');
   }
 
   async saveAkahuCredentials(request: SaveAkahuCredentialsRequest): Promise<SaveAkahuCredentialsResult> {

--- a/frontend/src/types/bank-connections.ts
+++ b/frontend/src/types/bank-connections.ts
@@ -116,6 +116,19 @@ export interface HasAkahuCredentialsResponse {
   hasCredentials: boolean;
 }
 
+// Akahu classic → official migration types (banner)
+export interface AkahuMigrationStatus {
+  pendingConnections: PendingMigrationConnection[];
+  deadline: string; // ISO timestamp
+}
+
+export interface PendingMigrationConnection {
+  connectionId: number;
+  bankName: string | null;
+  externalAccountId: string | null;
+  lastSyncedAt: string | null;
+}
+
 export interface SaveAkahuCredentialsRequest {
   appIdToken: string;
   userToken: string;

--- a/src/Core/MyMascada.Application/BackgroundJobs/IAkahuMigrationJobService.cs
+++ b/src/Core/MyMascada.Application/BackgroundJobs/IAkahuMigrationJobService.cs
@@ -1,0 +1,20 @@
+namespace MyMascada.Application.BackgroundJobs;
+
+/// <summary>
+/// Service that enqueues Akahu classic→official migration as a Hangfire background job,
+/// keeping the webhook and OAuth callbacks responsive (they must not block on the
+/// migration's network calls to Akahu and database remap).
+/// </summary>
+public interface IAkahuMigrationJobService
+{
+    /// <summary>
+    /// Enqueues a fire-and-forget migration for one connection.
+    /// </summary>
+    /// <returns>The Hangfire job ID for diagnostics.</returns>
+    string EnqueueMigration(Guid userId, int bankConnectionId);
+
+    /// <summary>
+    /// Hangfire entry-point. Sends the MigrateAkahuConnectionCommand inside a fresh DI scope.
+    /// </summary>
+    Task ProcessMigrationAsync(Guid userId, int bankConnectionId);
+}

--- a/src/Core/MyMascada.Application/BackgroundJobs/IAkahuWebhookSubscriptionReconciliationJobService.cs
+++ b/src/Core/MyMascada.Application/BackgroundJobs/IAkahuWebhookSubscriptionReconciliationJobService.cs
@@ -1,0 +1,15 @@
+namespace MyMascada.Application.BackgroundJobs;
+
+/// <summary>
+/// Service for reconciling Akahu webhook subscriptions across all active users.
+/// Runs periodically to heal drift between MyMascada's stored subscription rows and
+/// Akahu's authoritative subscription list.
+/// </summary>
+public interface IAkahuWebhookSubscriptionReconciliationJobService
+{
+    /// <summary>
+    /// Reconciles webhook subscriptions for every active Akahu user credential.
+    /// Called by Hangfire on a recurring schedule.
+    /// </summary>
+    Task ReconcileAllAsync();
+}

--- a/src/Core/MyMascada.Application/Common/Interfaces/IAkahuApiClient.cs
+++ b/src/Core/MyMascada.Application/Common/Interfaces/IAkahuApiClient.cs
@@ -54,6 +54,37 @@ public interface IAkahuApiClient
         CancellationToken ct = default);
 
     /// <summary>
+    /// Lists the user's bank connections (conn_xxx). Used during the classic-to-official
+    /// migration window to detect which connections have a `_classic` predecessor.
+    /// </summary>
+    /// <param name="appIdToken">Akahu App ID Token (app_token_xxx)</param>
+    /// <param name="userToken">User's access token (user_token_xxx)</param>
+    /// <param name="ct">Cancellation token</param>
+    Task<IReadOnlyList<AkahuConnectionInfo>> GetConnectionsWithCredentialsAsync(
+        string appIdToken,
+        string userToken,
+        CancellationToken ct = default);
+
+    /// <summary>
+    /// Fetches transactions for a given Akahu account between two dates. Returned DTOs include
+    /// the `Migrated` field so callers can build classic-to-official transaction ID maps during
+    /// the Akahu open-banking migration.
+    /// </summary>
+    /// <param name="appIdToken">Akahu App ID Token (app_token_xxx)</param>
+    /// <param name="userToken">User's access token (user_token_xxx)</param>
+    /// <param name="accountId">Akahu account ID (acc_xxx)</param>
+    /// <param name="start">Inclusive start date (null for no lower bound)</param>
+    /// <param name="end">Inclusive end date (null for no upper bound)</param>
+    /// <param name="ct">Cancellation token</param>
+    Task<IReadOnlyList<MyMascada.Application.Features.BankConnections.DTOs.BankTransactionDto>> GetTransactionsWithCredentialsAsync(
+        string appIdToken,
+        string userToken,
+        string accountId,
+        DateTime? start = null,
+        DateTime? end = null,
+        CancellationToken ct = default);
+
+    /// <summary>
     /// Validates that the provided credentials are valid by making a test API call.
     /// </summary>
     /// <param name="appIdToken">Akahu App ID Token (app_token_xxx)</param>
@@ -81,7 +112,8 @@ public interface IAkahuApiClient
     /// <param name="webhookType">Webhook type (TOKEN, ACCOUNT, TRANSACTION)</param>
     /// <param name="state">State value passed back in webhook events (e.g. user ID)</param>
     /// <param name="ct">Cancellation token</param>
-    Task SubscribeToWebhookAsync(string appIdToken, string userToken, string webhookType, string? state = null, CancellationToken ct = default);
+    /// <returns>The created webhook subscription as returned by Akahu.</returns>
+    Task<AkahuWebhookSubscriptionInfo> SubscribeToWebhookAsync(string appIdToken, string userToken, string webhookType, string? state = null, CancellationToken ct = default);
 
     /// <summary>
     /// Unsubscribes from an Akahu webhook.
@@ -182,4 +214,46 @@ public record AkahuAccountInfo
     /// Name of the bank (e.g., "ANZ")
     /// </summary>
     public string BankName { get; init; } = string.Empty;
+
+    /// <summary>
+    /// The Akahu ID of the classic account this account was migrated from (the official open
+    /// banking migration carries this on the new account record). Null when no migration applies.
+    /// </summary>
+    public string? Migrated { get; init; }
+
+    /// <summary>
+    /// The Akahu ID of the classic connection this account's connection was migrated from.
+    /// Sourced from the `_classic` field on the parent connection. Null for native official
+    /// connections (no classic predecessor) and for classic connections themselves.
+    /// </summary>
+    public string? ConnectionClassic { get; init; }
+}
+
+/// <summary>
+/// Represents an Akahu bank connection (conn_xxx) — the linkage between the user and a
+/// specific bank in Akahu. During the classic-to-official migration window, an official
+/// connection may carry a `_classic` reference back to the predecessor classic connection.
+/// </summary>
+public record AkahuConnectionInfo
+{
+    /// <summary>
+    /// Akahu connection ID (conn_xxx).
+    /// </summary>
+    public string Id { get; init; } = string.Empty;
+
+    /// <summary>
+    /// Display name of the bank (e.g., "ANZ").
+    /// </summary>
+    public string Name { get; init; } = string.Empty;
+
+    /// <summary>
+    /// Optional URL of the bank's logo.
+    /// </summary>
+    public string? Logo { get; init; }
+
+    /// <summary>
+    /// When this is an official open-banking connection that was migrated from a classic
+    /// predecessor, this is the classic connection's ID. Null otherwise.
+    /// </summary>
+    public string? Classic { get; init; }
 }

--- a/src/Core/MyMascada.Application/Common/Interfaces/IAkahuUserCredentialRepository.cs
+++ b/src/Core/MyMascada.Application/Common/Interfaces/IAkahuUserCredentialRepository.cs
@@ -63,6 +63,14 @@ public interface IAkahuUserCredentialRepository
     Task<IReadOnlyList<AkahuUserCredential>> GetPendingRevocationsAsync(CancellationToken ct = default);
 
     /// <summary>
+    /// Gets all active, non-soft-deleted credentials whose consent has not been revoked.
+    /// Used by recurring jobs that operate over every connected Akahu user.
+    /// </summary>
+    /// <param name="ct">Cancellation token</param>
+    /// <returns>List of active Akahu credentials</returns>
+    Task<IReadOnlyList<AkahuUserCredential>> GetActiveCredentialsAsync(CancellationToken ct = default);
+
+    /// <summary>
     /// Updates only the revocation-related columns for a credential.
     /// Uses a targeted UPDATE to avoid overwriting fields modified by other processes.
     /// </summary>

--- a/src/Core/MyMascada.Application/Common/Interfaces/IAkahuWebhookSubscriptionRepository.cs
+++ b/src/Core/MyMascada.Application/Common/Interfaces/IAkahuWebhookSubscriptionRepository.cs
@@ -1,0 +1,41 @@
+using MyMascada.Domain.Entities;
+
+namespace MyMascada.Application.Common.Interfaces;
+
+/// <summary>
+/// Repository interface for managing Akahu webhook subscription records.
+/// One row per (UserId, WebhookType); soft-delete semantics match
+/// <see cref="IAkahuUserCredentialRepository"/>.
+/// </summary>
+public interface IAkahuWebhookSubscriptionRepository
+{
+    /// <summary>
+    /// Gets all active subscriptions for a user.
+    /// </summary>
+    Task<IReadOnlyList<AkahuWebhookSubscription>> GetByUserIdAsync(Guid userId, CancellationToken ct = default);
+
+    /// <summary>
+    /// Looks up a single subscription by Akahu webhook ID.
+    /// </summary>
+    Task<AkahuWebhookSubscription?> GetByWebhookIdAsync(string webhookId, CancellationToken ct = default);
+
+    /// <summary>
+    /// Inserts a new subscription row.
+    /// </summary>
+    Task<AkahuWebhookSubscription> AddAsync(AkahuWebhookSubscription subscription, CancellationToken ct = default);
+
+    /// <summary>
+    /// Updates an existing subscription row (e.g. reconciliation timestamps).
+    /// </summary>
+    Task UpdateAsync(AkahuWebhookSubscription subscription, CancellationToken ct = default);
+
+    /// <summary>
+    /// Soft-deletes a subscription by primary key.
+    /// </summary>
+    Task DeleteByIdAsync(int id, CancellationToken ct = default);
+
+    /// <summary>
+    /// Soft-deletes every subscription belonging to a user.
+    /// </summary>
+    Task DeleteByUserIdAsync(Guid userId, CancellationToken ct = default);
+}

--- a/src/Core/MyMascada.Application/Common/Interfaces/IAkahuWebhookSubscriptionService.cs
+++ b/src/Core/MyMascada.Application/Common/Interfaces/IAkahuWebhookSubscriptionService.cs
@@ -1,0 +1,48 @@
+namespace MyMascada.Application.Common.Interfaces;
+
+/// <summary>
+/// Application service that owns the per-user Akahu webhook subscription lifecycle.
+/// Wraps the raw <see cref="IAkahuApiClient"/> subscribe/unsubscribe/list endpoints and
+/// keeps local <c>AkahuWebhookSubscription</c> rows in sync.
+/// </summary>
+public interface IAkahuWebhookSubscriptionService
+{
+    /// <summary>
+    /// Ensures that for the given user there is exactly one healthy subscription per required
+    /// webhook type. Idempotent: skips healthy ones, re-subscribes if the local row is stale,
+    /// adopts an Akahu-side subscription without re-POSTing when appropriate. Per-type failures
+    /// are swallowed so a partial failure never propagates out of the OAuth/save handlers.
+    /// </summary>
+    Task<EnsureSubscriptionsResult> EnsureSubscriptionsAsync(Guid userId, CancellationToken ct = default);
+
+    /// <summary>
+    /// Best-effort teardown: deletes every persisted subscription for the user, calling
+    /// DELETE /webhooks/{id} for each. Tolerates Akahu errors (the underlying token revoke
+    /// kills the subscription anyway).
+    /// </summary>
+    Task TearDownSubscriptionsAsync(Guid userId, CancellationToken ct = default);
+
+    /// <summary>
+    /// Reconciles drift between local rows and Akahu's authoritative list. Re-subscribes
+    /// missing types and adopts orphan Akahu subscriptions when appropriate.
+    /// </summary>
+    Task<ReconcileResult> ReconcileAsync(Guid userId, CancellationToken ct = default);
+}
+
+/// <summary>
+/// Outcome of <see cref="IAkahuWebhookSubscriptionService.EnsureSubscriptionsAsync"/>.
+/// </summary>
+public record EnsureSubscriptionsResult(
+    IReadOnlyList<string> SubscribedTypes,
+    IReadOnlyList<string> AdoptedTypes,
+    IReadOnlyList<string> AlreadyHealthyTypes,
+    IReadOnlyDictionary<string, string> FailedTypes);
+
+/// <summary>
+/// Outcome of <see cref="IAkahuWebhookSubscriptionService.ReconcileAsync"/>.
+/// </summary>
+public record ReconcileResult(
+    IReadOnlyList<string> SubscribedTypes,
+    IReadOnlyList<string> AdoptedTypes,
+    IReadOnlyList<string> AlreadyHealthyTypes,
+    IReadOnlyDictionary<string, string> FailedTypes);

--- a/src/Core/MyMascada.Application/Common/Interfaces/ITransactionRepository.cs
+++ b/src/Core/MyMascada.Application/Common/Interfaces/ITransactionRepository.cs
@@ -75,6 +75,23 @@ public interface ITransactionRepository
     // Bulk operations for categorization
     Task BulkUpdateCategorizationAsync<T>(IEnumerable<T> updates, Guid userId, CancellationToken cancellationToken = default)
         where T : class;
+
+    /// <summary>
+    /// Returns the oldest <see cref="Transaction.TransactionDate"/> for the given account, or
+    /// null when the account has no transactions. Used by the Akahu classic-to-official
+    /// migration to determine how far back to refetch transaction history when remapping
+    /// external IDs.
+    /// </summary>
+    Task<DateTime?> GetOldestTransactionDateForAccountAsync(int accountId, CancellationToken ct = default);
+
+    /// <summary>
+    /// Updates <see cref="Transaction.ExternalId"/> for transactions on the given account
+    /// according to the supplied old-to-new map. Only rows whose current <c>ExternalId</c>
+    /// matches a key in the map are touched. Returns the number of rows actually updated.
+    /// Used by the Akahu classic-to-official migration to rewrite <c>trans_xxx</c> IDs in
+    /// bulk while preserving categorisation history.
+    /// </summary>
+    Task<int> RemapExternalIdsAsync(int accountId, IReadOnlyDictionary<string, string> oldToNewExternalIds, CancellationToken ct = default);
 }
 
 public interface IAccountRepository

--- a/src/Core/MyMascada.Application/Common/Interfaces/IUnitOfWork.cs
+++ b/src/Core/MyMascada.Application/Common/Interfaces/IUnitOfWork.cs
@@ -1,0 +1,26 @@
+namespace MyMascada.Application.Common.Interfaces;
+
+/// <summary>
+/// Lightweight unit-of-work abstraction so application-layer handlers can compose
+/// multiple repository writes into a single atomic database transaction without
+/// taking a hard dependency on EF Core types.
+/// </summary>
+public interface IUnitOfWork
+{
+    /// <summary>
+    /// Begins a database transaction. The caller must Commit or the transaction will
+    /// be rolled back when the returned scope is disposed.
+    /// </summary>
+    Task<IUnitOfWorkTransaction> BeginTransactionAsync(CancellationToken cancellationToken = default);
+}
+
+/// <summary>
+/// A transactional scope. Disposing without committing rolls back.
+/// </summary>
+public interface IUnitOfWorkTransaction : IAsyncDisposable
+{
+    /// <summary>
+    /// Commits the underlying database transaction.
+    /// </summary>
+    Task CommitAsync(CancellationToken cancellationToken = default);
+}

--- a/src/Core/MyMascada.Application/Features/Accounts/DTOs/UpdateAccountDto.cs
+++ b/src/Core/MyMascada.Application/Features/Accounts/DTOs/UpdateAccountDto.cs
@@ -28,7 +28,9 @@ public class UpdateAccountDto
     [StringLength(500)]
     public string? Notes { get; set; }
     
-    public bool IsActive { get; set; }
+    // Nullable so an omitted JSON field doesn't silently archive an account.
+    // The mapper only applies this when the caller explicitly sets it.
+    public bool? IsActive { get; set; }
     
     [Required]
     [StringLength(3, MinimumLength = 3)]

--- a/src/Core/MyMascada.Application/Features/Accounts/Mappings/AccountMapper.cs
+++ b/src/Core/MyMascada.Application/Features/Accounts/Mappings/AccountMapper.cs
@@ -50,8 +50,18 @@ public static partial class AccountMapper
     public static partial Account ToEntity(CreateAccountDto dto);
 
     // UpdateAccountDto -> Account (in-place update)
+    public static void ApplyTo(UpdateAccountDto dto, Account account)
+    {
+        ApplyToGenerated(dto, account);
+        if (dto.IsActive.HasValue)
+        {
+            account.IsActive = dto.IsActive.Value;
+        }
+    }
+
     [MapperIgnoreTarget(nameof(Account.UserId))]
     [MapperIgnoreTarget(nameof(Account.CurrentBalance))]
+    [MapperIgnoreTarget(nameof(Account.IsActive))]
     [MapperIgnoreTarget(nameof(Account.Transactions))]
     [MapperIgnoreTarget(nameof(Account.BankConnection))]
     [MapperIgnoreTarget(nameof(Account.Shares))]
@@ -62,7 +72,7 @@ public static partial class AccountMapper
     [MapperIgnoreTarget(nameof(Account.UpdatedBy))]
     [MapperIgnoreTarget(nameof(Account.LastReconciledDate))]
     [MapperIgnoreTarget(nameof(Account.LastReconciledBalance))]
-    public static partial void ApplyTo(UpdateAccountDto dto, Account account);
+    private static partial void ApplyToGenerated(UpdateAccountDto dto, Account account);
 
     // Account -> AccountWithBalanceDto
     [MapProperty(nameof(Account.Type), nameof(AccountWithBalanceDto.TypeDisplayName), Use = nameof(GetAccountTypeDisplayName))]

--- a/src/Core/MyMascada.Application/Features/BankConnections/Commands/CompleteAkahuConnectionCommand.cs
+++ b/src/Core/MyMascada.Application/Features/BankConnections/Commands/CompleteAkahuConnectionCommand.cs
@@ -181,16 +181,4 @@ public class CompleteAkahuConnectionCommandHandler : IRequestHandler<CompleteAka
             CreatedAt = savedConnection.CreatedAt
         };
     }
-
-    /// <summary>
-    /// Settings class for Akahu connections stored in encrypted settings.
-    /// NOTE: Access tokens are now stored per-user in AkahuUserCredential, not here.
-    /// This only stores sync state and the specific Akahu account ID for this connection.
-    /// </summary>
-    private class AkahuConnectionSettings
-    {
-        public string AkahuAccountId { get; set; } = string.Empty;
-        public string? LastSyncedTransactionId { get; set; }
-        public DateTime? LastSyncTimestamp { get; set; }
-    }
 }

--- a/src/Core/MyMascada.Application/Features/BankConnections/Commands/DisconnectBankConnectionCommand.cs
+++ b/src/Core/MyMascada.Application/Features/BankConnections/Commands/DisconnectBankConnectionCommand.cs
@@ -24,6 +24,7 @@ public class DisconnectBankConnectionCommandHandler : IRequestHandler<Disconnect
     private readonly IAkahuApiClient _akahuApiClient;
     private readonly IAkahuUserCredentialRepository _credentialRepository;
     private readonly ISettingsEncryptionService _encryptionService;
+    private readonly IAkahuWebhookSubscriptionService _webhookSubscriptionService;
     private readonly IApplicationLogger<DisconnectBankConnectionCommandHandler> _logger;
 
     public DisconnectBankConnectionCommandHandler(
@@ -32,6 +33,7 @@ public class DisconnectBankConnectionCommandHandler : IRequestHandler<Disconnect
         IAkahuApiClient akahuApiClient,
         IAkahuUserCredentialRepository credentialRepository,
         ISettingsEncryptionService encryptionService,
+        IAkahuWebhookSubscriptionService webhookSubscriptionService,
         IApplicationLogger<DisconnectBankConnectionCommandHandler> logger)
     {
         _bankConnectionRepository = bankConnectionRepository ?? throw new ArgumentNullException(nameof(bankConnectionRepository));
@@ -39,6 +41,7 @@ public class DisconnectBankConnectionCommandHandler : IRequestHandler<Disconnect
         _akahuApiClient = akahuApiClient ?? throw new ArgumentNullException(nameof(akahuApiClient));
         _credentialRepository = credentialRepository ?? throw new ArgumentNullException(nameof(credentialRepository));
         _encryptionService = encryptionService ?? throw new ArgumentNullException(nameof(encryptionService));
+        _webhookSubscriptionService = webhookSubscriptionService ?? throw new ArgumentNullException(nameof(webhookSubscriptionService));
         _logger = logger ?? throw new ArgumentNullException(nameof(logger));
     }
 
@@ -71,6 +74,17 @@ public class DisconnectBankConnectionCommandHandler : IRequestHandler<Disconnect
         // Tokens are stored per-user in AkahuUserCredential, not per-connection.
         if (connection.ProviderId == AkahuProviderId)
         {
+            // 3a. Best-effort teardown of webhook subscriptions before the token is revoked.
+            // Wrapped so a failure here never blocks the disconnect.
+            try
+            {
+                await _webhookSubscriptionService.TearDownSubscriptionsAsync(request.UserId, cancellationToken);
+            }
+            catch (Exception ex)
+            {
+                _logger.LogWarning(ex, "TearDownSubscriptionsAsync failed for user {UserId} during disconnect; continuing", request.UserId);
+            }
+
             try
             {
                 var credential = await _credentialRepository.GetByUserIdAsync(request.UserId, cancellationToken);

--- a/src/Core/MyMascada.Application/Features/BankConnections/Commands/InitiateAkahuConnectionCommand.cs
+++ b/src/Core/MyMascada.Application/Features/BankConnections/Commands/InitiateAkahuConnectionCommand.cs
@@ -120,7 +120,7 @@ public class InitiateAkahuConnectionCommandHandler : IRequestHandler<InitiateAka
             credential.UpdatedAt = DateTime.UtcNow;
             await _credentialRepository.UpdateAsync(credential, cancellationToken);
 
-            if (mode == "personal_app")
+            if (mode == "personal_tokens")
             {
                 return new InitiateConnectionResult
                 {
@@ -145,7 +145,7 @@ public class InitiateAkahuConnectionCommandHandler : IRequestHandler<InitiateAka
             credential.UpdatedAt = DateTime.UtcNow;
             await _credentialRepository.UpdateAsync(credential, cancellationToken);
 
-            if (mode == "personal_app")
+            if (mode == "personal_tokens")
             {
                 return new InitiateConnectionResult
                 {

--- a/src/Core/MyMascada.Application/Features/BankConnections/Commands/InitiateAkahuConnectionCommand.cs
+++ b/src/Core/MyMascada.Application/Features/BankConnections/Commands/InitiateAkahuConnectionCommand.cs
@@ -50,6 +50,25 @@ public class InitiateAkahuConnectionCommandHandler : IRequestHandler<InitiateAka
         _logger.LogInformation("Initiating Akahu connection for user {UserId}", request.UserId);
 
         var mode = _modeResolver.Resolve("akahu");
+
+        // If the user already has valid (non-revoked) credentials, fetch accounts directly
+        // instead of forcing another OAuth round-trip. This applies to both hosted_oauth
+        // and personal_app modes — once authorized, the user shouldn't have to re-authorize
+        // just to link an additional account.
+        var credential = await _credentialRepository.GetByUserIdAsync(request.UserId, cancellationToken);
+        var hasUsableCredential = credential != null && credential.ConsentRevokedAt == null;
+
+        if (hasUsableCredential)
+        {
+            var reuseResult = await TryReuseExistingCredentialsAsync(credential!, request.UserId, mode.DefaultMode, cancellationToken);
+            if (reuseResult != null)
+            {
+                return reuseResult;
+            }
+            // Token couldn't be decrypted or was rejected by Akahu — fall through to
+            // a fresh authorization flow appropriate to the configured mode.
+        }
+
         if (mode.DefaultMode == "hosted_oauth")
         {
             var state = Guid.NewGuid().ToString("N");
@@ -65,22 +84,26 @@ public class InitiateAkahuConnectionCommandHandler : IRequestHandler<InitiateAka
             };
         }
 
-        // Check if user has stored credentials
-        var credential = await _credentialRepository.GetByUserIdAsync(request.UserId, cancellationToken);
-
-        if (credential == null)
+        _logger.LogInformation("User {UserId} has no Akahu credentials - setup required", request.UserId);
+        return new InitiateConnectionResult
         {
-            // User needs to set up credentials first
-            _logger.LogInformation("User {UserId} has no Akahu credentials - setup required", request.UserId);
-            return new InitiateConnectionResult
-            {
-                RequiresCredentials = true,
-                IsPersonalAppMode = true // We only support Personal App mode
-            };
-        }
+            RequiresCredentials = true,
+            IsPersonalAppMode = true
+        };
+    }
 
-        // User has credentials - decrypt them and fetch accounts
-        _logger.LogInformation("User {UserId} has Akahu credentials - fetching available accounts", request.UserId);
+    /// <summary>
+    /// Attempts to fetch the user's available Akahu accounts using their existing stored credentials.
+    /// Returns null if the credentials are unusable (decryption failure or rejected by Akahu) — the
+    /// caller should then fall back to a fresh authorization flow.
+    /// </summary>
+    private async Task<InitiateConnectionResult?> TryReuseExistingCredentialsAsync(
+        Domain.Entities.AkahuUserCredential credential,
+        Guid userId,
+        string mode,
+        CancellationToken cancellationToken)
+    {
+        _logger.LogInformation("User {UserId} has Akahu credentials - fetching available accounts without re-auth", userId);
 
         string? appIdToken;
         string? userToken;
@@ -91,20 +114,22 @@ public class InitiateAkahuConnectionCommandHandler : IRequestHandler<InitiateAka
         }
         catch (Exception ex)
         {
-            // Decryption failed - Data Protection keys may have changed (e.g., after deployment)
-            // Mark credentials as needing re-setup
-            _logger.LogWarning(ex, "Failed to decrypt Akahu credentials for user {UserId} - keys may have changed", request.UserId);
-
+            // Decryption failed - Data Protection keys may have changed (e.g., after deployment).
+            _logger.LogWarning(ex, "Failed to decrypt Akahu credentials for user {UserId} - keys may have changed", userId);
             credential.LastValidationError = "Credentials could not be decrypted. Please re-enter your tokens.";
             credential.UpdatedAt = DateTime.UtcNow;
             await _credentialRepository.UpdateAsync(credential, cancellationToken);
 
-            return new InitiateConnectionResult
+            if (mode == "personal_app")
             {
-                RequiresCredentials = true,
-                IsPersonalAppMode = true,
-                CredentialsError = "Your stored credentials could not be decrypted. This can happen after system updates. Please re-enter your App Token and User Token."
-            };
+                return new InitiateConnectionResult
+                {
+                    RequiresCredentials = true,
+                    IsPersonalAppMode = true,
+                    CredentialsError = "Your stored credentials could not be decrypted. This can happen after system updates. Please re-enter your App Token and User Token."
+                };
+            }
+            return null; // OAuth mode → caller will produce a fresh authorization URL.
         }
 
         IReadOnlyList<AkahuAccountInfo> accounts;
@@ -114,29 +139,30 @@ public class InitiateAkahuConnectionCommandHandler : IRequestHandler<InitiateAka
         }
         catch (UnauthorizedAccessException ex)
         {
-            // Credentials may have been revoked - mark as needing re-setup
-            _logger.LogWarning(ex, "Akahu credentials invalid for user {UserId}", request.UserId);
-
-            // Update credential with validation error
-            credential.LastValidationError = "Credentials are no longer valid. Please re-enter your tokens.";
+            // Tokens have been revoked or expired upstream.
+            _logger.LogWarning(ex, "Akahu credentials invalid for user {UserId}", userId);
+            credential.LastValidationError = "Credentials are no longer valid. Please re-authorize.";
             credential.UpdatedAt = DateTime.UtcNow;
             await _credentialRepository.UpdateAsync(credential, cancellationToken);
 
-            return new InitiateConnectionResult
+            if (mode == "personal_app")
             {
-                RequiresCredentials = true,
-                IsPersonalAppMode = true,
-                CredentialsError = "Your Akahu credentials are no longer valid. Please re-enter your App Token and User Token."
-            };
+                return new InitiateConnectionResult
+                {
+                    RequiresCredentials = true,
+                    IsPersonalAppMode = true,
+                    CredentialsError = "Your Akahu credentials are no longer valid. Please re-enter your App Token and User Token."
+                };
+            }
+            return null;
         }
         catch (Exception ex)
         {
-            _logger.LogError(ex, "Failed to fetch Akahu accounts for user {UserId}", request.UserId);
+            _logger.LogError(ex, "Failed to fetch Akahu accounts for user {UserId}", userId);
             throw new InvalidOperationException("Failed to connect to Akahu. Please try again later.", ex);
         }
 
-        // Get existing connections to mark already linked accounts
-        var existingConnections = await _bankConnectionRepository.GetByUserIdAsync(request.UserId, cancellationToken);
+        var existingConnections = await _bankConnectionRepository.GetByUserIdAsync(userId, cancellationToken);
         var linkedExternalIds = existingConnections
             .Where(c => c.ProviderId == "akahu")
             .Select(c => c.ExternalAccountId)
@@ -154,7 +180,6 @@ public class InitiateAkahuConnectionCommandHandler : IRequestHandler<InitiateAka
             IsAlreadyLinked = linkedExternalIds.Contains(a.Id)
         });
 
-        // Update last validated timestamp
         credential.LastValidatedAt = DateTime.UtcNow;
         credential.LastValidationError = null;
         credential.UpdatedAt = DateTime.UtcNow;
@@ -162,6 +187,9 @@ public class InitiateAkahuConnectionCommandHandler : IRequestHandler<InitiateAka
 
         return new InitiateConnectionResult
         {
+            // IsPersonalAppMode=true tells the frontend "use the inline accounts" — this
+            // is the same shape the frontend already handles for personal-app mode, so
+            // reusing it avoids a new code path on the client.
             IsPersonalAppMode = true,
             RequiresCredentials = false,
             AvailableAccounts = accountDtos

--- a/src/Core/MyMascada.Application/Features/BankConnections/Commands/MigrateAkahuConnectionCommand.cs
+++ b/src/Core/MyMascada.Application/Features/BankConnections/Commands/MigrateAkahuConnectionCommand.cs
@@ -1,0 +1,213 @@
+using MediatR;
+using MyMascada.Application.Common.Interfaces;
+
+namespace MyMascada.Application.Features.BankConnections.Commands;
+
+/// <summary>
+/// Command to migrate a MyMascada bank connection from the user's Akahu classic account
+/// (<c>acc_xxx</c>) to the equivalent official open-banking account that Akahu created during
+/// the 2026-05 classic-to-official migration. The handler updates
+/// <see cref="MyMascada.Domain.Entities.BankConnection.ExternalAccountId"/>, the encrypted
+/// <c>AkahuConnectionSettings.AkahuAccountId</c>, and rewrites historical
+/// <see cref="MyMascada.Domain.Entities.Transaction.ExternalId"/> values for the account so
+/// that the existing exact-match dedup pipeline keeps catching duplicate Akahu re-imports.
+/// </summary>
+public record MigrateAkahuConnectionCommand(Guid UserId, int BankConnectionId) : IRequest<MigrateAkahuConnectionResult>;
+
+/// <summary>
+/// Result of <see cref="MigrateAkahuConnectionCommand"/>.
+/// </summary>
+public record MigrateAkahuConnectionResult(
+    bool Success,
+    string? OldExternalAccountId,
+    string? NewExternalAccountId,
+    int TransactionsRemapped,
+    string? ErrorMessage);
+
+public class MigrateAkahuConnectionCommandHandler
+    : IRequestHandler<MigrateAkahuConnectionCommand, MigrateAkahuConnectionResult>
+{
+    private const string AkahuProviderId = "akahu";
+    private const int MaxMigrationLookbackDays = 365;
+
+    private readonly IBankConnectionRepository _bankConnectionRepository;
+    private readonly IAkahuUserCredentialRepository _credentialRepository;
+    private readonly IAkahuApiClient _akahuApiClient;
+    private readonly ITransactionRepository _transactionRepository;
+    private readonly ISettingsEncryptionService _encryptionService;
+    private readonly IApplicationLogger<MigrateAkahuConnectionCommandHandler> _logger;
+
+    public MigrateAkahuConnectionCommandHandler(
+        IBankConnectionRepository bankConnectionRepository,
+        IAkahuUserCredentialRepository credentialRepository,
+        IAkahuApiClient akahuApiClient,
+        ITransactionRepository transactionRepository,
+        ISettingsEncryptionService encryptionService,
+        IApplicationLogger<MigrateAkahuConnectionCommandHandler> logger)
+    {
+        _bankConnectionRepository = bankConnectionRepository ?? throw new ArgumentNullException(nameof(bankConnectionRepository));
+        _credentialRepository = credentialRepository ?? throw new ArgumentNullException(nameof(credentialRepository));
+        _akahuApiClient = akahuApiClient ?? throw new ArgumentNullException(nameof(akahuApiClient));
+        _transactionRepository = transactionRepository ?? throw new ArgumentNullException(nameof(transactionRepository));
+        _encryptionService = encryptionService ?? throw new ArgumentNullException(nameof(encryptionService));
+        _logger = logger ?? throw new ArgumentNullException(nameof(logger));
+    }
+
+    public async Task<MigrateAkahuConnectionResult> Handle(MigrateAkahuConnectionCommand request, CancellationToken cancellationToken)
+    {
+        var connection = await _bankConnectionRepository.GetByIdAsync(request.BankConnectionId, cancellationToken);
+        if (connection == null || connection.ProviderId != AkahuProviderId)
+        {
+            _logger.LogWarning("Migrate Akahu connection: BankConnection {ConnectionId} not found or not an Akahu connection", request.BankConnectionId);
+            return new MigrateAkahuConnectionResult(false, null, null, 0, "Bank connection not found");
+        }
+
+        if (connection.UserId != request.UserId)
+        {
+            _logger.LogWarning(
+                "Migrate Akahu connection: BankConnection {ConnectionId} belongs to user {OwnerId}, not requesting user {RequestUserId}",
+                connection.Id, connection.UserId, request.UserId);
+            return new MigrateAkahuConnectionResult(false, connection.ExternalAccountId, null, 0, "Bank connection not found");
+        }
+
+        var oldExternalAccountId = connection.ExternalAccountId;
+        if (string.IsNullOrEmpty(oldExternalAccountId))
+        {
+            _logger.LogWarning("Migrate Akahu connection {ConnectionId}: no ExternalAccountId set, nothing to migrate", connection.Id);
+            return new MigrateAkahuConnectionResult(false, null, null, 0, "Bank connection has no external account ID");
+        }
+
+        var credential = await _credentialRepository.GetByUserIdAsync(request.UserId, cancellationToken);
+        if (credential == null)
+        {
+            _logger.LogWarning("Migrate Akahu connection {ConnectionId}: no Akahu credentials for user {UserId}", connection.Id, request.UserId);
+            return new MigrateAkahuConnectionResult(false, oldExternalAccountId, null, 0, "Akahu credentials not found for user");
+        }
+
+        string appIdToken;
+        string userToken;
+        try
+        {
+            var decryptedApp = _encryptionService.DecryptSettings<string>(credential.EncryptedAppToken);
+            var decryptedUser = _encryptionService.DecryptSettings<string>(credential.EncryptedUserToken);
+            if (string.IsNullOrEmpty(decryptedApp) || string.IsNullOrEmpty(decryptedUser))
+            {
+                _logger.LogWarning("Migrate Akahu connection {ConnectionId}: decrypted Akahu tokens were empty", connection.Id);
+                return new MigrateAkahuConnectionResult(false, oldExternalAccountId, null, 0, "Akahu credentials could not be decrypted");
+            }
+            appIdToken = decryptedApp;
+            userToken = decryptedUser;
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(ex, "Migrate Akahu connection {ConnectionId}: failed to decrypt Akahu credentials", connection.Id);
+            return new MigrateAkahuConnectionResult(false, oldExternalAccountId, null, 0, "Akahu credentials could not be decrypted");
+        }
+
+        IReadOnlyList<AkahuAccountInfo> accounts;
+        try
+        {
+            accounts = await _akahuApiClient.GetAccountsWithCredentialsAsync(appIdToken, userToken, cancellationToken);
+        }
+        catch (UnauthorizedAccessException ex)
+        {
+            _logger.LogWarning(ex, "Migrate Akahu connection {ConnectionId}: Akahu credentials unauthorised", connection.Id);
+            return new MigrateAkahuConnectionResult(false, oldExternalAccountId, null, 0, "Akahu credentials are no longer valid");
+        }
+
+        var migratedAccount = accounts.FirstOrDefault(a =>
+            !string.IsNullOrEmpty(a.Migrated) && a.Migrated == oldExternalAccountId);
+
+        if (migratedAccount == null)
+        {
+            _logger.LogWarning(
+                "Migrate Akahu connection {ConnectionId}: no account in Akahu carries _migrated={OldAccountId}; marking awaiting re-auth",
+                connection.Id, oldExternalAccountId);
+
+            connection.IsActive = false;
+            connection.LastSyncError = "Awaiting re-authorisation";
+            connection.UpdatedAt = DateTime.UtcNow;
+            await _bankConnectionRepository.UpdateAsync(connection, cancellationToken);
+
+            return new MigrateAkahuConnectionResult(
+                false,
+                oldExternalAccountId,
+                null,
+                0,
+                "No migrated Akahu account found — user must re-authorise");
+        }
+
+        var newAccountId = migratedAccount.Id;
+
+        var oldestDate = await _transactionRepository.GetOldestTransactionDateForAccountAsync(connection.AccountId, cancellationToken);
+        var today = DateTime.UtcNow.Date;
+        var earliest = today.AddDays(-MaxMigrationLookbackDays);
+        var fromDate = oldestDate.HasValue && oldestDate.Value.Date > earliest
+            ? oldestDate.Value.Date
+            : earliest;
+        if (fromDate > today)
+        {
+            fromDate = earliest;
+        }
+
+        var newTransactions = await _akahuApiClient.GetTransactionsWithCredentialsAsync(
+            appIdToken, userToken, newAccountId, fromDate, today, cancellationToken);
+
+        var idMap = new Dictionary<string, string>(StringComparer.Ordinal);
+        foreach (var tx in newTransactions)
+        {
+            if (!string.IsNullOrEmpty(tx.Migrated) && !string.IsNullOrEmpty(tx.ExternalId) && tx.Migrated != tx.ExternalId)
+            {
+                idMap[tx.Migrated] = tx.ExternalId;
+            }
+        }
+
+        connection.ExternalAccountId = newAccountId;
+        if (!string.IsNullOrEmpty(migratedAccount.Name))
+        {
+            connection.ExternalAccountName = migratedAccount.Name;
+        }
+        connection.IsActive = true;
+        connection.LastSyncError = null;
+        connection.LastMigratedAt = DateTime.UtcNow;
+        connection.UpdatedAt = DateTime.UtcNow;
+
+        var existingSettings = !string.IsNullOrEmpty(connection.EncryptedSettings)
+            ? _encryptionService.DecryptSettings<AkahuConnectionSettings>(connection.EncryptedSettings)
+            : null;
+        var updatedSettings = existingSettings ?? new AkahuConnectionSettings();
+        updatedSettings.AkahuAccountId = newAccountId;
+        connection.EncryptedSettings = _encryptionService.EncryptSettings(updatedSettings);
+
+        await _bankConnectionRepository.UpdateAsync(connection, cancellationToken);
+
+        var remapped = 0;
+        if (idMap.Count > 0)
+        {
+            remapped = await _transactionRepository.RemapExternalIdsAsync(connection.AccountId, idMap, cancellationToken);
+        }
+
+        // TODO(akahu-migration follow-up PR): rewrite trans_xxx values embedded in
+        // ReconciliationItem.BankReferenceData JSON and trigger a fresh BankSyncService run
+        // for this connection so post-migration deltas are picked up. Tracked in
+        // docs/plans/akahu-migration-impact.md §4.3 steps 10-11.
+
+        _logger.LogInformation(
+            "Akahu connection migrated. User={UserId}, ConnectionId={ConnectionId}, Old={OldAccountId}, New={NewAccountId}, TxRemapped={TransactionsRemapped}",
+            request.UserId, connection.Id, oldExternalAccountId, newAccountId, remapped);
+
+        return new MigrateAkahuConnectionResult(
+            true,
+            oldExternalAccountId,
+            newAccountId,
+            remapped,
+            null);
+    }
+
+    private sealed class AkahuConnectionSettings
+    {
+        public string AkahuAccountId { get; set; } = string.Empty;
+        public string? LastSyncedTransactionId { get; set; }
+        public DateTime? LastSyncTimestamp { get; set; }
+    }
+}

--- a/src/Core/MyMascada.Application/Features/BankConnections/Commands/MigrateAkahuConnectionCommand.cs
+++ b/src/Core/MyMascada.Application/Features/BankConnections/Commands/MigrateAkahuConnectionCommand.cs
@@ -1,5 +1,6 @@
 using MediatR;
 using MyMascada.Application.Common.Interfaces;
+using MyMascada.Application.Features.BankConnections.DTOs;
 
 namespace MyMascada.Application.Features.BankConnections.Commands;
 
@@ -35,6 +36,7 @@ public class MigrateAkahuConnectionCommandHandler
     private readonly IAkahuApiClient _akahuApiClient;
     private readonly ITransactionRepository _transactionRepository;
     private readonly ISettingsEncryptionService _encryptionService;
+    private readonly IUnitOfWork _unitOfWork;
     private readonly IApplicationLogger<MigrateAkahuConnectionCommandHandler> _logger;
 
     public MigrateAkahuConnectionCommandHandler(
@@ -43,6 +45,7 @@ public class MigrateAkahuConnectionCommandHandler
         IAkahuApiClient akahuApiClient,
         ITransactionRepository transactionRepository,
         ISettingsEncryptionService encryptionService,
+        IUnitOfWork unitOfWork,
         IApplicationLogger<MigrateAkahuConnectionCommandHandler> logger)
     {
         _bankConnectionRepository = bankConnectionRepository ?? throw new ArgumentNullException(nameof(bankConnectionRepository));
@@ -50,6 +53,7 @@ public class MigrateAkahuConnectionCommandHandler
         _akahuApiClient = akahuApiClient ?? throw new ArgumentNullException(nameof(akahuApiClient));
         _transactionRepository = transactionRepository ?? throw new ArgumentNullException(nameof(transactionRepository));
         _encryptionService = encryptionService ?? throw new ArgumentNullException(nameof(encryptionService));
+        _unitOfWork = unitOfWork ?? throw new ArgumentNullException(nameof(unitOfWork));
         _logger = logger ?? throw new ArgumentNullException(nameof(logger));
     }
 
@@ -102,6 +106,31 @@ public class MigrateAkahuConnectionCommandHandler
         {
             _logger.LogError(ex, "Migrate Akahu connection {ConnectionId}: failed to decrypt Akahu credentials", connection.Id);
             return new MigrateAkahuConnectionResult(false, oldExternalAccountId, null, 0, "Akahu credentials could not be decrypted");
+        }
+
+        // Decrypt EncryptedSettings up front so we fail fast (before any expensive Akahu
+        // API calls) if Data Protection keys have rotated and rendered the blob unreadable.
+        AkahuConnectionSettings existingSettings;
+        if (!string.IsNullOrEmpty(connection.EncryptedSettings))
+        {
+            try
+            {
+                existingSettings = _encryptionService.DecryptSettings<AkahuConnectionSettings>(connection.EncryptedSettings)
+                    ?? new AkahuConnectionSettings();
+            }
+            catch (Exception ex)
+            {
+                _logger.LogError(ex, "Migrate Akahu connection {ConnectionId}: failed to decrypt EncryptedSettings", connection.Id);
+                connection.IsActive = false;
+                connection.LastSyncError = "Settings could not be decrypted; please re-link this account.";
+                connection.UpdatedAt = DateTime.UtcNow;
+                await _bankConnectionRepository.UpdateAsync(connection, cancellationToken);
+                return new MigrateAkahuConnectionResult(false, oldExternalAccountId, null, 0, "Connection settings could not be decrypted");
+            }
+        }
+        else
+        {
+            existingSettings = new AkahuConnectionSettings();
         }
 
         IReadOnlyList<AkahuAccountInfo> accounts;
@@ -172,19 +201,23 @@ public class MigrateAkahuConnectionCommandHandler
         connection.LastMigratedAt = DateTime.UtcNow;
         connection.UpdatedAt = DateTime.UtcNow;
 
-        var existingSettings = !string.IsNullOrEmpty(connection.EncryptedSettings)
-            ? _encryptionService.DecryptSettings<AkahuConnectionSettings>(connection.EncryptedSettings)
-            : null;
-        var updatedSettings = existingSettings ?? new AkahuConnectionSettings();
-        updatedSettings.AkahuAccountId = newAccountId;
-        connection.EncryptedSettings = _encryptionService.EncryptSettings(updatedSettings);
+        existingSettings.AkahuAccountId = newAccountId;
+        connection.EncryptedSettings = _encryptionService.EncryptSettings(existingSettings);
 
-        await _bankConnectionRepository.UpdateAsync(connection, cancellationToken);
-
+        // Wrap the connection update and transaction remap in a single DB transaction so a
+        // failure during remap leaves the connection still pointing at the old ExternalAccountId
+        // (which the next sync will retry) rather than at the new one with stale transaction rows.
         var remapped = 0;
-        if (idMap.Count > 0)
+        await using (var tx = await _unitOfWork.BeginTransactionAsync(cancellationToken))
         {
-            remapped = await _transactionRepository.RemapExternalIdsAsync(connection.AccountId, idMap, cancellationToken);
+            await _bankConnectionRepository.UpdateAsync(connection, cancellationToken);
+
+            if (idMap.Count > 0)
+            {
+                remapped = await _transactionRepository.RemapExternalIdsAsync(connection.AccountId, idMap, cancellationToken);
+            }
+
+            await tx.CommitAsync(cancellationToken);
         }
 
         // TODO(akahu-migration follow-up PR): rewrite trans_xxx values embedded in
@@ -202,12 +235,5 @@ public class MigrateAkahuConnectionCommandHandler
             newAccountId,
             remapped,
             null);
-    }
-
-    private sealed class AkahuConnectionSettings
-    {
-        public string AkahuAccountId { get; set; } = string.Empty;
-        public string? LastSyncedTransactionId { get; set; }
-        public DateTime? LastSyncTimestamp { get; set; }
     }
 }

--- a/src/Core/MyMascada.Application/Features/BankConnections/Commands/ProcessAkahuWebhookCommand.cs
+++ b/src/Core/MyMascada.Application/Features/BankConnections/Commands/ProcessAkahuWebhookCommand.cs
@@ -16,6 +16,8 @@ public class ProcessAkahuWebhookCommandHandler : IRequestHandler<ProcessAkahuWeb
     private readonly IBankSyncService _bankSyncService;
     private readonly IAkahuUserCredentialRepository _credentialRepository;
     private readonly ITransactionRepository _transactionRepository;
+    private readonly IAkahuWebhookSubscriptionRepository _subscriptionRepository;
+    private readonly IMediator _mediator;
     private readonly IApplicationLogger<ProcessAkahuWebhookCommandHandler> _logger;
 
     private const string AkahuProviderId = "akahu";
@@ -25,12 +27,16 @@ public class ProcessAkahuWebhookCommandHandler : IRequestHandler<ProcessAkahuWeb
         IBankSyncService bankSyncService,
         IAkahuUserCredentialRepository credentialRepository,
         ITransactionRepository transactionRepository,
+        IAkahuWebhookSubscriptionRepository subscriptionRepository,
+        IMediator mediator,
         IApplicationLogger<ProcessAkahuWebhookCommandHandler> logger)
     {
         _bankConnectionRepository = bankConnectionRepository;
         _bankSyncService = bankSyncService;
         _credentialRepository = credentialRepository;
         _transactionRepository = transactionRepository;
+        _subscriptionRepository = subscriptionRepository;
+        _mediator = mediator;
         _logger = logger;
     }
 
@@ -93,6 +99,10 @@ public class ProcessAkahuWebhookCommandHandler : IRequestHandler<ProcessAkahuWeb
 
         // Clean up stored credentials
         await _credentialRepository.DeleteByUserIdAsync(userId, ct);
+
+        // Akahu cancels the subscription on its end when the token is revoked, so we only need
+        // to purge the local rows — no DELETE /webhooks API call is necessary.
+        await _subscriptionRepository.DeleteByUserIdAsync(userId, ct);
     }
 
     private async Task HandleAccountEventAsync(AkahuWebhookPayload payload, CancellationToken ct)
@@ -111,10 +121,75 @@ public class ProcessAkahuWebhookCommandHandler : IRequestHandler<ProcessAkahuWeb
                 _logger.LogInformation("New Akahu account {AccountId} connected — will be picked up on next sync", payload.ItemId);
                 break;
 
+            case AkahuWebhookCodes.Migrate:
+                await HandleAccountMigrateAsync(payload, ct);
+                break;
+
+            case AkahuWebhookCodes.WebhookCancelled:
+                await HandleWebhookCancelledAsync(payload, AkahuWebhookTypes.Account, ct);
+                break;
+
             default:
                 _logger.LogInformation("Ignoring ACCOUNT/{WebhookCode} event", payload.WebhookCode);
                 break;
         }
+    }
+
+    private async Task HandleAccountMigrateAsync(AkahuWebhookPayload payload, CancellationToken ct)
+    {
+        if (string.IsNullOrEmpty(payload.PreviousItemId))
+        {
+            _logger.LogWarning("ACCOUNT/MIGRATE webhook missing previous_item_id");
+            return;
+        }
+
+        var connection = await _bankConnectionRepository.GetByExternalAccountIdAsync(payload.PreviousItemId, AkahuProviderId, ct);
+        if (connection == null)
+        {
+            _logger.LogWarning(
+                "ACCOUNT/MIGRATE webhook for unknown classic account {PreviousItemId}; will catch up on next sync",
+                payload.PreviousItemId);
+            return;
+        }
+
+        _logger.LogInformation(
+            "ACCOUNT/MIGRATE webhook: dispatching MigrateAkahuConnectionCommand for connection {ConnectionId} (user {UserId})",
+            connection.Id, connection.UserId);
+
+        try
+        {
+            var result = await _mediator.Send(new MigrateAkahuConnectionCommand(connection.UserId, connection.Id), ct);
+            _logger.LogInformation(
+                "ACCOUNT/MIGRATE complete for connection {ConnectionId}: success={Success}, txRemapped={TxRemapped}",
+                connection.Id, result.Success, result.TransactionsRemapped);
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(ex, "ACCOUNT/MIGRATE handler failed for connection {ConnectionId}", connection.Id);
+        }
+    }
+
+    private async Task HandleWebhookCancelledAsync(AkahuWebhookPayload payload, string webhookType, CancellationToken ct)
+    {
+        if (!TryParseUserId(payload.State, out var userId))
+        {
+            _logger.LogWarning("WEBHOOK_CANCELLED event missing or invalid state");
+            return;
+        }
+
+        var subscriptions = await _subscriptionRepository.GetByUserIdAsync(userId, ct);
+        var match = subscriptions.FirstOrDefault(s => string.Equals(s.WebhookType, webhookType, StringComparison.OrdinalIgnoreCase));
+        if (match == null)
+        {
+            _logger.LogInformation("WEBHOOK_CANCELLED for user {UserId} type {WebhookType}: no local row to delete", userId, webhookType);
+            return;
+        }
+
+        _logger.LogInformation(
+            "WEBHOOK_CANCELLED for user {UserId} type {WebhookType}: deleting local subscription row {Id} so reconciliation can re-create it",
+            userId, webhookType, match.Id);
+
+        await _subscriptionRepository.DeleteByIdAsync(match.Id, ct);
     }
 
     private async Task HandleAccountUpdateAsync(AkahuWebhookPayload payload, CancellationToken ct)
@@ -160,6 +235,10 @@ public class ProcessAkahuWebhookCommandHandler : IRequestHandler<ProcessAkahuWeb
 
             case AkahuWebhookCodes.Delete:
                 await HandleTransactionDeleteAsync(payload, ct);
+                break;
+
+            case AkahuWebhookCodes.WebhookCancelled:
+                await HandleWebhookCancelledAsync(payload, AkahuWebhookTypes.Transaction, ct);
                 break;
 
             default:

--- a/src/Core/MyMascada.Application/Features/BankConnections/Commands/ProcessAkahuWebhookCommand.cs
+++ b/src/Core/MyMascada.Application/Features/BankConnections/Commands/ProcessAkahuWebhookCommand.cs
@@ -1,4 +1,5 @@
 using MediatR;
+using MyMascada.Application.BackgroundJobs;
 using MyMascada.Application.Common.Interfaces;
 using MyMascada.Application.Features.BankConnections.DTOs;
 using MyMascada.Domain.Enums;
@@ -17,7 +18,7 @@ public class ProcessAkahuWebhookCommandHandler : IRequestHandler<ProcessAkahuWeb
     private readonly IAkahuUserCredentialRepository _credentialRepository;
     private readonly ITransactionRepository _transactionRepository;
     private readonly IAkahuWebhookSubscriptionRepository _subscriptionRepository;
-    private readonly IMediator _mediator;
+    private readonly IAkahuMigrationJobService _migrationJobService;
     private readonly IApplicationLogger<ProcessAkahuWebhookCommandHandler> _logger;
 
     private const string AkahuProviderId = "akahu";
@@ -28,7 +29,7 @@ public class ProcessAkahuWebhookCommandHandler : IRequestHandler<ProcessAkahuWeb
         IAkahuUserCredentialRepository credentialRepository,
         ITransactionRepository transactionRepository,
         IAkahuWebhookSubscriptionRepository subscriptionRepository,
-        IMediator mediator,
+        IAkahuMigrationJobService migrationJobService,
         IApplicationLogger<ProcessAkahuWebhookCommandHandler> logger)
     {
         _bankConnectionRepository = bankConnectionRepository;
@@ -36,7 +37,7 @@ public class ProcessAkahuWebhookCommandHandler : IRequestHandler<ProcessAkahuWeb
         _credentialRepository = credentialRepository;
         _transactionRepository = transactionRepository;
         _subscriptionRepository = subscriptionRepository;
-        _mediator = mediator;
+        _migrationJobService = migrationJobService;
         _logger = logger;
     }
 
@@ -153,20 +154,24 @@ public class ProcessAkahuWebhookCommandHandler : IRequestHandler<ProcessAkahuWeb
         }
 
         _logger.LogInformation(
-            "ACCOUNT/MIGRATE webhook: dispatching MigrateAkahuConnectionCommand for connection {ConnectionId} (user {UserId})",
+            "ACCOUNT/MIGRATE webhook: enqueueing migration job for connection {ConnectionId} (user {UserId})",
             connection.Id, connection.UserId);
 
         try
         {
-            var result = await _mediator.Send(new MigrateAkahuConnectionCommand(connection.UserId, connection.Id), ct);
+            // Fire-and-forget via Hangfire so this webhook handler responds within Akahu's
+            // timeout. The job retries automatically on failure.
+            var jobId = _migrationJobService.EnqueueMigration(connection.UserId, connection.Id);
             _logger.LogInformation(
-                "ACCOUNT/MIGRATE complete for connection {ConnectionId}: success={Success}, txRemapped={TxRemapped}",
-                connection.Id, result.Success, result.TransactionsRemapped);
+                "ACCOUNT/MIGRATE enqueued job {JobId} for connection {ConnectionId}",
+                jobId, connection.Id);
         }
         catch (Exception ex)
         {
-            _logger.LogError(ex, "ACCOUNT/MIGRATE handler failed for connection {ConnectionId}", connection.Id);
+            _logger.LogError(ex, "ACCOUNT/MIGRATE failed to enqueue migration job for connection {ConnectionId}", connection.Id);
         }
+
+        await Task.CompletedTask;
     }
 
     private async Task HandleWebhookCancelledAsync(AkahuWebhookPayload payload, string webhookType, CancellationToken ct)

--- a/src/Core/MyMascada.Application/Features/BankConnections/Commands/SaveAkahuCredentialsCommand.cs
+++ b/src/Core/MyMascada.Application/Features/BankConnections/Commands/SaveAkahuCredentialsCommand.cs
@@ -34,6 +34,7 @@ public class SaveAkahuCredentialsCommandHandler : IRequestHandler<SaveAkahuCrede
     private readonly IAkahuUserCredentialRepository _credentialRepository;
     private readonly IBankConnectionRepository _bankConnectionRepository;
     private readonly ISettingsEncryptionService _encryptionService;
+    private readonly IAkahuWebhookSubscriptionService _webhookSubscriptionService;
     private readonly IApplicationLogger<SaveAkahuCredentialsCommandHandler> _logger;
 
     public SaveAkahuCredentialsCommandHandler(
@@ -41,12 +42,14 @@ public class SaveAkahuCredentialsCommandHandler : IRequestHandler<SaveAkahuCrede
         IAkahuUserCredentialRepository credentialRepository,
         IBankConnectionRepository bankConnectionRepository,
         ISettingsEncryptionService encryptionService,
+        IAkahuWebhookSubscriptionService webhookSubscriptionService,
         IApplicationLogger<SaveAkahuCredentialsCommandHandler> logger)
     {
         _akahuApiClient = akahuApiClient;
         _credentialRepository = credentialRepository;
         _bankConnectionRepository = bankConnectionRepository;
         _encryptionService = encryptionService;
+        _webhookSubscriptionService = webhookSubscriptionService;
         _logger = logger;
     }
 
@@ -114,6 +117,23 @@ public class SaveAkahuCredentialsCommandHandler : IRequestHandler<SaveAkahuCrede
             };
             await _credentialRepository.AddAsync(newCredential, cancellationToken);
             _logger.LogInformation("Created new Akahu credentials for user {UserId}", request.UserId);
+        }
+
+        // 3b. Ensure Akahu webhook subscriptions exist for this user. Best-effort — never fails the save.
+        try
+        {
+            var ensureResult = await _webhookSubscriptionService.EnsureSubscriptionsAsync(request.UserId, cancellationToken);
+            _logger.LogInformation(
+                "Akahu webhook subscriptions ensured for user {UserId}: subscribed={SubscribedCount}, adopted={AdoptedCount}, healthy={HealthyCount}, failed={FailedCount}",
+                request.UserId,
+                ensureResult.SubscribedTypes.Count,
+                ensureResult.AdoptedTypes.Count,
+                ensureResult.AlreadyHealthyTypes.Count,
+                ensureResult.FailedTypes.Count);
+        }
+        catch (Exception ex)
+        {
+            _logger.LogWarning(ex, "EnsureSubscriptionsAsync threw for user {UserId} during Personal-App save; continuing", request.UserId);
         }
 
         // 4. Get existing connections to mark already linked accounts

--- a/src/Core/MyMascada.Application/Features/BankConnections/DTOs/AkahuConnectionSettings.cs
+++ b/src/Core/MyMascada.Application/Features/BankConnections/DTOs/AkahuConnectionSettings.cs
@@ -1,0 +1,24 @@
+namespace MyMascada.Application.Features.BankConnections.DTOs;
+
+/// <summary>
+/// Settings stored encrypted for an Akahu bank connection.
+/// These are per-connection sync state stored in BankConnection.EncryptedSettings.
+/// NOTE: Access tokens are now stored per-user in AkahuUserCredential, not per-connection.
+/// </summary>
+public class AkahuConnectionSettings
+{
+    /// <summary>
+    /// Akahu account ID (acc_xxx) that this connection is linked to.
+    /// </summary>
+    public string AkahuAccountId { get; set; } = string.Empty;
+
+    /// <summary>
+    /// Last transaction ID that was successfully synced (for incremental sync).
+    /// </summary>
+    public string? LastSyncedTransactionId { get; set; }
+
+    /// <summary>
+    /// Timestamp of the last successful sync.
+    /// </summary>
+    public DateTime? LastSyncTimestamp { get; set; }
+}

--- a/src/Core/MyMascada.Application/Features/BankConnections/DTOs/AkahuWebhookModels.cs
+++ b/src/Core/MyMascada.Application/Features/BankConnections/DTOs/AkahuWebhookModels.cs
@@ -48,6 +48,18 @@ public record AkahuWebhookPayload
     /// </summary>
     [JsonPropertyName("removed_transactions")]
     public string[]? RemovedTransactions { get; init; }
+
+    /// <summary>
+    /// On ACCOUNT/MIGRATE: the classic account ID being migrated away from.
+    /// </summary>
+    [JsonPropertyName("previous_item_id")]
+    public string? PreviousItemId { get; init; }
+
+    /// <summary>
+    /// On ACCOUNT/MIGRATE: the new official account ID.
+    /// </summary>
+    [JsonPropertyName("new_item_id")]
+    public string? NewItemId { get; init; }
 }
 
 /// <summary>
@@ -70,4 +82,6 @@ public static class AkahuWebhookCodes
     public const string Delete = "DELETE";
     public const string InitialUpdate = "INITIAL_UPDATE";
     public const string DefaultUpdate = "DEFAULT_UPDATE";
+    public const string Migrate = "MIGRATE";
+    public const string WebhookCancelled = "WEBHOOK_CANCELLED";
 }

--- a/src/Core/MyMascada.Application/Features/BankConnections/DTOs/BankProviderModels.cs
+++ b/src/Core/MyMascada.Application/Features/BankConnections/DTOs/BankProviderModels.cs
@@ -176,6 +176,14 @@ public record BankTransactionDto
     /// Additional metadata from the provider
     /// </summary>
     public Dictionary<string, object>? Metadata { get; init; }
+
+    /// <summary>
+    /// The external ID of the predecessor transaction when this record was created by Akahu's
+    /// classic-to-official migration. Used to remap historical Transaction.ExternalId values
+    /// without losing categorisation history. Null for new transactions that have no migration
+    /// predecessor.
+    /// </summary>
+    public string? Migrated { get; init; }
 }
 
 /// <summary>

--- a/src/Core/MyMascada.Application/Features/BankConnections/Queries/ExchangeAkahuCodeQuery.cs
+++ b/src/Core/MyMascada.Application/Features/BankConnections/Queries/ExchangeAkahuCodeQuery.cs
@@ -1,5 +1,6 @@
 using MediatR;
 using MyMascada.Application.Common.Interfaces;
+using MyMascada.Application.Features.BankConnections.Commands;
 using MyMascada.Application.Features.BankConnections.DTOs;
 
 namespace MyMascada.Application.Features.BankConnections.Queries;
@@ -39,6 +40,8 @@ public class ExchangeAkahuCodeQueryHandler : IRequestHandler<ExchangeAkahuCodeQu
     private readonly IBankConnectionRepository _bankConnectionRepository;
     private readonly ISettingsEncryptionService _encryptionService;
     private readonly IOAuthStateStore _oauthStateStore;
+    private readonly IAkahuWebhookSubscriptionService _webhookSubscriptionService;
+    private readonly IMediator _mediator;
     private readonly IApplicationLogger<ExchangeAkahuCodeQueryHandler> _logger;
 
     public ExchangeAkahuCodeQueryHandler(
@@ -47,6 +50,8 @@ public class ExchangeAkahuCodeQueryHandler : IRequestHandler<ExchangeAkahuCodeQu
         IBankConnectionRepository bankConnectionRepository,
         ISettingsEncryptionService encryptionService,
         IOAuthStateStore oauthStateStore,
+        IAkahuWebhookSubscriptionService webhookSubscriptionService,
+        IMediator mediator,
         IApplicationLogger<ExchangeAkahuCodeQueryHandler> logger)
     {
         _akahuApiClient = akahuApiClient ?? throw new ArgumentNullException(nameof(akahuApiClient));
@@ -54,6 +59,8 @@ public class ExchangeAkahuCodeQueryHandler : IRequestHandler<ExchangeAkahuCodeQu
         _bankConnectionRepository = bankConnectionRepository ?? throw new ArgumentNullException(nameof(bankConnectionRepository));
         _encryptionService = encryptionService ?? throw new ArgumentNullException(nameof(encryptionService));
         _oauthStateStore = oauthStateStore ?? throw new ArgumentNullException(nameof(oauthStateStore));
+        _webhookSubscriptionService = webhookSubscriptionService ?? throw new ArgumentNullException(nameof(webhookSubscriptionService));
+        _mediator = mediator ?? throw new ArgumentNullException(nameof(mediator));
         _logger = logger ?? throw new ArgumentNullException(nameof(logger));
     }
 
@@ -126,6 +133,76 @@ public class ExchangeAkahuCodeQueryHandler : IRequestHandler<ExchangeAkahuCodeQu
                 CreatedAt = DateTime.UtcNow,
                 UpdatedAt = DateTime.UtcNow
             }, cancellationToken);
+        }
+
+        // 1b. Make sure the user has the required Akahu webhook subscriptions in place. The
+        // service swallows per-type failures so this never blocks OAuth completion.
+        try
+        {
+            var ensureResult = await _webhookSubscriptionService.EnsureSubscriptionsAsync(request.UserId, cancellationToken);
+            _logger.LogInformation(
+                "Akahu webhook subscriptions ensured for user {UserId}: subscribed={SubscribedCount}, adopted={AdoptedCount}, healthy={HealthyCount}, failed={FailedCount}",
+                request.UserId,
+                ensureResult.SubscribedTypes.Count,
+                ensureResult.AdoptedTypes.Count,
+                ensureResult.AlreadyHealthyTypes.Count,
+                ensureResult.FailedTypes.Count);
+        }
+        catch (Exception ex)
+        {
+            _logger.LogWarning(ex, "EnsureSubscriptionsAsync threw for user {UserId} during OAuth callback; continuing", request.UserId);
+        }
+
+        // 1c. Run the Akahu classic→official migration for any existing active connections the
+        // user already has. Failures are logged but never block the OAuth callback — the
+        // command itself marks an unmigrated connection as "Awaiting re-authorisation".
+        try
+        {
+            var existingAkahuConnections = await _bankConnectionRepository.GetByUserIdAsync(request.UserId, cancellationToken);
+            var candidates = existingAkahuConnections
+                .Where(c => c.ProviderId == AkahuProviderId && c.IsActive)
+                .ToList();
+
+            if (candidates.Count > 0)
+            {
+                var migrated = 0;
+                var awaitingReauth = 0;
+                var failed = 0;
+                var totalTransactionsRemapped = 0;
+
+                foreach (var candidate in candidates)
+                {
+                    try
+                    {
+                        var migrateResult = await _mediator.Send(
+                            new MigrateAkahuConnectionCommand(request.UserId, candidate.Id),
+                            cancellationToken);
+
+                        if (migrateResult.Success)
+                        {
+                            migrated++;
+                            totalTransactionsRemapped += migrateResult.TransactionsRemapped;
+                        }
+                        else
+                        {
+                            awaitingReauth++;
+                        }
+                    }
+                    catch (Exception ex)
+                    {
+                        failed++;
+                        _logger.LogWarning(ex, "MigrateAkahuConnectionCommand threw for connection {ConnectionId}", candidate.Id);
+                    }
+                }
+
+                _logger.LogInformation(
+                    "Post-OAuth Akahu migration summary for user {UserId}: migrated={Migrated}, awaitingReauth={AwaitingReauth}, failed={Failed}, txRemapped={TxRemapped}",
+                    request.UserId, migrated, awaitingReauth, failed, totalTransactionsRemapped);
+            }
+        }
+        catch (Exception ex)
+        {
+            _logger.LogWarning(ex, "Post-OAuth Akahu migration sweep failed for user {UserId}; continuing", request.UserId);
         }
 
         // 2. Get all Akahu accounts using the app's token and the OAuth access token

--- a/src/Core/MyMascada.Application/Features/BankConnections/Queries/ExchangeAkahuCodeQuery.cs
+++ b/src/Core/MyMascada.Application/Features/BankConnections/Queries/ExchangeAkahuCodeQuery.cs
@@ -1,6 +1,6 @@
 using MediatR;
+using MyMascada.Application.BackgroundJobs;
 using MyMascada.Application.Common.Interfaces;
-using MyMascada.Application.Features.BankConnections.Commands;
 using MyMascada.Application.Features.BankConnections.DTOs;
 
 namespace MyMascada.Application.Features.BankConnections.Queries;
@@ -41,7 +41,7 @@ public class ExchangeAkahuCodeQueryHandler : IRequestHandler<ExchangeAkahuCodeQu
     private readonly ISettingsEncryptionService _encryptionService;
     private readonly IOAuthStateStore _oauthStateStore;
     private readonly IAkahuWebhookSubscriptionService _webhookSubscriptionService;
-    private readonly IMediator _mediator;
+    private readonly IAkahuMigrationJobService _migrationJobService;
     private readonly IApplicationLogger<ExchangeAkahuCodeQueryHandler> _logger;
 
     public ExchangeAkahuCodeQueryHandler(
@@ -51,7 +51,7 @@ public class ExchangeAkahuCodeQueryHandler : IRequestHandler<ExchangeAkahuCodeQu
         ISettingsEncryptionService encryptionService,
         IOAuthStateStore oauthStateStore,
         IAkahuWebhookSubscriptionService webhookSubscriptionService,
-        IMediator mediator,
+        IAkahuMigrationJobService migrationJobService,
         IApplicationLogger<ExchangeAkahuCodeQueryHandler> logger)
     {
         _akahuApiClient = akahuApiClient ?? throw new ArgumentNullException(nameof(akahuApiClient));
@@ -60,7 +60,7 @@ public class ExchangeAkahuCodeQueryHandler : IRequestHandler<ExchangeAkahuCodeQu
         _encryptionService = encryptionService ?? throw new ArgumentNullException(nameof(encryptionService));
         _oauthStateStore = oauthStateStore ?? throw new ArgumentNullException(nameof(oauthStateStore));
         _webhookSubscriptionService = webhookSubscriptionService ?? throw new ArgumentNullException(nameof(webhookSubscriptionService));
-        _mediator = mediator ?? throw new ArgumentNullException(nameof(mediator));
+        _migrationJobService = migrationJobService ?? throw new ArgumentNullException(nameof(migrationJobService));
         _logger = logger ?? throw new ArgumentNullException(nameof(logger));
     }
 
@@ -153,51 +153,36 @@ public class ExchangeAkahuCodeQueryHandler : IRequestHandler<ExchangeAkahuCodeQu
             _logger.LogWarning(ex, "EnsureSubscriptionsAsync threw for user {UserId} during OAuth callback; continuing", request.UserId);
         }
 
-        // 1c. Run the Akahu classic→official migration for any existing active connections the
-        // user already has. Failures are logged but never block the OAuth callback — the
-        // command itself marks an unmigrated connection as "Awaiting re-authorisation".
+        // 1c. Enqueue the Akahu classic→official migration as a background job for any
+        // existing active connections the user has that have not already been migrated.
+        // Failures are logged but never block the OAuth callback.
         try
         {
             var existingAkahuConnections = await _bankConnectionRepository.GetByUserIdAsync(request.UserId, cancellationToken);
             var candidates = existingAkahuConnections
-                .Where(c => c.ProviderId == AkahuProviderId && c.IsActive)
+                .Where(c => c.ProviderId == AkahuProviderId && c.IsActive && c.LastMigratedAt == null)
                 .ToList();
 
             if (candidates.Count > 0)
             {
-                var migrated = 0;
-                var awaitingReauth = 0;
-                var failed = 0;
-                var totalTransactionsRemapped = 0;
-
                 foreach (var candidate in candidates)
                 {
                     try
                     {
-                        var migrateResult = await _mediator.Send(
-                            new MigrateAkahuConnectionCommand(request.UserId, candidate.Id),
-                            cancellationToken);
-
-                        if (migrateResult.Success)
-                        {
-                            migrated++;
-                            totalTransactionsRemapped += migrateResult.TransactionsRemapped;
-                        }
-                        else
-                        {
-                            awaitingReauth++;
-                        }
+                        var jobId = _migrationJobService.EnqueueMigration(request.UserId, candidate.Id);
+                        _logger.LogInformation(
+                            "Post-OAuth: enqueued Akahu migration job {JobId} for connection {ConnectionId} (user {UserId})",
+                            jobId, candidate.Id, request.UserId);
                     }
                     catch (Exception ex)
                     {
-                        failed++;
-                        _logger.LogWarning(ex, "MigrateAkahuConnectionCommand threw for connection {ConnectionId}", candidate.Id);
+                        _logger.LogWarning(ex, "Post-OAuth: failed to enqueue Akahu migration for connection {ConnectionId}", candidate.Id);
                     }
                 }
 
                 _logger.LogInformation(
-                    "Post-OAuth Akahu migration summary for user {UserId}: migrated={Migrated}, awaitingReauth={AwaitingReauth}, failed={Failed}, txRemapped={TxRemapped}",
-                    request.UserId, migrated, awaitingReauth, failed, totalTransactionsRemapped);
+                    "Post-OAuth Akahu migration sweep enqueued {Count} job(s) for user {UserId}",
+                    candidates.Count, request.UserId);
             }
         }
         catch (Exception ex)

--- a/src/Core/MyMascada.Application/Features/BankConnections/Queries/GetAkahuMigrationStatusQuery.cs
+++ b/src/Core/MyMascada.Application/Features/BankConnections/Queries/GetAkahuMigrationStatusQuery.cs
@@ -36,6 +36,13 @@ public class GetAkahuMigrationStatusQueryHandler
     private const string AkahuProviderId = "akahu";
 
     /// <summary>
+    /// Marker the migration command writes into <c>BankConnection.LastSyncError</c> when it
+    /// cannot find a matching <c>_migrated</c> account and disables the connection. The
+    /// migration banner needs to keep showing those rows so the user can re-authorise.
+    /// </summary>
+    private const string AwaitingReauthMarker = "Awaiting re-authorisation";
+
+    /// <summary>
     /// 24 May 2026, 23:59:59 New Zealand time (UTC+12).
     /// </summary>
     private static readonly DateTimeOffset MigrationDeadline =
@@ -68,9 +75,10 @@ public class GetAkahuMigrationStatusQueryHandler
         var allConnections = await _bankConnectionRepository.GetByUserIdAsync(request.UserId, cancellationToken);
         var akahuConnections = allConnections
             .Where(c => c.ProviderId == AkahuProviderId
-                && c.IsActive
                 && !string.IsNullOrEmpty(c.ExternalAccountId)
-                && c.LastMigratedAt == null)
+                && c.LastMigratedAt == null
+                && (c.IsActive
+                    || (c.LastSyncError != null && c.LastSyncError.Contains(AwaitingReauthMarker, StringComparison.OrdinalIgnoreCase))))
             .ToList();
 
         if (akahuConnections.Count == 0)

--- a/src/Core/MyMascada.Application/Features/BankConnections/Queries/GetAkahuMigrationStatusQuery.cs
+++ b/src/Core/MyMascada.Application/Features/BankConnections/Queries/GetAkahuMigrationStatusQuery.cs
@@ -1,0 +1,141 @@
+using MediatR;
+using MyMascada.Application.Common.Interfaces;
+
+namespace MyMascada.Application.Features.BankConnections.Queries;
+
+/// <summary>
+/// Query returning the user's Akahu connections that still need to be migrated to the
+/// official open-banking equivalent before the 24 May 2026 cut-over.
+/// </summary>
+public record GetAkahuMigrationStatusQuery(Guid UserId) : IRequest<AkahuMigrationStatusDto>;
+
+/// <summary>
+/// DTO describing the user's pending Akahu migrations and the global deadline.
+/// </summary>
+public record AkahuMigrationStatusDto(
+    IReadOnlyList<PendingMigrationConnectionDto> PendingConnections,
+    DateTimeOffset Deadline);
+
+/// <summary>
+/// One row per Akahu <see cref="MyMascada.Domain.Entities.BankConnection"/> that still
+/// resolves to a classic <c>acc_xxx</c> and has a discoverable <c>_migrated</c> successor.
+/// </summary>
+public record PendingMigrationConnectionDto(
+    int ConnectionId,
+    string? BankName,
+    string? ExternalAccountId,
+    DateTime? LastSyncedAt);
+
+/// <summary>
+/// Handler for <see cref="GetAkahuMigrationStatusQuery"/>. Tolerates token errors and returns
+/// an empty list rather than throwing, so the frontend dashboard can call this without guarding.
+/// </summary>
+public class GetAkahuMigrationStatusQueryHandler
+    : IRequestHandler<GetAkahuMigrationStatusQuery, AkahuMigrationStatusDto>
+{
+    private const string AkahuProviderId = "akahu";
+
+    /// <summary>
+    /// 24 May 2026, 23:59:59 New Zealand time (UTC+12).
+    /// </summary>
+    private static readonly DateTimeOffset MigrationDeadline =
+        new(2026, 5, 24, 23, 59, 59, TimeSpan.FromHours(12));
+
+    private readonly IBankConnectionRepository _bankConnectionRepository;
+    private readonly IAkahuUserCredentialRepository _credentialRepository;
+    private readonly IAkahuApiClient _akahuApiClient;
+    private readonly ISettingsEncryptionService _encryptionService;
+    private readonly IApplicationLogger<GetAkahuMigrationStatusQueryHandler> _logger;
+
+    public GetAkahuMigrationStatusQueryHandler(
+        IBankConnectionRepository bankConnectionRepository,
+        IAkahuUserCredentialRepository credentialRepository,
+        IAkahuApiClient akahuApiClient,
+        ISettingsEncryptionService encryptionService,
+        IApplicationLogger<GetAkahuMigrationStatusQueryHandler> logger)
+    {
+        _bankConnectionRepository = bankConnectionRepository ?? throw new ArgumentNullException(nameof(bankConnectionRepository));
+        _credentialRepository = credentialRepository ?? throw new ArgumentNullException(nameof(credentialRepository));
+        _akahuApiClient = akahuApiClient ?? throw new ArgumentNullException(nameof(akahuApiClient));
+        _encryptionService = encryptionService ?? throw new ArgumentNullException(nameof(encryptionService));
+        _logger = logger ?? throw new ArgumentNullException(nameof(logger));
+    }
+
+    public async Task<AkahuMigrationStatusDto> Handle(GetAkahuMigrationStatusQuery request, CancellationToken cancellationToken)
+    {
+        var empty = new AkahuMigrationStatusDto(Array.Empty<PendingMigrationConnectionDto>(), MigrationDeadline);
+
+        var allConnections = await _bankConnectionRepository.GetByUserIdAsync(request.UserId, cancellationToken);
+        var akahuConnections = allConnections
+            .Where(c => c.ProviderId == AkahuProviderId
+                && c.IsActive
+                && !string.IsNullOrEmpty(c.ExternalAccountId)
+                && c.LastMigratedAt == null)
+            .ToList();
+
+        if (akahuConnections.Count == 0)
+            return empty;
+
+        var credential = await _credentialRepository.GetByUserIdAsync(request.UserId, cancellationToken);
+        if (credential == null)
+            return empty;
+
+        string appIdToken;
+        string userToken;
+        try
+        {
+            var decryptedApp = _encryptionService.DecryptSettings<string>(credential.EncryptedAppToken);
+            var decryptedUser = _encryptionService.DecryptSettings<string>(credential.EncryptedUserToken);
+
+            if (string.IsNullOrEmpty(decryptedApp) || string.IsNullOrEmpty(decryptedUser))
+                return empty;
+
+            appIdToken = decryptedApp;
+            userToken = decryptedUser;
+        }
+        catch (Exception ex)
+        {
+            _logger.LogWarning(ex, "GetAkahuMigrationStatus: failed to decrypt credentials for user {UserId}", request.UserId);
+            return empty;
+        }
+
+        IReadOnlyList<AkahuAccountInfo> accounts;
+        try
+        {
+            accounts = await _akahuApiClient.GetAccountsWithCredentialsAsync(appIdToken, userToken, cancellationToken);
+        }
+        catch (UnauthorizedAccessException ex)
+        {
+            _logger.LogWarning(ex, "GetAkahuMigrationStatus: Akahu credentials unauthorised for user {UserId}", request.UserId);
+            return empty;
+        }
+        catch (Exception ex)
+        {
+            _logger.LogWarning(ex, "GetAkahuMigrationStatus: Akahu API call failed for user {UserId}", request.UserId);
+            return empty;
+        }
+
+        var migratedToOld = accounts
+            .Where(a => !string.IsNullOrEmpty(a.Migrated))
+            .GroupBy(a => a.Migrated!, StringComparer.Ordinal)
+            .ToDictionary(g => g.Key, g => g.First(), StringComparer.Ordinal);
+
+        var pending = new List<PendingMigrationConnectionDto>();
+        foreach (var connection in akahuConnections)
+        {
+            if (string.IsNullOrEmpty(connection.ExternalAccountId))
+                continue;
+
+            if (!migratedToOld.ContainsKey(connection.ExternalAccountId))
+                continue;
+
+            pending.Add(new PendingMigrationConnectionDto(
+                connection.Id,
+                connection.ExternalAccountName,
+                connection.ExternalAccountId,
+                connection.LastSyncAt));
+        }
+
+        return new AkahuMigrationStatusDto(pending, MigrationDeadline);
+    }
+}

--- a/src/Core/MyMascada.Domain/Entities/AkahuWebhookSubscription.cs
+++ b/src/Core/MyMascada.Domain/Entities/AkahuWebhookSubscription.cs
@@ -1,0 +1,61 @@
+using System.ComponentModel.DataAnnotations;
+using MyMascada.Domain.Common;
+
+namespace MyMascada.Domain.Entities;
+
+/// <summary>
+/// Persisted record of an Akahu webhook subscription tied to a user's <see cref="AkahuUserCredential"/>.
+/// One row per (UserId, WebhookType) at most. Mirrors Akahu's authoritative state so MyMascada
+/// can issue DELETE /webhooks/{id} on disconnect and reconcile drift on a schedule.
+/// </summary>
+public class AkahuWebhookSubscription : BaseEntity
+{
+    /// <summary>
+    /// The MyMascada user that owns this subscription. Also acts as the <c>state</c> value Akahu
+    /// echoes back on every webhook delivery (encoded as a Guid "N" format string).
+    /// </summary>
+    [Required]
+    public Guid UserId { get; set; }
+
+    /// <summary>
+    /// FK to <see cref="AkahuUserCredential"/>. Lets a credential delete cascade clean up subscriptions.
+    /// </summary>
+    [Required]
+    public int AkahuUserCredentialId { get; set; }
+
+    /// <summary>
+    /// The Akahu webhook subscription ID returned by POST /webhooks (e.g. <c>whk_xxx</c>).
+    /// </summary>
+    [Required]
+    [MaxLength(100)]
+    public string WebhookId { get; set; } = string.Empty;
+
+    /// <summary>
+    /// Akahu webhook type the subscription covers (one of TOKEN, ACCOUNT, TRANSACTION).
+    /// </summary>
+    [Required]
+    [MaxLength(40)]
+    public string WebhookType { get; set; } = string.Empty;
+
+    /// <summary>
+    /// Echo of the <c>state</c> value registered at subscription time.
+    /// </summary>
+    [MaxLength(100)]
+    public string? State { get; set; }
+
+    /// <summary>
+    /// UTC timestamp when the row (and the underlying Akahu subscription) was created.
+    /// </summary>
+    public DateTime SubscribedAt { get; set; }
+
+    /// <summary>
+    /// UTC timestamp when the reconciliation job last confirmed the subscription is healthy at Akahu.
+    /// </summary>
+    public DateTime? LastReconciledAt { get; set; }
+
+    /// <summary>
+    /// Last reconciliation error message (truncated). Null when the subscription is healthy.
+    /// </summary>
+    [MaxLength(500)]
+    public string? LastReconcileError { get; set; }
+}

--- a/src/Core/MyMascada.Domain/Entities/BankConnection.cs
+++ b/src/Core/MyMascada.Domain/Entities/BankConnection.cs
@@ -61,6 +61,12 @@ public class BankConnection : BaseEntity
     [MaxLength(1000)]
     public string? LastSyncError { get; set; }
 
+    /// <summary>
+    /// UTC timestamp of when this connection was successfully migrated from an Akahu
+    /// classic account to its official open-banking equivalent. Null = never migrated.
+    /// </summary>
+    public DateTime? LastMigratedAt { get; set; }
+
     // Navigation properties
 
     /// <summary>

--- a/src/Infrastructure/MyMascada.Infrastructure/BackgroundJobs/AkahuMigrationJobService.cs
+++ b/src/Infrastructure/MyMascada.Infrastructure/BackgroundJobs/AkahuMigrationJobService.cs
@@ -33,8 +33,8 @@ public class AkahuMigrationJobService : IAkahuMigrationJobService
             s => s.ProcessMigrationAsync(userId, bankConnectionId));
 
         _logger.LogInformation(
-            "Enqueued Akahu migration job {JobId} for connection {ConnectionId} (user {UserId})",
-            jobId, bankConnectionId, userId);
+            "Enqueued Akahu migration job {JobId} for connection {ConnectionId}",
+            jobId, bankConnectionId);
 
         return jobId;
     }

--- a/src/Infrastructure/MyMascada.Infrastructure/BackgroundJobs/AkahuMigrationJobService.cs
+++ b/src/Infrastructure/MyMascada.Infrastructure/BackgroundJobs/AkahuMigrationJobService.cs
@@ -1,0 +1,61 @@
+using Hangfire;
+using MediatR;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
+using MyMascada.Application.BackgroundJobs;
+using MyMascada.Application.Features.BankConnections.Commands;
+
+namespace MyMascada.Infrastructure.BackgroundJobs;
+
+/// <summary>
+/// Hangfire-backed implementation of <see cref="IAkahuMigrationJobService"/>.
+/// Decouples the webhook/OAuth request lifetime from the migration's network and DB work.
+/// </summary>
+public class AkahuMigrationJobService : IAkahuMigrationJobService
+{
+    private readonly IBackgroundJobClient _backgroundJobClient;
+    private readonly IServiceScopeFactory _serviceScopeFactory;
+    private readonly ILogger<AkahuMigrationJobService> _logger;
+
+    public AkahuMigrationJobService(
+        IBackgroundJobClient backgroundJobClient,
+        IServiceScopeFactory serviceScopeFactory,
+        ILogger<AkahuMigrationJobService> logger)
+    {
+        _backgroundJobClient = backgroundJobClient ?? throw new ArgumentNullException(nameof(backgroundJobClient));
+        _serviceScopeFactory = serviceScopeFactory ?? throw new ArgumentNullException(nameof(serviceScopeFactory));
+        _logger = logger ?? throw new ArgumentNullException(nameof(logger));
+    }
+
+    public string EnqueueMigration(Guid userId, int bankConnectionId)
+    {
+        var jobId = _backgroundJobClient.Enqueue<IAkahuMigrationJobService>(
+            s => s.ProcessMigrationAsync(userId, bankConnectionId));
+
+        _logger.LogInformation(
+            "Enqueued Akahu migration job {JobId} for connection {ConnectionId} (user {UserId})",
+            jobId, bankConnectionId, userId);
+
+        return jobId;
+    }
+
+    [AutomaticRetry(Attempts = 3, DelaysInSeconds = new[] { 60, 300, 900 })]
+    public async Task ProcessMigrationAsync(Guid userId, int bankConnectionId)
+    {
+        using var scope = _serviceScopeFactory.CreateScope();
+        var mediator = scope.ServiceProvider.GetRequiredService<IMediator>();
+
+        try
+        {
+            var result = await mediator.Send(new MigrateAkahuConnectionCommand(userId, bankConnectionId));
+            _logger.LogInformation(
+                "Akahu migration job complete for connection {ConnectionId}: success={Success}, txRemapped={TxRemapped}",
+                bankConnectionId, result.Success, result.TransactionsRemapped);
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(ex, "Akahu migration job failed for connection {ConnectionId}", bankConnectionId);
+            throw; // Let Hangfire's AutomaticRetry handle this.
+        }
+    }
+}

--- a/src/Infrastructure/MyMascada.Infrastructure/BackgroundJobs/AkahuWebhookSubscriptionReconciliationJobService.cs
+++ b/src/Infrastructure/MyMascada.Infrastructure/BackgroundJobs/AkahuWebhookSubscriptionReconciliationJobService.cs
@@ -1,0 +1,88 @@
+using Hangfire;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
+using MyMascada.Application.BackgroundJobs;
+using MyMascada.Application.Common.Interfaces;
+
+namespace MyMascada.Infrastructure.BackgroundJobs;
+
+/// <summary>
+/// Hangfire-based background job that reconciles Akahu webhook subscriptions for every
+/// active user. Runs daily to heal drift between MyMascada's stored subscription rows and
+/// Akahu's authoritative subscription list (the safety net for partial subscription failures).
+/// </summary>
+public class AkahuWebhookSubscriptionReconciliationJobService
+    : IAkahuWebhookSubscriptionReconciliationJobService
+{
+    private readonly IServiceScopeFactory _serviceScopeFactory;
+    private readonly ILogger<AkahuWebhookSubscriptionReconciliationJobService> _logger;
+
+    public AkahuWebhookSubscriptionReconciliationJobService(
+        IServiceScopeFactory serviceScopeFactory,
+        ILogger<AkahuWebhookSubscriptionReconciliationJobService> logger)
+    {
+        _serviceScopeFactory = serviceScopeFactory;
+        _logger = logger;
+    }
+
+    /// <summary>
+    /// Reconciles webhook subscriptions for every active Akahu user credential.
+    /// Scheduled to run daily at 4:00 AM.
+    /// </summary>
+    [AutomaticRetry(Attempts = 3, DelaysInSeconds = new[] { 60, 300, 900 })]
+    public async Task ReconcileAllAsync()
+    {
+        _logger.LogInformation("Starting Akahu webhook subscription reconciliation job");
+
+        try
+        {
+            List<Guid> userIds;
+            using (var scope = _serviceScopeFactory.CreateScope())
+            {
+                var credentialRepository = scope.ServiceProvider.GetRequiredService<IAkahuUserCredentialRepository>();
+                var credentials = await credentialRepository.GetActiveCredentialsAsync();
+                userIds = credentials.Select(c => c.UserId).Distinct().ToList();
+            }
+
+            if (userIds.Count == 0)
+            {
+                _logger.LogDebug("No active Akahu credentials to reconcile webhook subscriptions for");
+                return;
+            }
+
+            _logger.LogInformation("Reconciling Akahu webhook subscriptions for {Count} users", userIds.Count);
+
+            var successCount = 0;
+            var failCount = 0;
+
+            foreach (var userId in userIds)
+            {
+                try
+                {
+                    using var scope = _serviceScopeFactory.CreateScope();
+                    var subscriptionService = scope.ServiceProvider
+                        .GetRequiredService<IAkahuWebhookSubscriptionService>();
+
+                    await subscriptionService.ReconcileAsync(userId);
+                    successCount++;
+                }
+                catch (Exception ex)
+                {
+                    failCount++;
+                    _logger.LogError(ex,
+                        "Failed to reconcile Akahu webhook subscriptions for user {UserId}. Continuing with remaining users.",
+                        userId);
+                }
+            }
+
+            _logger.LogInformation(
+                "Akahu webhook subscription reconciliation job completed: {Success} succeeded, {Failed} failed",
+                successCount, failCount);
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(ex, "Akahu webhook subscription reconciliation job failed unexpectedly");
+            throw; // Let Hangfire retry
+        }
+    }
+}

--- a/src/Infrastructure/MyMascada.Infrastructure/Data/ApplicationDbContext.cs
+++ b/src/Infrastructure/MyMascada.Infrastructure/Data/ApplicationDbContext.cs
@@ -31,6 +31,7 @@ public class ApplicationDbContext : DbContext
     public DbSet<BankConnection> BankConnections => Set<BankConnection>();
     public DbSet<BankSyncLog> BankSyncLogs => Set<BankSyncLog>();
     public DbSet<AkahuUserCredential> AkahuUserCredentials => Set<AkahuUserCredential>();
+    public DbSet<AkahuWebhookSubscription> AkahuWebhookSubscriptions => Set<AkahuWebhookSubscription>();
     public DbSet<BankCategoryMapping> BankCategoryMappings => Set<BankCategoryMapping>();
     public DbSet<PasswordResetToken> PasswordResetTokens => Set<PasswordResetToken>();
     public DbSet<EmailVerificationToken> EmailVerificationTokens => Set<EmailVerificationToken>();
@@ -460,6 +461,30 @@ public class ApplicationDbContext : DbContext
 
             // Unique constraint: one credential per user (user can only have one Akahu Personal App)
             entity.HasIndex(e => e.UserId).IsUnique();
+
+            entity.HasQueryFilter(e => !e.IsDeleted);
+        });
+
+        // AkahuWebhookSubscription configuration
+        modelBuilder.Entity<AkahuWebhookSubscription>(entity =>
+        {
+            entity.HasKey(e => e.Id);
+            entity.Property(e => e.UserId).IsRequired();
+            entity.Property(e => e.AkahuUserCredentialId).IsRequired();
+            entity.Property(e => e.WebhookId).IsRequired().HasMaxLength(100);
+            entity.Property(e => e.WebhookType).IsRequired().HasMaxLength(40);
+            entity.Property(e => e.State).HasMaxLength(100);
+            entity.Property(e => e.LastReconcileError).HasMaxLength(500);
+
+            entity.HasIndex(e => e.WebhookId).IsUnique();
+            entity.HasIndex(e => new { e.UserId, e.WebhookType })
+                .IsUnique()
+                .HasFilter("\"IsDeleted\" = false");
+
+            entity.HasOne<AkahuUserCredential>()
+                .WithMany()
+                .HasForeignKey(e => e.AkahuUserCredentialId)
+                .OnDelete(DeleteBehavior.Cascade);
 
             entity.HasQueryFilter(e => !e.IsDeleted);
         });

--- a/src/Infrastructure/MyMascada.Infrastructure/Data/ApplicationDbContext.cs
+++ b/src/Infrastructure/MyMascada.Infrastructure/Data/ApplicationDbContext.cs
@@ -476,7 +476,12 @@ public class ApplicationDbContext : DbContext
             entity.Property(e => e.State).HasMaxLength(100);
             entity.Property(e => e.LastReconcileError).HasMaxLength(500);
 
-            entity.HasIndex(e => e.WebhookId).IsUnique();
+            // Both unique indexes are filtered to non-deleted rows: the entity is
+            // soft-deleted, and reconciliation re-subscribes (re-using a WebhookId)
+            // after a partial teardown — an unfiltered constraint would block that.
+            entity.HasIndex(e => e.WebhookId)
+                .IsUnique()
+                .HasFilter("\"IsDeleted\" = false");
             entity.HasIndex(e => new { e.UserId, e.WebhookType })
                 .IsUnique()
                 .HasFilter("\"IsDeleted\" = false");

--- a/src/Infrastructure/MyMascada.Infrastructure/Data/UnitOfWork.cs
+++ b/src/Infrastructure/MyMascada.Infrastructure/Data/UnitOfWork.cs
@@ -1,0 +1,61 @@
+using Microsoft.EntityFrameworkCore.Storage;
+using MyMascada.Application.Common.Interfaces;
+
+namespace MyMascada.Infrastructure.Data;
+
+/// <summary>
+/// EF Core-backed implementation of <see cref="IUnitOfWork"/>. Wraps an
+/// <see cref="IDbContextTransaction"/> so application-layer handlers can compose
+/// atomic multi-repository writes without referencing EF Core types directly.
+/// </summary>
+public class UnitOfWork : IUnitOfWork
+{
+    private readonly ApplicationDbContext _context;
+
+    public UnitOfWork(ApplicationDbContext context)
+    {
+        _context = context ?? throw new ArgumentNullException(nameof(context));
+    }
+
+    public async Task<IUnitOfWorkTransaction> BeginTransactionAsync(CancellationToken cancellationToken = default)
+    {
+        var transaction = await _context.Database.BeginTransactionAsync(cancellationToken);
+        return new UnitOfWorkTransaction(transaction);
+    }
+
+    private sealed class UnitOfWorkTransaction : IUnitOfWorkTransaction
+    {
+        private readonly IDbContextTransaction _transaction;
+        private bool _committed;
+
+        public UnitOfWorkTransaction(IDbContextTransaction transaction)
+        {
+            _transaction = transaction;
+        }
+
+        public async Task CommitAsync(CancellationToken cancellationToken = default)
+        {
+            await _transaction.CommitAsync(cancellationToken);
+            _committed = true;
+        }
+
+        public async ValueTask DisposeAsync()
+        {
+            if (!_committed)
+            {
+                try
+                {
+                    await _transaction.RollbackAsync();
+                }
+                catch
+                {
+                    // Rollback failures are swallowed because the underlying transaction
+                    // may already have been rolled back (e.g. connection drop). Dispose
+                    // must not throw out of a using block.
+                }
+            }
+
+            await _transaction.DisposeAsync();
+        }
+    }
+}

--- a/src/Infrastructure/MyMascada.Infrastructure/Data/UnitOfWork.cs
+++ b/src/Infrastructure/MyMascada.Infrastructure/Data/UnitOfWork.cs
@@ -1,4 +1,5 @@
 using Microsoft.EntityFrameworkCore.Storage;
+using Microsoft.Extensions.Logging;
 using MyMascada.Application.Common.Interfaces;
 
 namespace MyMascada.Infrastructure.Data;
@@ -11,26 +12,30 @@ namespace MyMascada.Infrastructure.Data;
 public class UnitOfWork : IUnitOfWork
 {
     private readonly ApplicationDbContext _context;
+    private readonly ILogger<UnitOfWork> _logger;
 
-    public UnitOfWork(ApplicationDbContext context)
+    public UnitOfWork(ApplicationDbContext context, ILogger<UnitOfWork> logger)
     {
         _context = context ?? throw new ArgumentNullException(nameof(context));
+        _logger = logger ?? throw new ArgumentNullException(nameof(logger));
     }
 
     public async Task<IUnitOfWorkTransaction> BeginTransactionAsync(CancellationToken cancellationToken = default)
     {
         var transaction = await _context.Database.BeginTransactionAsync(cancellationToken);
-        return new UnitOfWorkTransaction(transaction);
+        return new UnitOfWorkTransaction(transaction, _logger);
     }
 
     private sealed class UnitOfWorkTransaction : IUnitOfWorkTransaction
     {
         private readonly IDbContextTransaction _transaction;
+        private readonly ILogger _logger;
         private bool _committed;
 
-        public UnitOfWorkTransaction(IDbContextTransaction transaction)
+        public UnitOfWorkTransaction(IDbContextTransaction transaction, ILogger logger)
         {
             _transaction = transaction;
+            _logger = logger;
         }
 
         public async Task CommitAsync(CancellationToken cancellationToken = default)
@@ -47,11 +52,12 @@ public class UnitOfWork : IUnitOfWork
                 {
                     await _transaction.RollbackAsync();
                 }
-                catch
+                catch (Exception ex)
                 {
-                    // Rollback failures are swallowed because the underlying transaction
-                    // may already have been rolled back (e.g. connection drop). Dispose
-                    // must not throw out of a using block.
+                    // Don't throw out of DisposeAsync — but make the failed cleanup visible
+                    // during incidents. The underlying transaction may already have been
+                    // rolled back (e.g. connection drop), which is fine.
+                    _logger.LogWarning(ex, "UnitOfWork rollback failed during dispose");
                 }
             }
 

--- a/src/Infrastructure/MyMascada.Infrastructure/Repositories/AkahuUserCredentialRepository.cs
+++ b/src/Infrastructure/MyMascada.Infrastructure/Repositories/AkahuUserCredentialRepository.cs
@@ -62,6 +62,14 @@ public class AkahuUserCredentialRepository : IAkahuUserCredentialRepository
     }
 
     /// <inheritdoc />
+    public async Task<IReadOnlyList<AkahuUserCredential>> GetActiveCredentialsAsync(CancellationToken ct = default)
+    {
+        return await _context.AkahuUserCredentials
+            .Where(c => !c.IsDeleted && c.ConsentRevokedAt == null)
+            .ToListAsync(ct);
+    }
+
+    /// <inheritdoc />
     public async Task UpdateRevocationStateAsync(int credentialId, bool isRevocationPending, int revocationFailureCount, DateTime? revocationFailedAt, CancellationToken ct = default)
     {
         await _context.AkahuUserCredentials

--- a/src/Infrastructure/MyMascada.Infrastructure/Repositories/AkahuWebhookSubscriptionRepository.cs
+++ b/src/Infrastructure/MyMascada.Infrastructure/Repositories/AkahuWebhookSubscriptionRepository.cs
@@ -1,0 +1,85 @@
+using Microsoft.EntityFrameworkCore;
+using MyMascada.Application.Common.Interfaces;
+using MyMascada.Domain.Entities;
+using MyMascada.Infrastructure.Data;
+
+namespace MyMascada.Infrastructure.Repositories;
+
+/// <summary>
+/// EF Core repository implementation for <see cref="AkahuWebhookSubscription"/>.
+/// </summary>
+public class AkahuWebhookSubscriptionRepository : IAkahuWebhookSubscriptionRepository
+{
+    private readonly ApplicationDbContext _context;
+
+    public AkahuWebhookSubscriptionRepository(ApplicationDbContext context)
+    {
+        _context = context;
+    }
+
+    /// <inheritdoc />
+    public async Task<IReadOnlyList<AkahuWebhookSubscription>> GetByUserIdAsync(Guid userId, CancellationToken ct = default)
+    {
+        return await _context.AkahuWebhookSubscriptions
+            .Where(s => s.UserId == userId)
+            .ToListAsync(ct);
+    }
+
+    /// <inheritdoc />
+    public async Task<AkahuWebhookSubscription?> GetByWebhookIdAsync(string webhookId, CancellationToken ct = default)
+    {
+        return await _context.AkahuWebhookSubscriptions
+            .FirstOrDefaultAsync(s => s.WebhookId == webhookId, ct);
+    }
+
+    /// <inheritdoc />
+    public async Task<AkahuWebhookSubscription> AddAsync(AkahuWebhookSubscription subscription, CancellationToken ct = default)
+    {
+        await _context.AkahuWebhookSubscriptions.AddAsync(subscription, ct);
+        await _context.SaveChangesAsync(ct);
+        return subscription;
+    }
+
+    /// <inheritdoc />
+    public async Task UpdateAsync(AkahuWebhookSubscription subscription, CancellationToken ct = default)
+    {
+        _context.AkahuWebhookSubscriptions.Update(subscription);
+        await _context.SaveChangesAsync(ct);
+    }
+
+    /// <inheritdoc />
+    public async Task DeleteByIdAsync(int id, CancellationToken ct = default)
+    {
+        var subscription = await _context.AkahuWebhookSubscriptions
+            .FirstOrDefaultAsync(s => s.Id == id, ct);
+
+        if (subscription != null)
+        {
+            subscription.IsDeleted = true;
+            subscription.DeletedAt = DateTime.UtcNow;
+            _context.AkahuWebhookSubscriptions.Update(subscription);
+            await _context.SaveChangesAsync(ct);
+        }
+    }
+
+    /// <inheritdoc />
+    public async Task DeleteByUserIdAsync(Guid userId, CancellationToken ct = default)
+    {
+        var subscriptions = await _context.AkahuWebhookSubscriptions
+            .Where(s => s.UserId == userId)
+            .ToListAsync(ct);
+
+        if (subscriptions.Count == 0)
+            return;
+
+        var now = DateTime.UtcNow;
+        foreach (var subscription in subscriptions)
+        {
+            subscription.IsDeleted = true;
+            subscription.DeletedAt = now;
+        }
+
+        _context.AkahuWebhookSubscriptions.UpdateRange(subscriptions);
+        await _context.SaveChangesAsync(ct);
+    }
+}

--- a/src/Infrastructure/MyMascada.Infrastructure/Repositories/AkahuWebhookSubscriptionRepository.cs
+++ b/src/Infrastructure/MyMascada.Infrastructure/Repositories/AkahuWebhookSubscriptionRepository.cs
@@ -21,7 +21,7 @@ public class AkahuWebhookSubscriptionRepository : IAkahuWebhookSubscriptionRepos
     public async Task<IReadOnlyList<AkahuWebhookSubscription>> GetByUserIdAsync(Guid userId, CancellationToken ct = default)
     {
         return await _context.AkahuWebhookSubscriptions
-            .Where(s => s.UserId == userId)
+            .Where(s => s.UserId == userId && !s.IsDeleted)
             .ToListAsync(ct);
     }
 
@@ -29,7 +29,7 @@ public class AkahuWebhookSubscriptionRepository : IAkahuWebhookSubscriptionRepos
     public async Task<AkahuWebhookSubscription?> GetByWebhookIdAsync(string webhookId, CancellationToken ct = default)
     {
         return await _context.AkahuWebhookSubscriptions
-            .FirstOrDefaultAsync(s => s.WebhookId == webhookId, ct);
+            .FirstOrDefaultAsync(s => s.WebhookId == webhookId && !s.IsDeleted, ct);
     }
 
     /// <inheritdoc />

--- a/src/Infrastructure/MyMascada.Infrastructure/Repositories/TransactionRepository.cs
+++ b/src/Infrastructure/MyMascada.Infrastructure/Repositories/TransactionRepository.cs
@@ -209,23 +209,39 @@ public class TransactionRepository : ITransactionRepository
         if (oldToNewExternalIds == null || oldToNewExternalIds.Count == 0)
             return 0;
 
-        // EF Core 8+ ExecuteUpdate cannot translate dictionary lookups, so update per-key.
-        // Each call is a single targeted UPDATE filtered on the indexed (AccountId, ExternalId)
-        // pair, which is materially cheaper than loading rows into memory.
-        var now = DateTime.UtcNow;
-        var updated = 0;
-        foreach (var (oldId, newId) in oldToNewExternalIds)
-        {
-            if (string.IsNullOrEmpty(oldId) || string.IsNullOrEmpty(newId) || oldId == newId)
-                continue;
+        // Filter to only well-formed remap pairs (non-empty old/new, and actually changing).
+        var pairs = oldToNewExternalIds
+            .Where(kvp => !string.IsNullOrEmpty(kvp.Key) && !string.IsNullOrEmpty(kvp.Value) && kvp.Key != kvp.Value)
+            .ToList();
 
-            updated += await _context.Transactions
-                .Where(t => t.AccountId == accountId && t.ExternalId == oldId && !t.IsDeleted)
-                .ExecuteUpdateAsync(setters => setters
-                    .SetProperty(t => t.ExternalId, newId)
-                    .SetProperty(t => t.UpdatedAt, now), ct);
+        if (pairs.Count == 0)
+            return 0;
+
+        // Single round-trip: build a VALUES (...) join that maps every (oldId, newId) pair
+        // and update Transactions in one statement. This replaces the previous per-key loop,
+        // which fired N ExecuteUpdateAsync calls.
+        var now = DateTime.UtcNow;
+
+        var sql = new System.Text.StringBuilder();
+        sql.Append("UPDATE \"Transactions\" t SET \"ExternalId\" = m.\"NewId\", \"UpdatedAt\" = {0} FROM (VALUES ");
+
+        var parameters = new List<object> { now };
+        for (var i = 0; i < pairs.Count; i++)
+        {
+            if (i > 0) sql.Append(", ");
+            var oldIdx = parameters.Count;
+            parameters.Add(pairs[i].Key);
+            var newIdx = parameters.Count;
+            parameters.Add(pairs[i].Value);
+            sql.Append("({").Append(oldIdx).Append("}, {").Append(newIdx).Append("})");
         }
-        return updated;
+
+        sql.Append(") AS m(\"OldId\", \"NewId\") ");
+        sql.Append("WHERE t.\"AccountId\" = {").Append(parameters.Count).Append("} ");
+        parameters.Add(accountId);
+        sql.Append("AND t.\"ExternalId\" = m.\"OldId\" AND t.\"IsDeleted\" = false");
+
+        return await _context.Database.ExecuteSqlRawAsync(sql.ToString(), parameters, ct);
     }
 
     public async Task DeleteByAccountIdAsync(int accountId, Guid userId)

--- a/src/Infrastructure/MyMascada.Infrastructure/Repositories/TransactionRepository.cs
+++ b/src/Infrastructure/MyMascada.Infrastructure/Repositories/TransactionRepository.cs
@@ -193,6 +193,41 @@ public class TransactionRepository : ITransactionRepository
                 .SetProperty(t => t.DeletedAt, now), ct);
     }
 
+    public async Task<DateTime?> GetOldestTransactionDateForAccountAsync(int accountId, CancellationToken ct = default)
+    {
+        var dates = await _context.Transactions
+            .Where(t => t.AccountId == accountId && !t.IsDeleted)
+            .OrderBy(t => t.TransactionDate)
+            .Select(t => (DateTime?)t.TransactionDate)
+            .Take(1)
+            .ToListAsync(ct);
+        return dates.FirstOrDefault();
+    }
+
+    public async Task<int> RemapExternalIdsAsync(int accountId, IReadOnlyDictionary<string, string> oldToNewExternalIds, CancellationToken ct = default)
+    {
+        if (oldToNewExternalIds == null || oldToNewExternalIds.Count == 0)
+            return 0;
+
+        // EF Core 8+ ExecuteUpdate cannot translate dictionary lookups, so update per-key.
+        // Each call is a single targeted UPDATE filtered on the indexed (AccountId, ExternalId)
+        // pair, which is materially cheaper than loading rows into memory.
+        var now = DateTime.UtcNow;
+        var updated = 0;
+        foreach (var (oldId, newId) in oldToNewExternalIds)
+        {
+            if (string.IsNullOrEmpty(oldId) || string.IsNullOrEmpty(newId) || oldId == newId)
+                continue;
+
+            updated += await _context.Transactions
+                .Where(t => t.AccountId == accountId && t.ExternalId == oldId && !t.IsDeleted)
+                .ExecuteUpdateAsync(setters => setters
+                    .SetProperty(t => t.ExternalId, newId)
+                    .SetProperty(t => t.UpdatedAt, now), ct);
+        }
+        return updated;
+    }
+
     public async Task DeleteByAccountIdAsync(int accountId, Guid userId)
     {
         if (!await _accountAccess.IsOwnerAsync(userId, accountId))

--- a/src/Infrastructure/MyMascada.Infrastructure/Services/BankIntegration/BankSyncService.cs
+++ b/src/Infrastructure/MyMascada.Infrastructure/Services/BankIntegration/BankSyncService.cs
@@ -49,6 +49,20 @@ public class BankSyncService : IBankSyncService
     /// </summary>
     private const decimal AutoCategorizeMinConfidence = 0.9m;
 
+    /// <summary>
+    /// Confidence at or above which a potential duplicate is skipped during a normal sync.
+    /// </summary>
+    private const decimal DuplicateSkipConfidence = 0.95m;
+
+    /// <summary>
+    /// Lowered skip confidence used inside the post-migration window. Akahu re-emits
+    /// historical transactions with date/description drift that caps the fuzzy-match
+    /// confidence (see ImportAnalysisService) well below the normal 0.95 bar — a 1-day
+    /// date drift with an exact-amount match maxes out around 0.8 — so without this the
+    /// widened tolerances would flag the re-imports but never actually suppress them.
+    /// </summary>
+    private const decimal MigrationDuplicateSkipConfidence = 0.60m;
+
     public BankSyncService(
         IBankProviderFactory providerFactory,
         IBankConnectionRepository connectionRepository,
@@ -171,6 +185,13 @@ public class BankSyncService : IBankSyncService
                     IncludeRecentImports = true
                 };
 
+            // The skip bar moves with the tolerance: a normal sync demands near-certain
+            // matches, but during the migration window the confidence formula cannot
+            // reach 0.95 for a drifted re-import, so the bar drops to match.
+            var duplicateSkipConfidence = usesMigrationFallback
+                ? MigrationDuplicateSkipConfidence
+                : DuplicateSkipConfidence;
+
             var analysisRequest = new AnalyzeImportRequest
             {
                 Source = "bankapi",
@@ -222,7 +243,7 @@ public class BankSyncService : IBankSyncService
                 // Check for exact duplicates (same external reference ID) or other high-confidence duplicates
                 var hasExactDuplicate = item.Conflicts.Any(c =>
                     c.Type == ConflictType.ExactDuplicate ||
-                    (c.Type == ConflictType.PotentialDuplicate && c.ConfidenceScore >= 0.95m));
+                    (c.Type == ConflictType.PotentialDuplicate && c.ConfidenceScore >= duplicateSkipConfidence));
 
                 if (hasExactDuplicate)
                 {

--- a/src/Infrastructure/MyMascada.Infrastructure/Services/BankIntegration/BankSyncService.cs
+++ b/src/Infrastructure/MyMascada.Infrastructure/Services/BankIntegration/BankSyncService.cs
@@ -1,8 +1,10 @@
+using Microsoft.Extensions.Options;
 using MyMascada.Application.Common.Interfaces;
 using MyMascada.Application.Features.BankConnections.DTOs;
 using MyMascada.Application.Features.ImportReview.DTOs;
 using MyMascada.Domain.Entities;
 using MyMascada.Domain.Enums;
+using MyMascada.Infrastructure.Services.BankIntegration.Providers;
 
 namespace MyMascada.Infrastructure.Services.BankIntegration;
 
@@ -19,7 +21,18 @@ public class BankSyncService : IBankSyncService
     private readonly IImportAnalysisService _importAnalysisService;
     private readonly ITransactionRepository _transactionRepository;
     private readonly IBankCategoryMappingService _categoryMappingService;
+    private readonly AkahuOptions _akahuOptions;
     private readonly IApplicationLogger<BankSyncService> _logger;
+
+    /// <summary>
+    /// Provider ID of Akahu connections.
+    /// </summary>
+    private const string AkahuProviderId = "akahu";
+
+    /// <summary>
+    /// How long after a migration the loosened dedup tolerance applies.
+    /// </summary>
+    private const int MigrationFallbackWindowDays = 30;
 
     /// <summary>
     /// Default sync window: last 30 days
@@ -44,6 +57,7 @@ public class BankSyncService : IBankSyncService
         IImportAnalysisService importAnalysisService,
         ITransactionRepository transactionRepository,
         IBankCategoryMappingService categoryMappingService,
+        IOptions<AkahuOptions> akahuOptions,
         IApplicationLogger<BankSyncService> logger)
     {
         _providerFactory = providerFactory ?? throw new ArgumentNullException(nameof(providerFactory));
@@ -53,6 +67,7 @@ public class BankSyncService : IBankSyncService
         _importAnalysisService = importAnalysisService ?? throw new ArgumentNullException(nameof(importAnalysisService));
         _transactionRepository = transactionRepository ?? throw new ArgumentNullException(nameof(transactionRepository));
         _categoryMappingService = categoryMappingService ?? throw new ArgumentNullException(nameof(categoryMappingService));
+        _akahuOptions = akahuOptions?.Value ?? throw new ArgumentNullException(nameof(akahuOptions));
         _logger = logger ?? throw new ArgumentNullException(nameof(logger));
     }
 
@@ -128,20 +143,41 @@ public class BankSyncService : IBankSyncService
                 .ToList();
 
             // 9. Use ImportAnalysisService for duplicate detection
-            var analysisRequest = new AnalyzeImportRequest
-            {
-                Source = "bankapi",
-                AccountId = connection.AccountId,
-                UserId = connection.UserId,
-                Candidates = candidates,
-                Options = new ImportAnalysisOptions
+            // Akahu's classic-to-official migration re-emits historical transactions with new IDs
+            // and documented drift in date/type/description, so exact-match dedup misses them.
+            // For recently-migrated Akahu connections we widen the tolerance during a 30-day
+            // window so near-duplicate re-imports are still caught.
+            var usesMigrationFallback =
+                _akahuOptions.MigrationFallbackEnabled
+                && connection.ProviderId == AkahuProviderId
+                && connection.LastMigratedAt.HasValue
+                && connection.LastMigratedAt.Value >= DateTime.UtcNow.AddDays(-MigrationFallbackWindowDays);
+
+            var importOptions = usesMigrationFallback
+                ? new ImportAnalysisOptions
+                {
+                    DateToleranceDays = 2,
+                    AmountTolerance = 0.005m,
+                    DescriptionSimilarityThreshold = 0.7,
+                    IncludeManualTransactions = true,
+                    IncludeRecentImports = true
+                }
+                : new ImportAnalysisOptions
                 {
                     DateToleranceDays = 0, // Exact date match for bank API (bank APIs provide precise dates)
                     AmountTolerance = 0m, // Exact amount match
                     DescriptionSimilarityThreshold = 0.5,
                     IncludeManualTransactions = true,
                     IncludeRecentImports = true
-                }
+                };
+
+            var analysisRequest = new AnalyzeImportRequest
+            {
+                Source = "bankapi",
+                AccountId = connection.AccountId,
+                UserId = connection.UserId,
+                Candidates = candidates,
+                Options = importOptions
             };
 
             var analysisResult = await _importAnalysisService.AnalyzeImportAsync(analysisRequest);

--- a/src/Infrastructure/MyMascada.Infrastructure/Services/BankIntegration/Providers/AkahuApiClient.cs
+++ b/src/Infrastructure/MyMascada.Infrastructure/Services/BankIntegration/Providers/AkahuApiClient.cs
@@ -5,6 +5,8 @@ using System.Text.Json;
 using System.Text.Json.Serialization;
 using Microsoft.Extensions.Options;
 using MyMascada.Application.Common.Interfaces;
+using MyMascada.Application.Features.BankConnections.DTOs;
+using MyMascada.Domain.Common;
 
 namespace MyMascada.Infrastructure.Services.BankIntegration.Providers;
 
@@ -110,6 +112,40 @@ public class AkahuApiClient : IAkahuApiClient
         return account != null ? MapToAccountInfo(account) : null;
     }
 
+    public async Task<IReadOnlyList<AkahuConnectionInfo>> GetConnectionsWithCredentialsAsync(
+        string appIdToken,
+        string userToken,
+        CancellationToken ct = default)
+    {
+        var request = CreateAuthenticatedRequest(HttpMethod.Get, "connections", appIdToken, userToken);
+        _logger.LogInformation("Akahu API request: {Method} {BaseAddress}{RequestUri}",
+            request.Method, _httpClient.BaseAddress, request.RequestUri);
+        var response = await _httpClient.SendAsync(request, ct);
+        await EnsureSuccessAsync(response, "Get connections");
+
+        var result = await response.Content.ReadFromJsonAsync<AkahuListResponse<AkahuConnection>>(JsonOptions, ct);
+        var connections = result?.Items ?? Array.Empty<AkahuConnection>();
+        return connections.Select(c => new AkahuConnectionInfo
+        {
+            Id = c.Id,
+            Name = c.Name,
+            Logo = c.Logo,
+            Classic = c.Classic
+        }).ToList();
+    }
+
+    public async Task<IReadOnlyList<BankTransactionDto>> GetTransactionsWithCredentialsAsync(
+        string appIdToken,
+        string userToken,
+        string accountId,
+        DateTime? start = null,
+        DateTime? end = null,
+        CancellationToken ct = default)
+    {
+        var transactions = await GetTransactionsAsync(appIdToken, userToken, accountId, start, end, ct);
+        return transactions.Select(MapToBankTransactionDto).ToList();
+    }
+
     /// <summary>
     /// Validates that the provided credentials are valid by making a test API call.
     /// </summary>
@@ -144,8 +180,45 @@ public class AkahuApiClient : IAkahuApiClient
         CurrentBalance = account.Balance?.Current,
         AvailableBalance = account.Balance?.Available,
         Currency = account.Balance?.Currency ?? "NZD",
-        BankName = account.Connection?.Name ?? string.Empty
+        BankName = account.Connection?.Name ?? string.Empty,
+        Migrated = account.Migrated,
+        ConnectionClassic = account.Connection?.Classic
     };
+
+    private static BankTransactionDto MapToBankTransactionDto(AkahuTransaction tx)
+    {
+        var referenceParts = new[] { tx.Meta?.Particulars, tx.Meta?.Code, tx.Meta?.Reference }
+            .Where(p => !string.IsNullOrEmpty(p));
+        var reference = referenceParts.Any() ? string.Join(" | ", referenceParts) : null;
+
+        var metadata = new Dictionary<string, object>();
+        if (tx.Meta?.OtherAccount != null)
+            metadata["otherAccount"] = tx.Meta.OtherAccount;
+        if (tx.Meta?.CardSuffix != null)
+            metadata["cardSuffix"] = tx.Meta.CardSuffix;
+        if (tx.Meta?.Conversion != null)
+        {
+            metadata["foreignAmount"] = tx.Meta.Conversion.Amount;
+            metadata["foreignCurrency"] = tx.Meta.Conversion.Currency;
+            metadata["exchangeRate"] = tx.Meta.Conversion.Rate;
+        }
+        if (tx.Category?.Groups?.PersonalFinance != null)
+            metadata["akahuCategoryGroup"] = tx.Category.Groups.PersonalFinance;
+
+        return new BankTransactionDto
+        {
+            ExternalId = tx.Id,
+            // Match AkahuBankProvider.MapTransaction so timezone display does not shift the date.
+            Date = DateTimeProvider.StartOfDayUtc(tx.Date),
+            Amount = tx.Amount,
+            Description = tx.Description,
+            Reference = reference,
+            Category = tx.Category?.Name,
+            MerchantName = tx.Merchant?.Name,
+            Metadata = metadata.Count > 0 ? metadata : null,
+            Migrated = tx.Migrated
+        };
+    }
 
     /// <summary>
     /// Exchange authorization code for access token (internal - Production App mode)
@@ -331,9 +404,10 @@ public class AkahuApiClient : IAkahuApiClient
     }
 
     /// <summary>
-    /// Subscribe to an Akahu webhook type for the given user.
+    /// Subscribe to an Akahu webhook type for the given user. Returns the created subscription
+    /// (Akahu-issued <c>_id</c>, type, and the echoed state) so the caller can persist the row.
     /// </summary>
-    public async Task SubscribeToWebhookAsync(string appIdToken, string userToken, string webhookType, string? state = null, CancellationToken ct = default)
+    public async Task<AkahuWebhookSubscriptionInfo> SubscribeToWebhookAsync(string appIdToken, string userToken, string webhookType, string? state = null, CancellationToken ct = default)
     {
         var request = CreateAuthenticatedRequest(HttpMethod.Post, "webhooks", appIdToken, userToken);
         var payload = new { webhook_type = webhookType, state };
@@ -342,7 +416,70 @@ public class AkahuApiClient : IAkahuApiClient
         var response = await _httpClient.SendAsync(request, ct);
         await EnsureSuccessAsync(response, $"Subscribe to webhook ({webhookType})");
 
-        _logger.LogInformation("Subscribed to Akahu {WebhookType} webhook", webhookType);
+        // Buffer the body to a string so we can attempt multiple response shapes without
+        // re-reading the underlying Stream (which is disposed after the first read).
+        // Akahu's POST /webhooks actually returns { "success": true, "item_id": "hook_xxx" }
+        // (verified empirically against the dev environment, 2026-05-17); the other shapes
+        // are kept as fallbacks in case other endpoints or future versions differ.
+        var body = await response.Content.ReadAsStringAsync(ct);
+
+        AkahuWebhookSubscriptionResponse? parsed = null;
+
+        // Shape 1 (current Akahu behaviour for POST /webhooks): { success, item_id }
+        try
+        {
+            var idResponse = JsonSerializer.Deserialize<AkahuItemIdResponse>(body, JsonOptions);
+            if (!string.IsNullOrEmpty(idResponse?.ItemId))
+            {
+                parsed = new AkahuWebhookSubscriptionResponse
+                {
+                    Id = idResponse.ItemId,
+                    WebhookType = webhookType,
+                    State = state
+                };
+            }
+        }
+        catch (JsonException) { /* fall through */ }
+
+        // Shape 2: { success, item: { _id, webhook_type, state } }
+        if (parsed == null || string.IsNullOrEmpty(parsed.Id))
+        {
+            try
+            {
+                var item = JsonSerializer.Deserialize<AkahuItemResponse<AkahuWebhookSubscriptionResponse>>(body, JsonOptions);
+                parsed = item?.Item;
+            }
+            catch (JsonException) { parsed = null; }
+        }
+
+        // Shape 3: bare { _id, webhook_type, state }
+        if (parsed == null || string.IsNullOrEmpty(parsed.Id))
+        {
+            try
+            {
+                parsed = JsonSerializer.Deserialize<AkahuWebhookSubscriptionResponse>(body, JsonOptions);
+            }
+            catch (JsonException) { parsed = null; }
+        }
+
+        if (parsed == null || string.IsNullOrEmpty(parsed.Id))
+        {
+            // Include a truncated snippet of the body so we can diagnose unexpected shapes
+            // without leaking large or sensitive payloads into logs.
+            var snippet = body.Length > 200 ? body.Substring(0, 200) + "..." : body;
+            throw new AkahuApiException(
+                $"Akahu: Subscribe to webhook ({webhookType}) - response did not include a webhook ID. Body: {snippet}",
+                response.StatusCode);
+        }
+
+        _logger.LogInformation("Subscribed to Akahu {WebhookType} webhook (id={WebhookId})", webhookType, parsed.Id);
+
+        return new AkahuWebhookSubscriptionInfo
+        {
+            Id = parsed.Id,
+            WebhookType = string.IsNullOrEmpty(parsed.WebhookType) ? webhookType : parsed.WebhookType,
+            State = parsed.State ?? state
+        };
     }
 
     /// <summary>
@@ -449,6 +586,13 @@ public record AkahuItemResponse<T>
     public T? Item { get; init; }
 }
 
+public record AkahuItemIdResponse
+{
+    public bool Success { get; init; }
+    [JsonPropertyName("item_id")]
+    public string? ItemId { get; init; }
+}
+
 public record AkahuTokenResponse
 {
     public string AccessToken { get; init; } = string.Empty;
@@ -468,6 +612,8 @@ public record AkahuAccount
     public AkahuAccountBalance? Balance { get; init; }
     public AkahuConnection? Connection { get; init; }
     public string[] Attributes { get; init; } = Array.Empty<string>();
+    [JsonPropertyName("_migrated")]
+    public string? Migrated { get; init; }
 }
 
 public record AkahuAccountBalance
@@ -485,6 +631,8 @@ public record AkahuConnection
     public string Id { get; init; } = string.Empty;  // conn_xxx
     public string Name { get; init; } = string.Empty;  // e.g., "ANZ"
     public string? Logo { get; init; }
+    [JsonPropertyName("_classic")]
+    public string? Classic { get; init; }
 }
 
 public record AkahuTransaction
@@ -503,6 +651,8 @@ public record AkahuTransaction
     public AkahuTransactionMeta? Meta { get; init; }
     [JsonPropertyName("created_at")]
     public DateTime CreatedAt { get; init; }
+    [JsonPropertyName("_migrated")]
+    public string? Migrated { get; init; }
 }
 
 public record AkahuTransactionCategory

--- a/src/Infrastructure/MyMascada.Infrastructure/Services/BankIntegration/Providers/AkahuApiClient.cs
+++ b/src/Infrastructure/MyMascada.Infrastructure/Services/BankIntegration/Providers/AkahuApiClient.cs
@@ -464,13 +464,13 @@ public class AkahuApiClient : IAkahuApiClient
 
         if (parsed == null || string.IsNullOrEmpty(parsed.Id))
         {
-            // The body can echo the request's state value (we use the user's GUID), so we route
-            // it through the structured logger (which scrubs sensitive fields) instead of letting
-            // it bleed into the exception message and downstream APM tooling.
-            var snippet = body.Length > 200 ? body.Substring(0, 200) + "..." : body;
+            // The body echoes the request's `state` value (we use the user's GUID),
+            // so we deliberately don't include any of the body in logs or the exception
+            // message. Length + status code is enough to diagnose a future shape drift
+            // without leaking user identifiers into logs/APM.
             _logger.LogWarning(
-                "Akahu webhook subscribe ({WebhookType}) returned unexpected shape; status={StatusCode}, body={BodySnippet}",
-                webhookType, response.StatusCode, snippet);
+                "Akahu webhook subscribe ({WebhookType}) returned unexpected shape; status={StatusCode}, bodyLength={BodyLength}",
+                webhookType, response.StatusCode, body.Length);
             throw new AkahuApiException(
                 $"Akahu webhook subscribe ({webhookType}) returned unexpected shape (status {(int)response.StatusCode}).",
                 response.StatusCode);

--- a/src/Infrastructure/MyMascada.Infrastructure/Services/BankIntegration/Providers/AkahuApiClient.cs
+++ b/src/Infrastructure/MyMascada.Infrastructure/Services/BankIntegration/Providers/AkahuApiClient.cs
@@ -464,11 +464,15 @@ public class AkahuApiClient : IAkahuApiClient
 
         if (parsed == null || string.IsNullOrEmpty(parsed.Id))
         {
-            // Include a truncated snippet of the body so we can diagnose unexpected shapes
-            // without leaking large or sensitive payloads into logs.
+            // The body can echo the request's state value (we use the user's GUID), so we route
+            // it through the structured logger (which scrubs sensitive fields) instead of letting
+            // it bleed into the exception message and downstream APM tooling.
             var snippet = body.Length > 200 ? body.Substring(0, 200) + "..." : body;
+            _logger.LogWarning(
+                "Akahu webhook subscribe ({WebhookType}) returned unexpected shape; status={StatusCode}, body={BodySnippet}",
+                webhookType, response.StatusCode, snippet);
             throw new AkahuApiException(
-                $"Akahu: Subscribe to webhook ({webhookType}) - response did not include a webhook ID. Body: {snippet}",
+                $"Akahu webhook subscribe ({webhookType}) returned unexpected shape (status {(int)response.StatusCode}).",
                 response.StatusCode);
         }
 

--- a/src/Infrastructure/MyMascada.Infrastructure/Services/BankIntegration/Providers/AkahuBankProvider.cs
+++ b/src/Infrastructure/MyMascada.Infrastructure/Services/BankIntegration/Providers/AkahuBankProvider.cs
@@ -273,7 +273,8 @@ public class AkahuBankProvider : IBankProvider
             Reference = reference,
             Category = tx.Category?.Name,
             MerchantName = tx.Merchant?.Name,
-            Metadata = metadata.Count > 0 ? metadata : null
+            Metadata = metadata.Count > 0 ? metadata : null,
+            Migrated = tx.Migrated
         };
     }
 }

--- a/src/Infrastructure/MyMascada.Infrastructure/Services/BankIntegration/Providers/AkahuSettings.cs
+++ b/src/Infrastructure/MyMascada.Infrastructure/Services/BankIntegration/Providers/AkahuSettings.cs
@@ -73,4 +73,10 @@ public class AkahuOptions
     /// Default: 1440 (24 hours).
     /// </summary>
     public int WebhookSigningKeysCacheMinutes { get; set; } = 1440;
+
+    /// <summary>
+    /// Whether to loosen duplicate-detection tolerance for Akahu connections that were
+    /// migrated to official open banking within the last 30 days. Default: true.
+    /// </summary>
+    public bool MigrationFallbackEnabled { get; set; } = true;
 }

--- a/src/Infrastructure/MyMascada.Infrastructure/Services/BankIntegration/Providers/AkahuSettings.cs
+++ b/src/Infrastructure/MyMascada.Infrastructure/Services/BankIntegration/Providers/AkahuSettings.cs
@@ -1,29 +1,6 @@
 namespace MyMascada.Infrastructure.Services.BankIntegration.Providers;
 
 /// <summary>
-/// Settings stored encrypted for an Akahu bank connection.
-/// These are per-connection sync state stored in BankConnection.EncryptedSettings.
-/// NOTE: Access tokens are now stored per-user in AkahuUserCredential, not per-connection.
-/// </summary>
-public class AkahuConnectionSettings
-{
-    /// <summary>
-    /// Akahu account ID (acc_xxx) that this connection is linked to.
-    /// </summary>
-    public string AkahuAccountId { get; set; } = string.Empty;
-
-    /// <summary>
-    /// Last transaction ID that was successfully synced (for incremental sync).
-    /// </summary>
-    public string? LastSyncedTransactionId { get; set; }
-
-    /// <summary>
-    /// Timestamp of the last successful sync.
-    /// </summary>
-    public DateTime? LastSyncTimestamp { get; set; }
-}
-
-/// <summary>
 /// Akahu application configuration (from appsettings, not encrypted per-connection).
 /// NOTE: For Personal App mode, tokens are stored per-user in AkahuUserCredential,
 /// NOT in this configuration. These options are primarily for Production App OAuth mode.

--- a/src/Infrastructure/MyMascada.Infrastructure/Services/BankIntegration/Providers/AkahuWebhookSignatureService.cs
+++ b/src/Infrastructure/MyMascada.Infrastructure/Services/BankIntegration/Providers/AkahuWebhookSignatureService.cs
@@ -100,7 +100,12 @@ public partial class AkahuWebhookSignatureService : IAkahuWebhookSignatureServic
                 return null;
             }
 
-            var publicKey = doc.RootElement.GetProperty("item").GetProperty("key").GetString();
+            // Akahu's GET /keys/{id} returns the PEM public key as a bare string in "item":
+            //   { "success": true, "item": "-----BEGIN RSA PUBLIC KEY-----\n..." }
+            var itemElement = doc.RootElement.GetProperty("item");
+            var publicKey = itemElement.ValueKind == JsonValueKind.String
+                ? itemElement.GetString()
+                : null;
             if (string.IsNullOrEmpty(publicKey))
             {
                 _logger.LogWarning("Signing key {KeyId} had empty key value", keyId);

--- a/src/Infrastructure/MyMascada.Infrastructure/Services/BankIntegration/Providers/AkahuWebhookSubscriptionService.cs
+++ b/src/Infrastructure/MyMascada.Infrastructure/Services/BankIntegration/Providers/AkahuWebhookSubscriptionService.cs
@@ -71,8 +71,14 @@ public class AkahuWebhookSubscriptionService : IAkahuWebhookSubscriptionService
         }
         catch (Exception ex)
         {
-            _logger.LogWarning(ex, "EnsureSubscriptions: ListWebhooksAsync failed for user {UserId}; proceeding with local view only", userId);
-            remoteSubscriptions = Array.Empty<AkahuWebhookSubscriptionInfo>();
+            // Bail out: treating an unreachable Akahu as "remote has no subscriptions" would
+            // tear down perfectly-good local rows. Retry on the next reconciliation cycle.
+            _logger.LogWarning(ex, "EnsureSubscriptions: ListWebhooksAsync failed for user {UserId}; aborting reconcile until Akahu is reachable", userId);
+            foreach (var webhookType in RequiredTypes)
+            {
+                failed[webhookType] = "Akahu webhooks endpoint unavailable; retrying next cycle";
+            }
+            return new EnsureSubscriptionsResult(subscribed, adopted, alreadyHealthy, failed);
         }
 
         var remoteByType = remoteSubscriptions

--- a/src/Infrastructure/MyMascada.Infrastructure/Services/BankIntegration/Providers/AkahuWebhookSubscriptionService.cs
+++ b/src/Infrastructure/MyMascada.Infrastructure/Services/BankIntegration/Providers/AkahuWebhookSubscriptionService.cs
@@ -1,0 +1,219 @@
+using MyMascada.Application.Common.Interfaces;
+using MyMascada.Application.Features.BankConnections.DTOs;
+using MyMascada.Domain.Entities;
+
+namespace MyMascada.Infrastructure.Services.BankIntegration.Providers;
+
+/// <summary>
+/// Default implementation of <see cref="IAkahuWebhookSubscriptionService"/>.
+/// </summary>
+public class AkahuWebhookSubscriptionService : IAkahuWebhookSubscriptionService
+{
+    private static readonly string[] RequiredTypes =
+    {
+        AkahuWebhookTypes.Token,
+        AkahuWebhookTypes.Account,
+        AkahuWebhookTypes.Transaction
+    };
+
+    private readonly IAkahuApiClient _akahuApiClient;
+    private readonly IAkahuUserCredentialRepository _credentialRepository;
+    private readonly IAkahuWebhookSubscriptionRepository _subscriptionRepository;
+    private readonly ISettingsEncryptionService _encryptionService;
+    private readonly IApplicationLogger<AkahuWebhookSubscriptionService> _logger;
+
+    public AkahuWebhookSubscriptionService(
+        IAkahuApiClient akahuApiClient,
+        IAkahuUserCredentialRepository credentialRepository,
+        IAkahuWebhookSubscriptionRepository subscriptionRepository,
+        ISettingsEncryptionService encryptionService,
+        IApplicationLogger<AkahuWebhookSubscriptionService> logger)
+    {
+        _akahuApiClient = akahuApiClient ?? throw new ArgumentNullException(nameof(akahuApiClient));
+        _credentialRepository = credentialRepository ?? throw new ArgumentNullException(nameof(credentialRepository));
+        _subscriptionRepository = subscriptionRepository ?? throw new ArgumentNullException(nameof(subscriptionRepository));
+        _encryptionService = encryptionService ?? throw new ArgumentNullException(nameof(encryptionService));
+        _logger = logger ?? throw new ArgumentNullException(nameof(logger));
+    }
+
+    /// <inheritdoc />
+    public async Task<EnsureSubscriptionsResult> EnsureSubscriptionsAsync(Guid userId, CancellationToken ct = default)
+    {
+        var subscribed = new List<string>();
+        var adopted = new List<string>();
+        var alreadyHealthy = new List<string>();
+        var failed = new Dictionary<string, string>(StringComparer.Ordinal);
+
+        var credential = await _credentialRepository.GetByUserIdAsync(userId, ct);
+        if (credential == null)
+        {
+            _logger.LogWarning("EnsureSubscriptions: no Akahu credential for user {UserId}", userId);
+            return new EnsureSubscriptionsResult(subscribed, adopted, alreadyHealthy, failed);
+        }
+
+        if (!TryDecryptTokens(credential, out var appIdToken, out var userToken))
+        {
+            _logger.LogWarning("EnsureSubscriptions: failed to decrypt Akahu tokens for user {UserId}", userId);
+            return new EnsureSubscriptionsResult(subscribed, adopted, alreadyHealthy, failed);
+        }
+
+        var stateValue = userId.ToString("N");
+
+        var localSubscriptions = await _subscriptionRepository.GetByUserIdAsync(userId, ct);
+        var localByType = localSubscriptions
+            .GroupBy(s => s.WebhookType, StringComparer.OrdinalIgnoreCase)
+            .ToDictionary(g => g.Key, g => g.First(), StringComparer.OrdinalIgnoreCase);
+
+        IReadOnlyList<AkahuWebhookSubscriptionInfo> remoteSubscriptions;
+        try
+        {
+            remoteSubscriptions = await _akahuApiClient.ListWebhooksAsync(appIdToken, userToken, ct);
+        }
+        catch (Exception ex)
+        {
+            _logger.LogWarning(ex, "EnsureSubscriptions: ListWebhooksAsync failed for user {UserId}; proceeding with local view only", userId);
+            remoteSubscriptions = Array.Empty<AkahuWebhookSubscriptionInfo>();
+        }
+
+        var remoteByType = remoteSubscriptions
+            .GroupBy(r => r.WebhookType, StringComparer.OrdinalIgnoreCase)
+            .ToDictionary(g => g.Key, g => g.First(), StringComparer.OrdinalIgnoreCase);
+
+        foreach (var webhookType in RequiredTypes)
+        {
+            try
+            {
+                localByType.TryGetValue(webhookType, out var localRow);
+                remoteByType.TryGetValue(webhookType, out var remoteRow);
+
+                if (localRow != null && remoteRow != null && string.Equals(localRow.WebhookId, remoteRow.Id, StringComparison.Ordinal))
+                {
+                    alreadyHealthy.Add(webhookType);
+                    continue;
+                }
+
+                if (localRow != null && remoteRow == null)
+                {
+                    // Akahu no longer has the subscription — purge stale local row, then re-subscribe.
+                    await _subscriptionRepository.DeleteByIdAsync(localRow.Id, ct);
+                    var created = await _akahuApiClient.SubscribeToWebhookAsync(appIdToken, userToken, webhookType, stateValue, ct);
+                    await PersistAsync(credential, userId, webhookType, created, stateValue, ct);
+                    subscribed.Add(webhookType);
+                    continue;
+                }
+
+                if (localRow == null && remoteRow != null)
+                {
+                    await PersistAsync(credential, userId, webhookType, remoteRow, stateValue, ct);
+                    adopted.Add(webhookType);
+                    continue;
+                }
+
+                if (localRow == null && remoteRow == null)
+                {
+                    var created = await _akahuApiClient.SubscribeToWebhookAsync(appIdToken, userToken, webhookType, stateValue, ct);
+                    await PersistAsync(credential, userId, webhookType, created, stateValue, ct);
+                    subscribed.Add(webhookType);
+                    continue;
+                }
+
+                // Both rows exist but IDs disagree — drop the local one and adopt the remote.
+                await _subscriptionRepository.DeleteByIdAsync(localRow!.Id, ct);
+                await PersistAsync(credential, userId, webhookType, remoteRow!, stateValue, ct);
+                adopted.Add(webhookType);
+            }
+            catch (Exception ex)
+            {
+                _logger.LogWarning(ex, "EnsureSubscriptions: failed to ensure Akahu {WebhookType} subscription for user {UserId}", webhookType, userId);
+                failed[webhookType] = ex.Message;
+            }
+        }
+
+        return new EnsureSubscriptionsResult(subscribed, adopted, alreadyHealthy, failed);
+    }
+
+    /// <inheritdoc />
+    public async Task TearDownSubscriptionsAsync(Guid userId, CancellationToken ct = default)
+    {
+        var localSubscriptions = await _subscriptionRepository.GetByUserIdAsync(userId, ct);
+        if (localSubscriptions.Count == 0)
+            return;
+
+        var credential = await _credentialRepository.GetByUserIdAsync(userId, ct);
+        string? appIdToken = null;
+        string? userToken = null;
+        var hasTokens = credential != null && TryDecryptTokens(credential, out appIdToken, out userToken);
+
+        if (hasTokens && appIdToken != null && userToken != null)
+        {
+            foreach (var subscription in localSubscriptions)
+            {
+                try
+                {
+                    await _akahuApiClient.UnsubscribeFromWebhookAsync(appIdToken, userToken, subscription.WebhookId, ct);
+                }
+                catch (Exception ex)
+                {
+                    _logger.LogWarning(ex, "TearDown: Akahu DELETE /webhooks/{WebhookId} failed for user {UserId}; continuing", subscription.WebhookId, userId);
+                }
+            }
+        }
+
+        await _subscriptionRepository.DeleteByUserIdAsync(userId, ct);
+    }
+
+    /// <inheritdoc />
+    public async Task<ReconcileResult> ReconcileAsync(Guid userId, CancellationToken ct = default)
+    {
+        var ensure = await EnsureSubscriptionsAsync(userId, ct);
+        return new ReconcileResult(ensure.SubscribedTypes, ensure.AdoptedTypes, ensure.AlreadyHealthyTypes, ensure.FailedTypes);
+    }
+
+    private async Task PersistAsync(
+        AkahuUserCredential credential,
+        Guid userId,
+        string webhookType,
+        AkahuWebhookSubscriptionInfo info,
+        string stateValue,
+        CancellationToken ct)
+    {
+        var now = DateTime.UtcNow;
+        var entity = new AkahuWebhookSubscription
+        {
+            UserId = userId,
+            AkahuUserCredentialId = credential.Id,
+            WebhookId = info.Id,
+            WebhookType = string.IsNullOrEmpty(info.WebhookType) ? webhookType : info.WebhookType,
+            State = info.State ?? stateValue,
+            SubscribedAt = now,
+            CreatedAt = now,
+            UpdatedAt = now
+        };
+
+        await _subscriptionRepository.AddAsync(entity, ct);
+    }
+
+    private bool TryDecryptTokens(AkahuUserCredential credential, out string? appIdToken, out string? userToken)
+    {
+        appIdToken = null;
+        userToken = null;
+
+        try
+        {
+            var decryptedApp = _encryptionService.DecryptSettings<string>(credential.EncryptedAppToken);
+            var decryptedUser = _encryptionService.DecryptSettings<string>(credential.EncryptedUserToken);
+
+            if (string.IsNullOrEmpty(decryptedApp) || string.IsNullOrEmpty(decryptedUser))
+                return false;
+
+            appIdToken = decryptedApp;
+            userToken = decryptedUser;
+            return true;
+        }
+        catch (Exception ex)
+        {
+            _logger.LogWarning(ex, "Failed to decrypt Akahu credentials");
+            return false;
+        }
+    }
+}

--- a/src/Infrastructure/MyMascada.Infrastructure/Services/UserData/UserDataDeletionService.cs
+++ b/src/Infrastructure/MyMascada.Infrastructure/Services/UserData/UserDataDeletionService.cs
@@ -13,17 +13,20 @@ public class UserDataDeletionService : IUserDataDeletionService
     private readonly ApplicationDbContext _context;
     private readonly IAkahuApiClient _akahuApiClient;
     private readonly ISettingsEncryptionService _encryptionService;
+    private readonly IAkahuWebhookSubscriptionService _webhookSubscriptionService;
     private readonly ILogger<UserDataDeletionService> _logger;
 
     public UserDataDeletionService(
         ApplicationDbContext context,
         IAkahuApiClient akahuApiClient,
         ISettingsEncryptionService encryptionService,
+        IAkahuWebhookSubscriptionService webhookSubscriptionService,
         ILogger<UserDataDeletionService> logger)
     {
         _context = context;
         _akahuApiClient = akahuApiClient;
         _encryptionService = encryptionService;
+        _webhookSubscriptionService = webhookSubscriptionService;
         _logger = logger;
     }
 
@@ -357,6 +360,20 @@ public class UserDataDeletionService : IUserDataDeletionService
             {
                 _logger.LogError(ex,
                     "Failed to revoke Akahu access token for user {UserId} during account deletion. Continuing with deletion.",
+                    userId);
+            }
+
+            // 31b. Tear down Akahu webhook subscriptions (best-effort — subscriptions die when the
+            // token is revoked anyway, but this calls DELETE /webhooks for cleanliness while the
+            // credential is still decryptable).
+            try
+            {
+                await _webhookSubscriptionService.TearDownSubscriptionsAsync(userId, cancellationToken);
+            }
+            catch (Exception ex)
+            {
+                _logger.LogWarning(ex,
+                    "Failed to tear down Akahu webhook subscriptions for user {UserId} during account deletion. Continuing with deletion.",
                     userId);
             }
 

--- a/src/WebAPI/MyMascada.WebAPI/Controllers/BankConnectionsController.cs
+++ b/src/WebAPI/MyMascada.WebAPI/Controllers/BankConnectionsController.cs
@@ -116,6 +116,19 @@ public class BankConnectionsController : ControllerBase
     }
 
     /// <summary>
+    /// Returns the user's Akahu connections that still need to be migrated to the official
+    /// open-banking equivalent before the 24 May 2026 cut-over. Drives the in-app upgrade banner.
+    /// </summary>
+    [HttpGet("akahu/migration-status")]
+    [ProducesResponseType(typeof(AkahuMigrationStatusDto), StatusCodes.Status200OK)]
+    public async Task<ActionResult<AkahuMigrationStatusDto>> GetAkahuMigrationStatus()
+    {
+        var query = new GetAkahuMigrationStatusQuery(_currentUserService.GetUserId());
+        var result = await _mediator.Send(query);
+        return Ok(result);
+    }
+
+    /// <summary>
     /// Saves or updates the user's Akahu credentials.
     /// Validates the credentials against the Akahu API before saving.
     /// </summary>

--- a/src/WebAPI/MyMascada.WebAPI/Extensions/BackgroundJobServiceExtensions.cs
+++ b/src/WebAPI/MyMascada.WebAPI/Extensions/BackgroundJobServiceExtensions.cs
@@ -48,6 +48,10 @@ public static class BackgroundJobServiceExtensions
         services.AddScoped<MyMascada.Application.BackgroundJobs.ITokenRevocationRetryJobService,
             MyMascada.Infrastructure.BackgroundJobs.TokenRevocationRetryJobService>();
 
+        // Akahu webhook subscription reconciliation service
+        services.AddScoped<MyMascada.Application.BackgroundJobs.IAkahuWebhookSubscriptionReconciliationJobService,
+            MyMascada.Infrastructure.BackgroundJobs.AkahuWebhookSubscriptionReconciliationJobService>();
+
         // Rule suggestion generation job service
         services.AddScoped<MyMascada.Application.BackgroundJobs.IRuleSuggestionGenerationJobService,
             MyMascada.Infrastructure.BackgroundJobs.RuleSuggestionGenerationJobService>();

--- a/src/WebAPI/MyMascada.WebAPI/Extensions/BackgroundJobServiceExtensions.cs
+++ b/src/WebAPI/MyMascada.WebAPI/Extensions/BackgroundJobServiceExtensions.cs
@@ -52,6 +52,10 @@ public static class BackgroundJobServiceExtensions
         services.AddScoped<MyMascada.Application.BackgroundJobs.IAkahuWebhookSubscriptionReconciliationJobService,
             MyMascada.Infrastructure.BackgroundJobs.AkahuWebhookSubscriptionReconciliationJobService>();
 
+        // Akahu classic→official migration service (fire-and-forget enqueue from webhook/OAuth)
+        services.AddScoped<MyMascada.Application.BackgroundJobs.IAkahuMigrationJobService,
+            MyMascada.Infrastructure.BackgroundJobs.AkahuMigrationJobService>();
+
         // Rule suggestion generation job service
         services.AddScoped<MyMascada.Application.BackgroundJobs.IRuleSuggestionGenerationJobService,
             MyMascada.Infrastructure.BackgroundJobs.RuleSuggestionGenerationJobService>();

--- a/src/WebAPI/MyMascada.WebAPI/Extensions/BankProviderServiceExtensions.cs
+++ b/src/WebAPI/MyMascada.WebAPI/Extensions/BankProviderServiceExtensions.cs
@@ -38,6 +38,7 @@ public static class BankProviderServiceExtensions
         services.AddScoped<IBankConnectionRepository, BankConnectionRepository>();
         services.AddScoped<IBankSyncLogRepository, BankSyncLogRepository>();
         services.AddScoped<IAkahuUserCredentialRepository, AkahuUserCredentialRepository>();
+        services.AddScoped<IAkahuWebhookSubscriptionRepository, AkahuWebhookSubscriptionRepository>();
         services.AddScoped<IBankCategoryMappingRepository, BankCategoryMappingRepository>();
 
         // Bank category mapping service
@@ -51,6 +52,9 @@ public static class BankProviderServiceExtensions
 
         // Register Akahu as a bank provider (factory will auto-discover via DI)
         services.AddScoped<IBankProvider, AkahuBankProvider>();
+
+        // Webhook subscription lifecycle service
+        services.AddScoped<IAkahuWebhookSubscriptionService, AkahuWebhookSubscriptionService>();
 
         // Akahu webhook signature verification
         services.AddHttpClient<IAkahuWebhookSignatureService, AkahuWebhookSignatureService>();

--- a/src/WebAPI/MyMascada.WebAPI/Extensions/RepositoryServiceExtensions.cs
+++ b/src/WebAPI/MyMascada.WebAPI/Extensions/RepositoryServiceExtensions.cs
@@ -1,4 +1,5 @@
 using MyMascada.Application.Common.Interfaces;
+using MyMascada.Infrastructure.Data;
 using MyMascada.Infrastructure.Repositories;
 
 namespace MyMascada.WebAPI.Extensions;
@@ -7,6 +8,9 @@ public static class RepositoryServiceExtensions
 {
     public static IServiceCollection AddRepositories(this IServiceCollection services)
     {
+        // Unit of work (DbContext transaction abstraction)
+        services.AddScoped<IUnitOfWork, UnitOfWork>();
+
         // Core repositories
         services.AddScoped<IUserRepository, UserRepository>();
         services.AddScoped<ITransactionRepository, TransactionRepository>();

--- a/src/WebAPI/MyMascada.WebAPI/Migrations/20260515054638_AddAkahuWebhookSubscription.Designer.cs
+++ b/src/WebAPI/MyMascada.WebAPI/Migrations/20260515054638_AddAkahuWebhookSubscription.Designer.cs
@@ -2,6 +2,7 @@
 using System;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using MyMascada.Infrastructure.Data;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
@@ -11,9 +12,11 @@ using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 namespace MyMascada.WebAPI.Migrations
 {
     [DbContext(typeof(ApplicationDbContext))]
-    partial class ApplicationDbContextModelSnapshot : ModelSnapshot
+    [Migration("20260515054638_AddAkahuWebhookSubscription")]
+    partial class AddAkahuWebhookSubscription
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder
@@ -556,9 +559,6 @@ namespace MyMascada.WebAPI.Migrations
 
                     b.Property<bool>("IsDeleted")
                         .HasColumnType("boolean");
-
-                    b.Property<DateTime?>("LastMigratedAt")
-                        .HasColumnType("timestamp with time zone");
 
                     b.Property<DateTime?>("LastSyncAt")
                         .HasColumnType("timestamp with time zone");

--- a/src/WebAPI/MyMascada.WebAPI/Migrations/20260515054638_AddAkahuWebhookSubscription.cs
+++ b/src/WebAPI/MyMascada.WebAPI/Migrations/20260515054638_AddAkahuWebhookSubscription.cs
@@ -1,0 +1,73 @@
+﻿using System;
+using Microsoft.EntityFrameworkCore.Migrations;
+using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
+
+#nullable disable
+
+namespace MyMascada.WebAPI.Migrations
+{
+    /// <inheritdoc />
+    public partial class AddAkahuWebhookSubscription : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.CreateTable(
+                name: "AkahuWebhookSubscriptions",
+                columns: table => new
+                {
+                    Id = table.Column<int>(type: "integer", nullable: false)
+                        .Annotation("Npgsql:ValueGenerationStrategy", NpgsqlValueGenerationStrategy.IdentityByDefaultColumn),
+                    UserId = table.Column<Guid>(type: "uuid", nullable: false),
+                    AkahuUserCredentialId = table.Column<int>(type: "integer", nullable: false),
+                    WebhookId = table.Column<string>(type: "character varying(100)", maxLength: 100, nullable: false),
+                    WebhookType = table.Column<string>(type: "character varying(40)", maxLength: 40, nullable: false),
+                    State = table.Column<string>(type: "character varying(100)", maxLength: 100, nullable: true),
+                    SubscribedAt = table.Column<DateTime>(type: "timestamp with time zone", nullable: false),
+                    LastReconciledAt = table.Column<DateTime>(type: "timestamp with time zone", nullable: true),
+                    LastReconcileError = table.Column<string>(type: "character varying(500)", maxLength: 500, nullable: true),
+                    CreatedAt = table.Column<DateTime>(type: "timestamp with time zone", nullable: false),
+                    UpdatedAt = table.Column<DateTime>(type: "timestamp with time zone", nullable: false),
+                    IsDeleted = table.Column<bool>(type: "boolean", nullable: false),
+                    DeletedAt = table.Column<DateTime>(type: "timestamp with time zone", nullable: true),
+                    CreatedBy = table.Column<string>(type: "text", nullable: true),
+                    UpdatedBy = table.Column<string>(type: "text", nullable: true)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_AkahuWebhookSubscriptions", x => x.Id);
+                    table.ForeignKey(
+                        name: "FK_AkahuWebhookSubscriptions_AkahuUserCredentials_AkahuUserCre~",
+                        column: x => x.AkahuUserCredentialId,
+                        principalTable: "AkahuUserCredentials",
+                        principalColumn: "Id",
+                        onDelete: ReferentialAction.Cascade);
+                });
+
+            migrationBuilder.CreateIndex(
+                name: "IX_AkahuWebhookSubscriptions_AkahuUserCredentialId",
+                table: "AkahuWebhookSubscriptions",
+                column: "AkahuUserCredentialId");
+
+            migrationBuilder.CreateIndex(
+                name: "IX_AkahuWebhookSubscriptions_UserId_WebhookType",
+                table: "AkahuWebhookSubscriptions",
+                columns: new[] { "UserId", "WebhookType" },
+                unique: true,
+                filter: "\"IsDeleted\" = false");
+
+            migrationBuilder.CreateIndex(
+                name: "IX_AkahuWebhookSubscriptions_WebhookId",
+                table: "AkahuWebhookSubscriptions",
+                column: "WebhookId",
+                unique: true);
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropTable(
+                name: "AkahuWebhookSubscriptions");
+        }
+    }
+}

--- a/src/WebAPI/MyMascada.WebAPI/Migrations/20260516100401_AddBankConnectionLastMigratedAt.Designer.cs
+++ b/src/WebAPI/MyMascada.WebAPI/Migrations/20260516100401_AddBankConnectionLastMigratedAt.Designer.cs
@@ -2,6 +2,7 @@
 using System;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using MyMascada.Infrastructure.Data;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
@@ -11,9 +12,11 @@ using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 namespace MyMascada.WebAPI.Migrations
 {
     [DbContext(typeof(ApplicationDbContext))]
-    partial class ApplicationDbContextModelSnapshot : ModelSnapshot
+    [Migration("20260516100401_AddBankConnectionLastMigratedAt")]
+    partial class AddBankConnectionLastMigratedAt
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/src/WebAPI/MyMascada.WebAPI/Migrations/20260516100401_AddBankConnectionLastMigratedAt.cs
+++ b/src/WebAPI/MyMascada.WebAPI/Migrations/20260516100401_AddBankConnectionLastMigratedAt.cs
@@ -1,0 +1,29 @@
+﻿using System;
+using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace MyMascada.WebAPI.Migrations
+{
+    /// <inheritdoc />
+    public partial class AddBankConnectionLastMigratedAt : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AddColumn<DateTime>(
+                name: "LastMigratedAt",
+                table: "BankConnections",
+                type: "timestamp with time zone",
+                nullable: true);
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropColumn(
+                name: "LastMigratedAt",
+                table: "BankConnections");
+        }
+    }
+}

--- a/src/WebAPI/MyMascada.WebAPI/Migrations/20260521044447_FilterAkahuWebhookIdUniqueIndex.Designer.cs
+++ b/src/WebAPI/MyMascada.WebAPI/Migrations/20260521044447_FilterAkahuWebhookIdUniqueIndex.Designer.cs
@@ -2,6 +2,7 @@
 using System;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using MyMascada.Infrastructure.Data;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
@@ -11,9 +12,11 @@ using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 namespace MyMascada.WebAPI.Migrations
 {
     [DbContext(typeof(ApplicationDbContext))]
-    partial class ApplicationDbContextModelSnapshot : ModelSnapshot
+    [Migration("20260521044447_FilterAkahuWebhookIdUniqueIndex")]
+    partial class FilterAkahuWebhookIdUniqueIndex
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/src/WebAPI/MyMascada.WebAPI/Migrations/20260521044447_FilterAkahuWebhookIdUniqueIndex.cs
+++ b/src/WebAPI/MyMascada.WebAPI/Migrations/20260521044447_FilterAkahuWebhookIdUniqueIndex.cs
@@ -1,0 +1,39 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace MyMascada.WebAPI.Migrations
+{
+    /// <inheritdoc />
+    public partial class FilterAkahuWebhookIdUniqueIndex : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropIndex(
+                name: "IX_AkahuWebhookSubscriptions_WebhookId",
+                table: "AkahuWebhookSubscriptions");
+
+            migrationBuilder.CreateIndex(
+                name: "IX_AkahuWebhookSubscriptions_WebhookId",
+                table: "AkahuWebhookSubscriptions",
+                column: "WebhookId",
+                unique: true,
+                filter: "\"IsDeleted\" = false");
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropIndex(
+                name: "IX_AkahuWebhookSubscriptions_WebhookId",
+                table: "AkahuWebhookSubscriptions");
+
+            migrationBuilder.CreateIndex(
+                name: "IX_AkahuWebhookSubscriptions_WebhookId",
+                table: "AkahuWebhookSubscriptions",
+                column: "WebhookId",
+                unique: true);
+        }
+    }
+}

--- a/src/WebAPI/MyMascada.WebAPI/Program.cs
+++ b/src/WebAPI/MyMascada.WebAPI/Program.cs
@@ -463,6 +463,11 @@ recurringJobManager.AddOrUpdate<MyMascada.Application.BackgroundJobs.ITokenRevoc
     service => service.RetryPendingRevocationsAsync(),
     Hangfire.Cron.Daily(3, 45)); // Run daily at 3:45 AM
 
+recurringJobManager.AddOrUpdate<MyMascada.Application.BackgroundJobs.IAkahuWebhookSubscriptionReconciliationJobService>(
+    "reconcile-akahu-webhook-subscriptions",
+    service => service.ReconcileAllAsync(),
+    Hangfire.Cron.Daily(4, 0)); // Run daily at 4:00 AM
+
 // Hangfire automatically replaces CancellationToken parameters with its shutdown token at runtime
 recurringJobManager.AddOrUpdate<MyMascada.Application.BackgroundJobs.IRuleSuggestionGenerationJobService>(
     "weekly-rule-suggestion-generation",

--- a/src/WebAPI/MyMascada.WebAPI/appsettings.json
+++ b/src/WebAPI/MyMascada.WebAPI/appsettings.json
@@ -123,7 +123,8 @@
     "RedirectUri": "http://localhost:3000/settings/bank-connections/callback",
     "DefaultScopes": ["ENDURING_CONSENT"],
     "ApiBaseUrl": "https://api.akahu.io/v1",
-    "OAuthBaseUrl": "https://oauth.akahu.nz"
+    "OAuthBaseUrl": "https://oauth.akahu.nz",
+    "MigrationFallbackEnabled": true
   },
   "PasswordReset": {
     "TokenExpirationMinutes": 30,

--- a/tests/MyMascada.Tests.Unit/Commands/InitiateAkahuConnectionCommandHandlerTests.cs
+++ b/tests/MyMascada.Tests.Unit/Commands/InitiateAkahuConnectionCommandHandlerTests.cs
@@ -1,13 +1,40 @@
 using MyMascada.Application.Common.Interfaces;
 using MyMascada.Application.Features.BankConnections.Commands;
 using MyMascada.Application.Features.BankConnections.DTOs;
+using MyMascada.Domain.Entities;
 
 namespace MyMascada.Tests.Unit.Commands;
 
 public class InitiateAkahuConnectionCommandHandlerTests
 {
+    private static BankProviderModeResolution HostedOAuthMode() => new(
+        "akahu",
+        "hosted_oauth",
+        new[]
+        {
+            new BankProviderAuthModeInfo
+            {
+                ModeId = "hosted_oauth",
+                DisplayName = "MyMascada OAuth",
+                RequiresUserCredentials = false
+            }
+        });
+
+    private static BankProviderModeResolution PersonalTokensMode() => new(
+        "akahu",
+        "personal_tokens",
+        new[]
+        {
+            new BankProviderAuthModeInfo
+            {
+                ModeId = "personal_tokens",
+                DisplayName = "Personal tokens",
+                RequiresUserCredentials = true
+            }
+        });
+
     [Fact]
-    public async Task Handle_HostedOAuthMode_ReturnsAuthorizationUrlAndSkipsCredentialLookup()
+    public async Task Handle_HostedOAuthMode_NoCredentials_ReturnsAuthorizationUrl()
     {
         var akahuApiClient = Substitute.For<IAkahuApiClient>();
         var credentialRepository = Substitute.For<IAkahuUserCredentialRepository>();
@@ -17,30 +44,15 @@ public class InitiateAkahuConnectionCommandHandlerTests
         var oauthStateStore = Substitute.For<IOAuthStateStore>();
         var logger = Substitute.For<IApplicationLogger<InitiateAkahuConnectionCommandHandler>>();
 
-        modeResolver.Resolve("akahu").Returns(new BankProviderModeResolution(
-            "akahu",
-            "hosted_oauth",
-            new[]
-            {
-                new BankProviderAuthModeInfo
-                {
-                    ModeId = "hosted_oauth",
-                    DisplayName = "MyMascada OAuth",
-                    RequiresUserCredentials = false
-                }
-            }));
-
+        modeResolver.Resolve("akahu").Returns(HostedOAuthMode());
+        credentialRepository.GetByUserIdAsync(Arg.Any<Guid>(), Arg.Any<CancellationToken>())
+            .Returns((AkahuUserCredential?)null);
         akahuApiClient.GetAuthorizationUrl(Arg.Any<string>(), "neo@example.com")
             .Returns("https://next.oauth.akahu.nz/?client_id=app_token_xxx");
 
         var handler = new InitiateAkahuConnectionCommandHandler(
-            akahuApiClient,
-            credentialRepository,
-            bankConnectionRepository,
-            encryptionService,
-            modeResolver,
-            oauthStateStore,
-            logger);
+            akahuApiClient, credentialRepository, bankConnectionRepository,
+            encryptionService, modeResolver, oauthStateStore, logger);
 
         var userId = Guid.NewGuid();
         var result = await handler.Handle(new InitiateAkahuConnectionCommand(userId, "neo@example.com"), CancellationToken.None);
@@ -49,11 +61,141 @@ public class InitiateAkahuConnectionCommandHandlerTests
         result.RequiresCredentials.Should().BeFalse();
         result.AuthorizationUrl.Should().StartWith("https://next.oauth.akahu.nz/");
         result.State.Should().NotBeNullOrWhiteSpace();
-
-        // State should be persisted server-side
         await oauthStateStore.Received(1).StoreAsync(userId, Arg.Any<string>(), Arg.Any<CancellationToken>());
+    }
 
-        await credentialRepository.DidNotReceive().GetByUserIdAsync(Arg.Any<Guid>(), Arg.Any<CancellationToken>());
+    [Fact]
+    public async Task Handle_ExistingValidCredentials_SkipsOAuthAndReturnsAvailableAccounts()
+    {
+        // Regression: previously the hosted_oauth path always redirected to Akahu even when
+        // the user already had valid credentials. Now we re-use them and return accounts
+        // directly so the user can link additional accounts without re-authorizing.
+        var akahuApiClient = Substitute.For<IAkahuApiClient>();
+        var credentialRepository = Substitute.For<IAkahuUserCredentialRepository>();
+        var bankConnectionRepository = Substitute.For<IBankConnectionRepository>();
+        var encryptionService = Substitute.For<ISettingsEncryptionService>();
+        var modeResolver = Substitute.For<IBankProviderModeResolver>();
+        var oauthStateStore = Substitute.For<IOAuthStateStore>();
+        var logger = Substitute.For<IApplicationLogger<InitiateAkahuConnectionCommandHandler>>();
+
+        modeResolver.Resolve("akahu").Returns(HostedOAuthMode());
+
+        var userId = Guid.NewGuid();
+        var credential = new AkahuUserCredential
+        {
+            UserId = userId,
+            EncryptedAppToken = "cipher-app",
+            EncryptedUserToken = "cipher-user",
+            ConsentRevokedAt = null
+        };
+        credentialRepository.GetByUserIdAsync(userId, Arg.Any<CancellationToken>()).Returns(credential);
+        encryptionService.DecryptSettings<string>("cipher-app").Returns("app_token_xxx");
+        encryptionService.DecryptSettings<string>("cipher-user").Returns("user_token_yyy");
+
+        akahuApiClient.GetAccountsWithCredentialsAsync("app_token_xxx", "user_token_yyy", Arg.Any<CancellationToken>())
+            .Returns(new List<AkahuAccountInfo>
+            {
+                new() { Id = "acc_1", Name = "Everyday", FormattedAccount = "01-0001-0000000-00", Type = "CHECKING", BankName = "ANZ", Currency = "NZD", CurrentBalance = 100m }
+            });
+
+        bankConnectionRepository.GetByUserIdAsync(userId, Arg.Any<CancellationToken>())
+            .Returns(new List<BankConnection>());
+
+        var handler = new InitiateAkahuConnectionCommandHandler(
+            akahuApiClient, credentialRepository, bankConnectionRepository,
+            encryptionService, modeResolver, oauthStateStore, logger);
+
+        var result = await handler.Handle(new InitiateAkahuConnectionCommand(userId), CancellationToken.None);
+
+        result.IsPersonalAppMode.Should().BeTrue();
+        result.RequiresCredentials.Should().BeFalse();
+        result.AuthorizationUrl.Should().BeNull();
+        result.AvailableAccounts.Should().NotBeNull();
+        result.AvailableAccounts!.Should().HaveCount(1);
+        result.AvailableAccounts!.First().Id.Should().Be("acc_1");
+
+        // No OAuth state should have been persisted.
+        await oauthStateStore.DidNotReceive().StoreAsync(Arg.Any<Guid>(), Arg.Any<string>(), Arg.Any<CancellationToken>());
+        akahuApiClient.DidNotReceive().GetAuthorizationUrl(Arg.Any<string>(), Arg.Any<string?>());
+    }
+
+    [Fact]
+    public async Task Handle_ExistingCredentialsRejectedByAkahu_FallsBackToOAuthFlow()
+    {
+        // If the stored token is revoked upstream, hosted_oauth mode should silently
+        // fall through to a fresh authorization URL rather than surfacing an error.
+        var akahuApiClient = Substitute.For<IAkahuApiClient>();
+        var credentialRepository = Substitute.For<IAkahuUserCredentialRepository>();
+        var bankConnectionRepository = Substitute.For<IBankConnectionRepository>();
+        var encryptionService = Substitute.For<ISettingsEncryptionService>();
+        var modeResolver = Substitute.For<IBankProviderModeResolver>();
+        var oauthStateStore = Substitute.For<IOAuthStateStore>();
+        var logger = Substitute.For<IApplicationLogger<InitiateAkahuConnectionCommandHandler>>();
+
+        modeResolver.Resolve("akahu").Returns(HostedOAuthMode());
+
+        var userId = Guid.NewGuid();
+        var credential = new AkahuUserCredential
+        {
+            UserId = userId,
+            EncryptedAppToken = "cipher-app",
+            EncryptedUserToken = "cipher-user",
+            ConsentRevokedAt = null
+        };
+        credentialRepository.GetByUserIdAsync(userId, Arg.Any<CancellationToken>()).Returns(credential);
+        encryptionService.DecryptSettings<string>("cipher-app").Returns("app_token_xxx");
+        encryptionService.DecryptSettings<string>("cipher-user").Returns("user_token_yyy");
+        akahuApiClient.GetAccountsWithCredentialsAsync(Arg.Any<string>(), Arg.Any<string>(), Arg.Any<CancellationToken>())
+            .Returns<IReadOnlyList<AkahuAccountInfo>>(_ => throw new UnauthorizedAccessException("Token revoked"));
+        akahuApiClient.GetAuthorizationUrl(Arg.Any<string>(), Arg.Any<string?>())
+            .Returns("https://next.oauth.akahu.nz/?client_id=app_token_xxx");
+
+        var handler = new InitiateAkahuConnectionCommandHandler(
+            akahuApiClient, credentialRepository, bankConnectionRepository,
+            encryptionService, modeResolver, oauthStateStore, logger);
+
+        var result = await handler.Handle(new InitiateAkahuConnectionCommand(userId), CancellationToken.None);
+
+        result.AuthorizationUrl.Should().StartWith("https://next.oauth.akahu.nz/");
+        result.RequiresCredentials.Should().BeFalse();
+        await oauthStateStore.Received(1).StoreAsync(userId, Arg.Any<string>(), Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task Handle_RevokedCredentials_HostedOAuthMode_ReturnsAuthorizationUrl()
+    {
+        // ConsentRevokedAt != null means the user explicitly disconnected; we must not
+        // try to reuse the row — issue a fresh authorization URL.
+        var akahuApiClient = Substitute.For<IAkahuApiClient>();
+        var credentialRepository = Substitute.For<IAkahuUserCredentialRepository>();
+        var bankConnectionRepository = Substitute.For<IBankConnectionRepository>();
+        var encryptionService = Substitute.For<ISettingsEncryptionService>();
+        var modeResolver = Substitute.For<IBankProviderModeResolver>();
+        var oauthStateStore = Substitute.For<IOAuthStateStore>();
+        var logger = Substitute.For<IApplicationLogger<InitiateAkahuConnectionCommandHandler>>();
+
+        modeResolver.Resolve("akahu").Returns(HostedOAuthMode());
+
+        var userId = Guid.NewGuid();
+        credentialRepository.GetByUserIdAsync(userId, Arg.Any<CancellationToken>())
+            .Returns(new AkahuUserCredential
+            {
+                UserId = userId,
+                EncryptedAppToken = "cipher-app",
+                EncryptedUserToken = "cipher-user",
+                ConsentRevokedAt = DateTime.UtcNow.AddDays(-1)
+            });
+        akahuApiClient.GetAuthorizationUrl(Arg.Any<string>(), Arg.Any<string?>())
+            .Returns("https://next.oauth.akahu.nz/?client_id=app_token_xxx");
+
+        var handler = new InitiateAkahuConnectionCommandHandler(
+            akahuApiClient, credentialRepository, bankConnectionRepository,
+            encryptionService, modeResolver, oauthStateStore, logger);
+
+        var result = await handler.Handle(new InitiateAkahuConnectionCommand(userId), CancellationToken.None);
+
+        result.AuthorizationUrl.Should().StartWith("https://next.oauth.akahu.nz/");
+        await akahuApiClient.DidNotReceive().GetAccountsWithCredentialsAsync(Arg.Any<string>(), Arg.Any<string>(), Arg.Any<CancellationToken>());
     }
 
     [Fact]

--- a/tests/MyMascada.Tests.Unit/Commands/MigrateAkahuConnectionCommandHandlerTests.cs
+++ b/tests/MyMascada.Tests.Unit/Commands/MigrateAkahuConnectionCommandHandlerTests.cs
@@ -297,6 +297,98 @@ public class MigrateAkahuConnectionCommandHandlerTests
     }
 
     [Fact]
+    public async Task Handle_EncryptedSettingsDecryptionFails_MarksConnectionAndSkipsAkahuCalls()
+    {
+        var userId = Guid.NewGuid();
+        var connectionId = 42;
+        var accountId = 100;
+        var ctx = CreateContext(userId, connectionId, accountId);
+
+        ctx.Connection!.EncryptedSettings = "ENC_BROKEN";
+
+        ctx.EncryptionService
+            .DecryptSettings<AkahuConnectionSettings>("ENC_BROKEN")
+            .Returns<AkahuConnectionSettings?>(_ => throw new InvalidOperationException("Data Protection keys missing"));
+
+        var handler = ctx.BuildHandler();
+
+        var result = await handler.Handle(new MigrateAkahuConnectionCommand(userId, connectionId), CancellationToken.None);
+
+        result.Success.Should().BeFalse();
+        result.ErrorMessage.Should().Contain("settings");
+
+        await ctx.BankConnectionRepository.Received(1).UpdateAsync(
+            Arg.Is<BankConnection>(c =>
+                c.Id == connectionId &&
+                c.IsActive == false &&
+                c.LastSyncError != null &&
+                c.LastSyncError.Contains("re-link")),
+            Arg.Any<CancellationToken>());
+
+        // Should not have called the Akahu accounts/transactions endpoints — fail fast.
+        await ctx.AkahuApiClient.DidNotReceive().GetAccountsWithCredentialsAsync(
+            Arg.Any<string>(), Arg.Any<string>(), Arg.Any<CancellationToken>());
+        await ctx.AkahuApiClient.DidNotReceive().GetTransactionsWithCredentialsAsync(
+            Arg.Any<string>(), Arg.Any<string>(), Arg.Any<string>(), Arg.Any<DateTime?>(), Arg.Any<DateTime?>(), Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task Handle_SuccessfulMigration_CommitsUnitOfWorkTransaction()
+    {
+        var userId = Guid.NewGuid();
+        var connectionId = 42;
+        var accountId = 100;
+        var ctx = CreateContext(userId, connectionId, accountId);
+
+        ctx.AkahuApiClient.GetAccountsWithCredentialsAsync("app_token", "user_token", Arg.Any<CancellationToken>())
+            .Returns(new[] { new AkahuAccountInfo { Id = NewAccountId, Name = "Everyday", Migrated = OldAccountId } });
+        ctx.TransactionRepository.GetOldestTransactionDateForAccountAsync(accountId, Arg.Any<CancellationToken>())
+            .Returns((DateTime?)null);
+        ctx.AkahuApiClient.GetTransactionsWithCredentialsAsync(
+                "app_token", "user_token", NewAccountId, Arg.Any<DateTime?>(), Arg.Any<DateTime?>(), Arg.Any<CancellationToken>())
+            .Returns(Array.Empty<BankTransactionDto>());
+
+        var handler = ctx.BuildHandler();
+        var result = await handler.Handle(new MigrateAkahuConnectionCommand(userId, connectionId), CancellationToken.None);
+
+        result.Success.Should().BeTrue();
+        await ctx.UnitOfWork.Received(1).BeginTransactionAsync(Arg.Any<CancellationToken>());
+        await ctx.Transaction.Received(1).CommitAsync(Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task Handle_RemapThrows_TransactionNotCommitted()
+    {
+        var userId = Guid.NewGuid();
+        var connectionId = 42;
+        var accountId = 100;
+        var ctx = CreateContext(userId, connectionId, accountId);
+
+        ctx.AkahuApiClient.GetAccountsWithCredentialsAsync("app_token", "user_token", Arg.Any<CancellationToken>())
+            .Returns(new[] { new AkahuAccountInfo { Id = NewAccountId, Name = "Everyday", Migrated = OldAccountId } });
+        ctx.TransactionRepository.GetOldestTransactionDateForAccountAsync(accountId, Arg.Any<CancellationToken>())
+            .Returns(DateTime.UtcNow.Date.AddDays(-30));
+        ctx.AkahuApiClient.GetTransactionsWithCredentialsAsync(
+                "app_token", "user_token", NewAccountId, Arg.Any<DateTime?>(), Arg.Any<DateTime?>(), Arg.Any<CancellationToken>())
+            .Returns(new[]
+            {
+                new BankTransactionDto { ExternalId = NewTxId1, Migrated = OldTxId1, Amount = -10m, Description = "Coffee" }
+            });
+
+        ctx.TransactionRepository.RemapExternalIdsAsync(accountId, Arg.Any<IReadOnlyDictionary<string, string>>(), Arg.Any<CancellationToken>())
+            .Returns<int>(_ => throw new InvalidOperationException("simulated remap failure"));
+
+        var handler = ctx.BuildHandler();
+
+        var act = async () => await handler.Handle(new MigrateAkahuConnectionCommand(userId, connectionId), CancellationToken.None);
+        await act.Should().ThrowAsync<InvalidOperationException>();
+
+        await ctx.UnitOfWork.Received(1).BeginTransactionAsync(Arg.Any<CancellationToken>());
+        await ctx.Transaction.DidNotReceive().CommitAsync(Arg.Any<CancellationToken>());
+        await ctx.Transaction.Received(1).DisposeAsync();
+    }
+
+    [Fact]
     public async Task Handle_EncryptedSettingsRoundTrip_AkahuAccountIdRewrittenInSettingsToo()
     {
         var userId = Guid.NewGuid();
@@ -306,9 +398,12 @@ public class MigrateAkahuConnectionCommandHandlerTests
 
         ctx.Connection!.EncryptedSettings = "ENC_OLD_SETTINGS";
 
+        // Settings round-trip: when the handler decrypts the existing connection settings, we
+        // return an instance with a stale AkahuAccountId so the test can assert that it gets
+        // rewritten with the new ID and re-encrypted.
         ctx.EncryptionService
-            .When(s => s.DecryptSettings<object>(Arg.Any<string>()))
-            .Do(_ => { });
+            .DecryptSettings<AkahuConnectionSettings>("ENC_OLD_SETTINGS")
+            .Returns(new AkahuConnectionSettings { AkahuAccountId = OldAccountId });
 
         var capturedEncrypt = new List<object>();
         ctx.EncryptionService
@@ -354,6 +449,9 @@ public class MigrateAkahuConnectionCommandHandlerTests
         var akahuApiClient = Substitute.For<IAkahuApiClient>();
         var transactionRepository = Substitute.For<ITransactionRepository>();
         var encryptionService = Substitute.For<ISettingsEncryptionService>();
+        var unitOfWork = Substitute.For<IUnitOfWork>();
+        var transaction = Substitute.For<IUnitOfWorkTransaction>();
+        unitOfWork.BeginTransactionAsync(Arg.Any<CancellationToken>()).Returns(transaction);
         var logger = Substitute.For<IApplicationLogger<MigrateAkahuConnectionCommandHandler>>();
 
         BankConnection? connection = null;
@@ -398,6 +496,8 @@ public class MigrateAkahuConnectionCommandHandlerTests
             akahuApiClient,
             transactionRepository,
             encryptionService,
+            unitOfWork,
+            transaction,
             logger,
             connection);
     }
@@ -408,6 +508,8 @@ public class MigrateAkahuConnectionCommandHandlerTests
         IAkahuApiClient AkahuApiClient,
         ITransactionRepository TransactionRepository,
         ISettingsEncryptionService EncryptionService,
+        IUnitOfWork UnitOfWork,
+        IUnitOfWorkTransaction Transaction,
         IApplicationLogger<MigrateAkahuConnectionCommandHandler> Logger,
         BankConnection? Connection)
     {
@@ -417,6 +519,7 @@ public class MigrateAkahuConnectionCommandHandlerTests
             AkahuApiClient,
             TransactionRepository,
             EncryptionService,
+            UnitOfWork,
             Logger);
     }
 }

--- a/tests/MyMascada.Tests.Unit/Commands/MigrateAkahuConnectionCommandHandlerTests.cs
+++ b/tests/MyMascada.Tests.Unit/Commands/MigrateAkahuConnectionCommandHandlerTests.cs
@@ -1,0 +1,422 @@
+using MyMascada.Application.Common.Interfaces;
+using MyMascada.Application.Features.BankConnections.Commands;
+using MyMascada.Application.Features.BankConnections.DTOs;
+using MyMascada.Domain.Entities;
+
+namespace MyMascada.Tests.Unit.Commands;
+
+public class MigrateAkahuConnectionCommandHandlerTests
+{
+    private const string OldAccountId = "acc_OLD_123";
+    private const string NewAccountId = "acc_NEW_456";
+    private const string OldTxId1 = "trans_OLD_aaa";
+    private const string NewTxId1 = "trans_NEW_aaa";
+    private const string OldTxId2 = "trans_OLD_bbb";
+    private const string NewTxId2 = "trans_NEW_bbb";
+
+    [Fact]
+    public async Task Handle_AccountFoundInMigrationList_UpdatesExternalAccountIdAndTransactions()
+    {
+        var userId = Guid.NewGuid();
+        var connectionId = 42;
+        var accountId = 100;
+        var ctx = CreateContext(userId, connectionId, accountId);
+
+        ctx.AkahuApiClient.GetAccountsWithCredentialsAsync("app_token", "user_token", Arg.Any<CancellationToken>())
+            .Returns(new[]
+            {
+                new AkahuAccountInfo
+                {
+                    Id = NewAccountId,
+                    Name = "Everyday (Official)",
+                    Migrated = OldAccountId,
+                    Currency = "NZD"
+                }
+            });
+
+        ctx.TransactionRepository.GetOldestTransactionDateForAccountAsync(accountId, Arg.Any<CancellationToken>())
+            .Returns(DateTime.UtcNow.Date.AddDays(-30));
+
+        ctx.AkahuApiClient.GetTransactionsWithCredentialsAsync(
+                "app_token", "user_token", NewAccountId, Arg.Any<DateTime?>(), Arg.Any<DateTime?>(), Arg.Any<CancellationToken>())
+            .Returns(new[]
+            {
+                new BankTransactionDto { ExternalId = NewTxId1, Migrated = OldTxId1, Amount = -10m, Description = "Coffee" },
+                new BankTransactionDto { ExternalId = NewTxId2, Migrated = OldTxId2, Amount = -20m, Description = "Lunch" }
+            });
+
+        ctx.TransactionRepository.RemapExternalIdsAsync(accountId, Arg.Any<IReadOnlyDictionary<string, string>>(), Arg.Any<CancellationToken>())
+            .Returns(2);
+
+        var handler = ctx.BuildHandler();
+
+        var result = await handler.Handle(new MigrateAkahuConnectionCommand(userId, connectionId), CancellationToken.None);
+
+        result.Success.Should().BeTrue();
+        result.OldExternalAccountId.Should().Be(OldAccountId);
+        result.NewExternalAccountId.Should().Be(NewAccountId);
+        result.TransactionsRemapped.Should().Be(2);
+        result.ErrorMessage.Should().BeNull();
+
+        await ctx.BankConnectionRepository.Received(1).UpdateAsync(
+            Arg.Is<BankConnection>(c =>
+                c.Id == connectionId &&
+                c.ExternalAccountId == NewAccountId &&
+                c.IsActive == true &&
+                c.LastSyncError == null),
+            Arg.Any<CancellationToken>());
+
+        await ctx.TransactionRepository.Received(1).RemapExternalIdsAsync(
+            accountId,
+            Arg.Is<IReadOnlyDictionary<string, string>>(map =>
+                map.Count == 2 &&
+                map[OldTxId1] == NewTxId1 &&
+                map[OldTxId2] == NewTxId2),
+            Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task Handle_NoMatchingMigratedAccount_MarksConnectionAwaitingReauth_ReturnsFailure()
+    {
+        var userId = Guid.NewGuid();
+        var connectionId = 42;
+        var accountId = 100;
+        var ctx = CreateContext(userId, connectionId, accountId);
+
+        ctx.AkahuApiClient.GetAccountsWithCredentialsAsync("app_token", "user_token", Arg.Any<CancellationToken>())
+            .Returns(new[]
+            {
+                new AkahuAccountInfo { Id = "acc_unrelated", Name = "Other", Migrated = "acc_somethingelse" },
+                new AkahuAccountInfo { Id = "acc_no_migration", Name = "Native" }
+            });
+
+        var handler = ctx.BuildHandler();
+
+        var result = await handler.Handle(new MigrateAkahuConnectionCommand(userId, connectionId), CancellationToken.None);
+
+        result.Success.Should().BeFalse();
+        result.OldExternalAccountId.Should().Be(OldAccountId);
+        result.NewExternalAccountId.Should().BeNull();
+        result.TransactionsRemapped.Should().Be(0);
+        result.ErrorMessage.Should().Contain("re-auth");
+
+        await ctx.BankConnectionRepository.Received(1).UpdateAsync(
+            Arg.Is<BankConnection>(c =>
+                c.Id == connectionId &&
+                c.ExternalAccountId == OldAccountId &&
+                c.IsActive == false &&
+                c.LastSyncError == "Awaiting re-authorisation"),
+            Arg.Any<CancellationToken>());
+
+        await ctx.TransactionRepository.DidNotReceive().RemapExternalIdsAsync(
+            Arg.Any<int>(), Arg.Any<IReadOnlyDictionary<string, string>>(), Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task Handle_SuccessfulMigration_SetsLastMigratedAt()
+    {
+        var userId = Guid.NewGuid();
+        var connectionId = 42;
+        var accountId = 100;
+        var ctx = CreateContext(userId, connectionId, accountId);
+
+        ctx.Connection!.LastMigratedAt.Should().BeNull("connection starts unmigrated");
+
+        ctx.AkahuApiClient.GetAccountsWithCredentialsAsync("app_token", "user_token", Arg.Any<CancellationToken>())
+            .Returns(new[]
+            {
+                new AkahuAccountInfo { Id = NewAccountId, Name = "Everyday", Migrated = OldAccountId }
+            });
+
+        ctx.TransactionRepository.GetOldestTransactionDateForAccountAsync(accountId, Arg.Any<CancellationToken>())
+            .Returns((DateTime?)null);
+
+        ctx.AkahuApiClient.GetTransactionsWithCredentialsAsync(
+                "app_token", "user_token", NewAccountId, Arg.Any<DateTime?>(), Arg.Any<DateTime?>(), Arg.Any<CancellationToken>())
+            .Returns(Array.Empty<BankTransactionDto>());
+
+        var before = DateTime.UtcNow;
+        var handler = ctx.BuildHandler();
+
+        var result = await handler.Handle(new MigrateAkahuConnectionCommand(userId, connectionId), CancellationToken.None);
+        var after = DateTime.UtcNow;
+
+        result.Success.Should().BeTrue();
+
+        await ctx.BankConnectionRepository.Received(1).UpdateAsync(
+            Arg.Is<BankConnection>(c =>
+                c.LastMigratedAt != null &&
+                c.LastMigratedAt >= before &&
+                c.LastMigratedAt <= after),
+            Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task Handle_NoMatchingMigratedAccount_LeavesLastMigratedAtNull()
+    {
+        var userId = Guid.NewGuid();
+        var connectionId = 42;
+        var accountId = 100;
+        var ctx = CreateContext(userId, connectionId, accountId);
+
+        ctx.AkahuApiClient.GetAccountsWithCredentialsAsync("app_token", "user_token", Arg.Any<CancellationToken>())
+            .Returns(new[]
+            {
+                new AkahuAccountInfo { Id = "acc_unrelated", Name = "Other", Migrated = "acc_somethingelse" }
+            });
+
+        var handler = ctx.BuildHandler();
+
+        var result = await handler.Handle(new MigrateAkahuConnectionCommand(userId, connectionId), CancellationToken.None);
+
+        result.Success.Should().BeFalse();
+
+        await ctx.BankConnectionRepository.Received(1).UpdateAsync(
+            Arg.Is<BankConnection>(c => c.LastMigratedAt == null),
+            Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task Handle_BankConnectionNotFound_ReturnsFailure()
+    {
+        var userId = Guid.NewGuid();
+        var ctx = CreateContext(userId, 99, 100, includeConnection: false);
+
+        var handler = ctx.BuildHandler();
+
+        var result = await handler.Handle(new MigrateAkahuConnectionCommand(userId, 99), CancellationToken.None);
+
+        result.Success.Should().BeFalse();
+        result.OldExternalAccountId.Should().BeNull();
+        result.NewExternalAccountId.Should().BeNull();
+        result.ErrorMessage.Should().Contain("not found");
+
+        await ctx.BankConnectionRepository.DidNotReceive().UpdateAsync(Arg.Any<BankConnection>(), Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task Handle_BankConnectionBelongsToDifferentUser_ReturnsFailure()
+    {
+        var requestingUserId = Guid.NewGuid();
+        var otherUserId = Guid.NewGuid();
+        var connectionId = 77;
+        var ctx = CreateContext(otherUserId, connectionId, 100);
+
+        var handler = ctx.BuildHandler();
+
+        var result = await handler.Handle(new MigrateAkahuConnectionCommand(requestingUserId, connectionId), CancellationToken.None);
+
+        result.Success.Should().BeFalse();
+        result.NewExternalAccountId.Should().BeNull();
+        result.ErrorMessage.Should().Contain("not found");
+
+        await ctx.BankConnectionRepository.DidNotReceive().UpdateAsync(Arg.Any<BankConnection>(), Arg.Any<CancellationToken>());
+        await ctx.AkahuApiClient.DidNotReceive().GetAccountsWithCredentialsAsync(
+            Arg.Any<string>(), Arg.Any<string>(), Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task Handle_NoTransactionsToMigrate_StillSucceeds_RemappedCountZero()
+    {
+        var userId = Guid.NewGuid();
+        var connectionId = 42;
+        var accountId = 100;
+        var ctx = CreateContext(userId, connectionId, accountId);
+
+        ctx.AkahuApiClient.GetAccountsWithCredentialsAsync("app_token", "user_token", Arg.Any<CancellationToken>())
+            .Returns(new[]
+            {
+                new AkahuAccountInfo { Id = NewAccountId, Name = "Everyday", Migrated = OldAccountId }
+            });
+
+        ctx.TransactionRepository.GetOldestTransactionDateForAccountAsync(accountId, Arg.Any<CancellationToken>())
+            .Returns((DateTime?)null);
+
+        ctx.AkahuApiClient.GetTransactionsWithCredentialsAsync(
+                "app_token", "user_token", NewAccountId, Arg.Any<DateTime?>(), Arg.Any<DateTime?>(), Arg.Any<CancellationToken>())
+            .Returns(Array.Empty<BankTransactionDto>());
+
+        var handler = ctx.BuildHandler();
+
+        var result = await handler.Handle(new MigrateAkahuConnectionCommand(userId, connectionId), CancellationToken.None);
+
+        result.Success.Should().BeTrue();
+        result.OldExternalAccountId.Should().Be(OldAccountId);
+        result.NewExternalAccountId.Should().Be(NewAccountId);
+        result.TransactionsRemapped.Should().Be(0);
+
+        await ctx.BankConnectionRepository.Received(1).UpdateAsync(
+            Arg.Is<BankConnection>(c => c.ExternalAccountId == NewAccountId),
+            Arg.Any<CancellationToken>());
+
+        await ctx.TransactionRepository.DidNotReceive().RemapExternalIdsAsync(
+            Arg.Any<int>(), Arg.Any<IReadOnlyDictionary<string, string>>(), Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task Handle_TransactionMigratedFieldNull_SkipsThatTransaction()
+    {
+        var userId = Guid.NewGuid();
+        var connectionId = 42;
+        var accountId = 100;
+        var ctx = CreateContext(userId, connectionId, accountId);
+
+        ctx.AkahuApiClient.GetAccountsWithCredentialsAsync("app_token", "user_token", Arg.Any<CancellationToken>())
+            .Returns(new[]
+            {
+                new AkahuAccountInfo { Id = NewAccountId, Name = "Everyday", Migrated = OldAccountId }
+            });
+
+        ctx.TransactionRepository.GetOldestTransactionDateForAccountAsync(accountId, Arg.Any<CancellationToken>())
+            .Returns(DateTime.UtcNow.Date.AddDays(-30));
+
+        ctx.AkahuApiClient.GetTransactionsWithCredentialsAsync(
+                "app_token", "user_token", NewAccountId, Arg.Any<DateTime?>(), Arg.Any<DateTime?>(), Arg.Any<CancellationToken>())
+            .Returns(new[]
+            {
+                new BankTransactionDto { ExternalId = NewTxId1, Migrated = OldTxId1, Amount = -10m, Description = "Coffee" },
+                new BankTransactionDto { ExternalId = "trans_NEW_native", Migrated = null, Amount = -5m, Description = "Native (not migrated)" }
+            });
+
+        ctx.TransactionRepository.RemapExternalIdsAsync(
+                accountId, Arg.Any<IReadOnlyDictionary<string, string>>(), Arg.Any<CancellationToken>())
+            .Returns(1);
+
+        var handler = ctx.BuildHandler();
+
+        var result = await handler.Handle(new MigrateAkahuConnectionCommand(userId, connectionId), CancellationToken.None);
+
+        result.Success.Should().BeTrue();
+        result.TransactionsRemapped.Should().Be(1);
+
+        await ctx.TransactionRepository.Received(1).RemapExternalIdsAsync(
+            accountId,
+            Arg.Is<IReadOnlyDictionary<string, string>>(map =>
+                map.Count == 1 && map.ContainsKey(OldTxId1) && map[OldTxId1] == NewTxId1),
+            Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task Handle_EncryptedSettingsRoundTrip_AkahuAccountIdRewrittenInSettingsToo()
+    {
+        var userId = Guid.NewGuid();
+        var connectionId = 42;
+        var accountId = 100;
+        var ctx = CreateContext(userId, connectionId, accountId);
+
+        ctx.Connection!.EncryptedSettings = "ENC_OLD_SETTINGS";
+
+        ctx.EncryptionService
+            .When(s => s.DecryptSettings<object>(Arg.Any<string>()))
+            .Do(_ => { });
+
+        var capturedEncrypt = new List<object>();
+        ctx.EncryptionService
+            .EncryptSettings(Arg.Do<object>(o => capturedEncrypt.Add(o)))
+            .Returns("ENC_NEW_SETTINGS");
+
+        ctx.AkahuApiClient.GetAccountsWithCredentialsAsync("app_token", "user_token", Arg.Any<CancellationToken>())
+            .Returns(new[]
+            {
+                new AkahuAccountInfo { Id = NewAccountId, Name = "Everyday", Migrated = OldAccountId }
+            });
+
+        ctx.TransactionRepository.GetOldestTransactionDateForAccountAsync(accountId, Arg.Any<CancellationToken>())
+            .Returns((DateTime?)null);
+
+        ctx.AkahuApiClient.GetTransactionsWithCredentialsAsync(
+                "app_token", "user_token", NewAccountId, Arg.Any<DateTime?>(), Arg.Any<DateTime?>(), Arg.Any<CancellationToken>())
+            .Returns(Array.Empty<BankTransactionDto>());
+
+        var handler = ctx.BuildHandler();
+
+        var result = await handler.Handle(new MigrateAkahuConnectionCommand(userId, connectionId), CancellationToken.None);
+
+        result.Success.Should().BeTrue();
+
+        await ctx.BankConnectionRepository.Received(1).UpdateAsync(
+            Arg.Is<BankConnection>(c =>
+                c.EncryptedSettings == "ENC_NEW_SETTINGS" &&
+                c.ExternalAccountId == NewAccountId),
+            Arg.Any<CancellationToken>());
+
+        capturedEncrypt.Should().NotBeEmpty();
+        var settingsObj = capturedEncrypt[^1];
+        var accountIdProp = settingsObj.GetType().GetProperty("AkahuAccountId");
+        accountIdProp.Should().NotBeNull("the encrypted settings object should expose AkahuAccountId");
+        accountIdProp!.GetValue(settingsObj).Should().Be(NewAccountId);
+    }
+
+    private static TestContext CreateContext(Guid userId, int connectionId, int accountId, bool includeConnection = true)
+    {
+        var bankConnectionRepository = Substitute.For<IBankConnectionRepository>();
+        var credentialRepository = Substitute.For<IAkahuUserCredentialRepository>();
+        var akahuApiClient = Substitute.For<IAkahuApiClient>();
+        var transactionRepository = Substitute.For<ITransactionRepository>();
+        var encryptionService = Substitute.For<ISettingsEncryptionService>();
+        var logger = Substitute.For<IApplicationLogger<MigrateAkahuConnectionCommandHandler>>();
+
+        BankConnection? connection = null;
+        if (includeConnection)
+        {
+            connection = new BankConnection
+            {
+                Id = connectionId,
+                UserId = userId,
+                AccountId = accountId,
+                ProviderId = "akahu",
+                ExternalAccountId = OldAccountId,
+                ExternalAccountName = "Everyday (Classic)",
+                EncryptedSettings = null,
+                IsActive = true
+            };
+            bankConnectionRepository.GetByIdAsync(connectionId, Arg.Any<CancellationToken>())
+                .Returns(connection);
+        }
+        else
+        {
+            bankConnectionRepository.GetByIdAsync(Arg.Any<int>(), Arg.Any<CancellationToken>())
+                .Returns((BankConnection?)null);
+        }
+
+        var credential = new AkahuUserCredential
+        {
+            Id = 1,
+            UserId = userId,
+            EncryptedAppToken = "ENC_APP",
+            EncryptedUserToken = "ENC_USER"
+        };
+        credentialRepository.GetByUserIdAsync(userId, Arg.Any<CancellationToken>()).Returns(credential);
+
+        encryptionService.DecryptSettings<string>("ENC_APP").Returns("app_token");
+        encryptionService.DecryptSettings<string>("ENC_USER").Returns("user_token");
+        encryptionService.EncryptSettings(Arg.Any<object>()).Returns("ENC_NEW_SETTINGS");
+
+        return new TestContext(
+            bankConnectionRepository,
+            credentialRepository,
+            akahuApiClient,
+            transactionRepository,
+            encryptionService,
+            logger,
+            connection);
+    }
+
+    private sealed record TestContext(
+        IBankConnectionRepository BankConnectionRepository,
+        IAkahuUserCredentialRepository CredentialRepository,
+        IAkahuApiClient AkahuApiClient,
+        ITransactionRepository TransactionRepository,
+        ISettingsEncryptionService EncryptionService,
+        IApplicationLogger<MigrateAkahuConnectionCommandHandler> Logger,
+        BankConnection? Connection)
+    {
+        public MigrateAkahuConnectionCommandHandler BuildHandler() => new(
+            BankConnectionRepository,
+            CredentialRepository,
+            AkahuApiClient,
+            TransactionRepository,
+            EncryptionService,
+            Logger);
+    }
+}

--- a/tests/MyMascada.Tests.Unit/Commands/ProcessAkahuWebhookCommandHandlerTests.cs
+++ b/tests/MyMascada.Tests.Unit/Commands/ProcessAkahuWebhookCommandHandlerTests.cs
@@ -1,0 +1,60 @@
+using MyMascada.Application.BackgroundJobs;
+using MyMascada.Application.Common.Interfaces;
+using MyMascada.Application.Features.BankConnections.Commands;
+using MyMascada.Application.Features.BankConnections.DTOs;
+using MyMascada.Domain.Entities;
+
+namespace MyMascada.Tests.Unit.Commands;
+
+public class ProcessAkahuWebhookCommandHandlerTests
+{
+    [Fact]
+    public async Task Handle_AccountMigrateEvent_EnqueuesJobInsteadOfRunningInline()
+    {
+        // Regression: previously the handler called _mediator.Send for MigrateAkahuConnectionCommand
+        // and awaited it. That blocked the webhook response until Akahu's API calls and DB remap
+        // completed, risking webhook timeouts. The handler must hand off to Hangfire.
+        var bankConnectionRepository = Substitute.For<IBankConnectionRepository>();
+        var bankSyncService = Substitute.For<IBankSyncService>();
+        var credentialRepository = Substitute.For<IAkahuUserCredentialRepository>();
+        var transactionRepository = Substitute.For<ITransactionRepository>();
+        var subscriptionRepository = Substitute.For<IAkahuWebhookSubscriptionRepository>();
+        var migrationJobService = Substitute.For<IAkahuMigrationJobService>();
+        var logger = Substitute.For<IApplicationLogger<ProcessAkahuWebhookCommandHandler>>();
+
+        var userId = Guid.NewGuid();
+        var connection = new BankConnection
+        {
+            Id = 42,
+            UserId = userId,
+            ProviderId = "akahu",
+            ExternalAccountId = "acc_OLD",
+            IsActive = true
+        };
+        bankConnectionRepository.GetByExternalAccountIdAsync("acc_OLD", "akahu", Arg.Any<CancellationToken>())
+            .Returns(connection);
+
+        migrationJobService.EnqueueMigration(userId, 42).Returns("job-123");
+
+        var handler = new ProcessAkahuWebhookCommandHandler(
+            bankConnectionRepository,
+            bankSyncService,
+            credentialRepository,
+            transactionRepository,
+            subscriptionRepository,
+            migrationJobService,
+            logger);
+
+        var payload = new AkahuWebhookPayload
+        {
+            WebhookType = AkahuWebhookTypes.Account,
+            WebhookCode = AkahuWebhookCodes.Migrate,
+            PreviousItemId = "acc_OLD",
+            ItemId = "acc_NEW"
+        };
+
+        await handler.Handle(new ProcessAkahuWebhookCommand(payload), CancellationToken.None);
+
+        migrationJobService.Received(1).EnqueueMigration(userId, 42);
+    }
+}

--- a/tests/MyMascada.Tests.Unit/Controllers/AccountsControllerTests.cs
+++ b/tests/MyMascada.Tests.Unit/Controllers/AccountsControllerTests.cs
@@ -252,6 +252,74 @@ public class AccountsControllerTests
     }
 
     [Fact]
+    public async Task UpdateAccount_WithIsActiveOmitted_PreservesExistingActiveState()
+    {
+        // Regression: UpdateAccountDto.IsActive used to be non-nullable bool, so a
+        // request that didn't include the field would deserialize to false and silently
+        // archive the account. Now nullable; null must preserve the existing value.
+        var accountId = 42;
+        var request = new UpdateAccountDto
+        {
+            Id = accountId,
+            Name = "Renamed",
+            Type = AccountType.Checking,
+            Currency = "NZD",
+            IsActive = null
+        };
+
+        var existingAccount = new Account
+        {
+            Id = accountId,
+            Name = "Original",
+            Currency = "NZD",
+            UserId = _userId,
+            IsActive = true
+        };
+
+        _accountRepository.GetByIdAsync(accountId, _userId).Returns(existingAccount);
+        _accountRepository.UpdateAsync(Arg.Any<Account>()).Returns(Task.CompletedTask);
+
+        var result = await _controller.UpdateAccount(accountId, request);
+
+        result.Result.Should().BeOfType<OkObjectResult>();
+        existingAccount.IsActive.Should().BeTrue();
+        await _accountRepository.Received(1).UpdateAsync(
+            Arg.Is<Account>(a => a.Id == accountId && a.IsActive));
+    }
+
+    [Fact]
+    public async Task UpdateAccount_WithIsActiveSetToFalse_AppliesIsActiveFalse()
+    {
+        // The complementary case: explicitly archiving via the update endpoint still works.
+        var accountId = 43;
+        var request = new UpdateAccountDto
+        {
+            Id = accountId,
+            Name = "Renamed",
+            Type = AccountType.Checking,
+            Currency = "NZD",
+            IsActive = false
+        };
+
+        var existingAccount = new Account
+        {
+            Id = accountId,
+            Name = "Original",
+            Currency = "NZD",
+            UserId = _userId,
+            IsActive = true
+        };
+
+        _accountRepository.GetByIdAsync(accountId, _userId).Returns(existingAccount);
+        _accountRepository.UpdateAsync(Arg.Any<Account>()).Returns(Task.CompletedTask);
+
+        var result = await _controller.UpdateAccount(accountId, request);
+
+        result.Result.Should().BeOfType<OkObjectResult>();
+        existingAccount.IsActive.Should().BeFalse();
+    }
+
+    [Fact]
     public async Task UpdateAccount_WithTransactions_ShouldAllowUpdate()
     {
         // Arrange

--- a/tests/MyMascada.Tests.Unit/Queries/ExchangeAkahuCodeQueryHandlerTests.cs
+++ b/tests/MyMascada.Tests.Unit/Queries/ExchangeAkahuCodeQueryHandlerTests.cs
@@ -1,3 +1,4 @@
+using MediatR;
 using MyMascada.Application.Common.Interfaces;
 using MyMascada.Application.Features.BankConnections.Queries;
 using MyMascada.Domain.Entities;
@@ -15,7 +16,12 @@ public class ExchangeAkahuCodeQueryHandlerTests
         var bankConnectionRepository = Substitute.For<IBankConnectionRepository>();
         var encryptionService = Substitute.For<ISettingsEncryptionService>();
         var oauthStateStore = Substitute.For<IOAuthStateStore>();
+        var webhookSubscriptionService = Substitute.For<IAkahuWebhookSubscriptionService>();
+        var mediator = Substitute.For<IMediator>();
         var logger = Substitute.For<IApplicationLogger<ExchangeAkahuCodeQueryHandler>>();
+
+        webhookSubscriptionService.EnsureSubscriptionsAsync(userId, Arg.Any<CancellationToken>())
+            .Returns(new EnsureSubscriptionsResult(Array.Empty<string>(), Array.Empty<string>(), Array.Empty<string>(), new Dictionary<string, string>()));
 
         oauthStateStore.ValidateAndConsumeAsync(userId, "valid-state", Arg.Any<CancellationToken>())
             .Returns(true);
@@ -58,6 +64,8 @@ public class ExchangeAkahuCodeQueryHandlerTests
             bankConnectionRepository,
             encryptionService,
             oauthStateStore,
+            webhookSubscriptionService,
+            mediator,
             logger);
 
         var result = await handler.Handle(
@@ -76,6 +84,8 @@ public class ExchangeAkahuCodeQueryHandlerTests
                 c.ConsentGrantedAt.HasValue &&
                 c.ConsentCorrelationId == "valid-state"),
             Arg.Any<CancellationToken>());
+
+        await webhookSubscriptionService.Received(1).EnsureSubscriptionsAsync(userId, Arg.Any<CancellationToken>());
     }
 
     [Fact]
@@ -87,7 +97,12 @@ public class ExchangeAkahuCodeQueryHandlerTests
         var bankConnectionRepository = Substitute.For<IBankConnectionRepository>();
         var encryptionService = Substitute.For<ISettingsEncryptionService>();
         var oauthStateStore = Substitute.For<IOAuthStateStore>();
+        var webhookSubscriptionService = Substitute.For<IAkahuWebhookSubscriptionService>();
+        var mediator = Substitute.For<IMediator>();
         var logger = Substitute.For<IApplicationLogger<ExchangeAkahuCodeQueryHandler>>();
+
+        webhookSubscriptionService.EnsureSubscriptionsAsync(userId, Arg.Any<CancellationToken>())
+            .Returns(new EnsureSubscriptionsResult(Array.Empty<string>(), Array.Empty<string>(), Array.Empty<string>(), new Dictionary<string, string>()));
 
         oauthStateStore.ValidateAndConsumeAsync(userId, "state-abc-123", Arg.Any<CancellationToken>())
             .Returns(true);
@@ -118,6 +133,8 @@ public class ExchangeAkahuCodeQueryHandlerTests
             bankConnectionRepository,
             encryptionService,
             oauthStateStore,
+            webhookSubscriptionService,
+            mediator,
             logger);
 
         await handler.Handle(
@@ -166,12 +183,18 @@ public class ExchangeAkahuCodeQueryHandlerTests
 
     private static ExchangeAkahuCodeQueryHandler CreateHandler(IOAuthStateStore? oauthStateStore = null)
     {
+        var webhookSubscriptionService = Substitute.For<IAkahuWebhookSubscriptionService>();
+        webhookSubscriptionService.EnsureSubscriptionsAsync(Arg.Any<Guid>(), Arg.Any<CancellationToken>())
+            .Returns(new EnsureSubscriptionsResult(Array.Empty<string>(), Array.Empty<string>(), Array.Empty<string>(), new Dictionary<string, string>()));
+
         return new ExchangeAkahuCodeQueryHandler(
             Substitute.For<IAkahuApiClient>(),
             Substitute.For<IAkahuUserCredentialRepository>(),
             Substitute.For<IBankConnectionRepository>(),
             Substitute.For<ISettingsEncryptionService>(),
             oauthStateStore ?? Substitute.For<IOAuthStateStore>(),
+            webhookSubscriptionService,
+            Substitute.For<IMediator>(),
             Substitute.For<IApplicationLogger<ExchangeAkahuCodeQueryHandler>>());
     }
 }

--- a/tests/MyMascada.Tests.Unit/Queries/ExchangeAkahuCodeQueryHandlerTests.cs
+++ b/tests/MyMascada.Tests.Unit/Queries/ExchangeAkahuCodeQueryHandlerTests.cs
@@ -1,4 +1,4 @@
-using MediatR;
+using MyMascada.Application.BackgroundJobs;
 using MyMascada.Application.Common.Interfaces;
 using MyMascada.Application.Features.BankConnections.Queries;
 using MyMascada.Domain.Entities;
@@ -17,7 +17,7 @@ public class ExchangeAkahuCodeQueryHandlerTests
         var encryptionService = Substitute.For<ISettingsEncryptionService>();
         var oauthStateStore = Substitute.For<IOAuthStateStore>();
         var webhookSubscriptionService = Substitute.For<IAkahuWebhookSubscriptionService>();
-        var mediator = Substitute.For<IMediator>();
+        var migrationJobService = Substitute.For<IAkahuMigrationJobService>();
         var logger = Substitute.For<IApplicationLogger<ExchangeAkahuCodeQueryHandler>>();
 
         webhookSubscriptionService.EnsureSubscriptionsAsync(userId, Arg.Any<CancellationToken>())
@@ -65,7 +65,7 @@ public class ExchangeAkahuCodeQueryHandlerTests
             encryptionService,
             oauthStateStore,
             webhookSubscriptionService,
-            mediator,
+            migrationJobService,
             logger);
 
         var result = await handler.Handle(
@@ -98,7 +98,7 @@ public class ExchangeAkahuCodeQueryHandlerTests
         var encryptionService = Substitute.For<ISettingsEncryptionService>();
         var oauthStateStore = Substitute.For<IOAuthStateStore>();
         var webhookSubscriptionService = Substitute.For<IAkahuWebhookSubscriptionService>();
-        var mediator = Substitute.For<IMediator>();
+        var migrationJobService = Substitute.For<IAkahuMigrationJobService>();
         var logger = Substitute.For<IApplicationLogger<ExchangeAkahuCodeQueryHandler>>();
 
         webhookSubscriptionService.EnsureSubscriptionsAsync(userId, Arg.Any<CancellationToken>())
@@ -134,7 +134,7 @@ public class ExchangeAkahuCodeQueryHandlerTests
             encryptionService,
             oauthStateStore,
             webhookSubscriptionService,
-            mediator,
+            migrationJobService,
             logger);
 
         await handler.Handle(
@@ -147,6 +147,70 @@ public class ExchangeAkahuCodeQueryHandlerTests
                 c.ConsentGrantedAt.HasValue &&
                 c.ConsentCorrelationId == "state-abc-123"),
             Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task Handle_OAuthCallback_EnqueuesMigrationJobOnlyForUnmigratedActiveConnections()
+    {
+        var userId = Guid.NewGuid();
+        var akahuApiClient = Substitute.For<IAkahuApiClient>();
+        var credentialRepository = Substitute.For<IAkahuUserCredentialRepository>();
+        var bankConnectionRepository = Substitute.For<IBankConnectionRepository>();
+        var encryptionService = Substitute.For<ISettingsEncryptionService>();
+        var oauthStateStore = Substitute.For<IOAuthStateStore>();
+        var webhookSubscriptionService = Substitute.For<IAkahuWebhookSubscriptionService>();
+        var migrationJobService = Substitute.For<IAkahuMigrationJobService>();
+        var logger = Substitute.For<IApplicationLogger<ExchangeAkahuCodeQueryHandler>>();
+
+        webhookSubscriptionService.EnsureSubscriptionsAsync(userId, Arg.Any<CancellationToken>())
+            .Returns(new EnsureSubscriptionsResult(Array.Empty<string>(), Array.Empty<string>(), Array.Empty<string>(), new Dictionary<string, string>()));
+
+        oauthStateStore.ValidateAndConsumeAsync(userId, "valid-state", Arg.Any<CancellationToken>()).Returns(true);
+        akahuApiClient.ExchangeCodeForTokenAsync("code-xyz", Arg.Any<CancellationToken>())
+            .Returns(new AkahuTokenResponse { AccessToken = "user_token_oauth", TokenType = "Bearer", Scope = "ENDURING_CONSENT" });
+        akahuApiClient.GetAccountsWithCredentialsAsync(Arg.Any<string>(), Arg.Any<string>(), Arg.Any<CancellationToken>())
+            .Returns(Array.Empty<AkahuAccountInfo>());
+
+        credentialRepository.GetByUserIdAsync(userId, Arg.Any<CancellationToken>())
+            .Returns((AkahuUserCredential?)null);
+
+        var alreadyMigrated = new BankConnection
+        {
+            Id = 1, UserId = userId, ProviderId = "akahu", IsActive = true,
+            ExternalAccountId = "acc_new", LastMigratedAt = DateTime.UtcNow.AddDays(-1)
+        };
+        var inactive = new BankConnection
+        {
+            Id = 2, UserId = userId, ProviderId = "akahu", IsActive = false,
+            ExternalAccountId = "acc_inactive"
+        };
+        var pending = new BankConnection
+        {
+            Id = 3, UserId = userId, ProviderId = "akahu", IsActive = true,
+            ExternalAccountId = "acc_old", LastMigratedAt = null
+        };
+        var notAkahu = new BankConnection
+        {
+            Id = 4, UserId = userId, ProviderId = "emailforward", IsActive = true
+        };
+
+        bankConnectionRepository.GetByUserIdAsync(userId, Arg.Any<CancellationToken>())
+            .Returns(new[] { alreadyMigrated, inactive, pending, notAkahu });
+
+        encryptionService.EncryptSettings(Arg.Any<string>()).Returns("enc");
+
+        var handler = new ExchangeAkahuCodeQueryHandler(
+            akahuApiClient, credentialRepository, bankConnectionRepository,
+            encryptionService, oauthStateStore, webhookSubscriptionService,
+            migrationJobService, logger);
+
+        await handler.Handle(new ExchangeAkahuCodeQuery(userId, "code-xyz", "valid-state", "app_token_123"), CancellationToken.None);
+
+        // Only the active, unmigrated, akahu connection should have been enqueued.
+        migrationJobService.Received(1).EnqueueMigration(userId, 3);
+        migrationJobService.DidNotReceive().EnqueueMigration(userId, 1);
+        migrationJobService.DidNotReceive().EnqueueMigration(userId, 2);
+        migrationJobService.DidNotReceive().EnqueueMigration(userId, 4);
     }
 
     [Fact]
@@ -194,7 +258,7 @@ public class ExchangeAkahuCodeQueryHandlerTests
             Substitute.For<ISettingsEncryptionService>(),
             oauthStateStore ?? Substitute.For<IOAuthStateStore>(),
             webhookSubscriptionService,
-            Substitute.For<IMediator>(),
+            Substitute.For<IAkahuMigrationJobService>(),
             Substitute.For<IApplicationLogger<ExchangeAkahuCodeQueryHandler>>());
     }
 }

--- a/tests/MyMascada.Tests.Unit/Queries/GetAkahuMigrationStatusQueryHandlerTests.cs
+++ b/tests/MyMascada.Tests.Unit/Queries/GetAkahuMigrationStatusQueryHandlerTests.cs
@@ -1,0 +1,304 @@
+using MyMascada.Application.Common.Interfaces;
+using MyMascada.Application.Features.BankConnections.Queries;
+using MyMascada.Domain.Entities;
+using NSubstitute.ExceptionExtensions;
+
+namespace MyMascada.Tests.Unit.Queries;
+
+public class GetAkahuMigrationStatusQueryHandlerTests
+{
+    private const string OldAccountId = "acc_OLD_xxx";
+    private const string NewAccountId = "acc_NEW_yyy";
+
+    [Fact]
+    public async Task Handle_NoAkahuConnections_ReturnsEmptyList()
+    {
+        var ctx = CreateContext();
+        var userId = Guid.NewGuid();
+
+        ctx.BankConnectionRepository.GetByUserIdAsync(userId, Arg.Any<CancellationToken>())
+            .Returns(Array.Empty<BankConnection>());
+
+        var result = await ctx.Handler.Handle(new GetAkahuMigrationStatusQuery(userId), CancellationToken.None);
+
+        result.PendingConnections.Should().BeEmpty();
+        result.Deadline.Year.Should().Be(2026);
+        result.Deadline.Month.Should().Be(5);
+        result.Deadline.Day.Should().Be(24);
+
+        await ctx.AkahuApiClient.DidNotReceive().GetAccountsWithCredentialsAsync(
+            Arg.Any<string>(), Arg.Any<string>(), Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task Handle_PendingMigration_ReturnsConnectionRow()
+    {
+        var ctx = CreateContext();
+        var userId = Guid.NewGuid();
+
+        var connection = new BankConnection
+        {
+            Id = 11,
+            UserId = userId,
+            ProviderId = "akahu",
+            IsActive = true,
+            ExternalAccountId = OldAccountId,
+            ExternalAccountName = "ANZ Everyday",
+            LastSyncAt = new DateTime(2026, 5, 10, 0, 0, 0, DateTimeKind.Utc)
+        };
+
+        ctx.BankConnectionRepository.GetByUserIdAsync(userId, Arg.Any<CancellationToken>())
+            .Returns(new[] { connection });
+
+        ctx.CredentialRepository.GetByUserIdAsync(userId, Arg.Any<CancellationToken>())
+            .Returns(new AkahuUserCredential
+            {
+                Id = 1,
+                UserId = userId,
+                EncryptedAppToken = "enc_app",
+                EncryptedUserToken = "enc_user"
+            });
+
+        ctx.EncryptionService.DecryptSettings<string>("enc_app").Returns("app_token");
+        ctx.EncryptionService.DecryptSettings<string>("enc_user").Returns("user_token");
+
+        ctx.AkahuApiClient.GetAccountsWithCredentialsAsync("app_token", "user_token", Arg.Any<CancellationToken>())
+            .Returns(new[]
+            {
+                new AkahuAccountInfo
+                {
+                    Id = NewAccountId,
+                    Name = "ANZ Everyday (Official)",
+                    Migrated = OldAccountId,
+                    BankName = "ANZ"
+                }
+            });
+
+        var result = await ctx.Handler.Handle(new GetAkahuMigrationStatusQuery(userId), CancellationToken.None);
+
+        result.PendingConnections.Should().HaveCount(1);
+        var pending = result.PendingConnections[0];
+        pending.ConnectionId.Should().Be(11);
+        pending.ExternalAccountId.Should().Be(OldAccountId);
+        pending.BankName.Should().Be("ANZ Everyday");
+        pending.LastSyncedAt.Should().Be(connection.LastSyncAt);
+    }
+
+    [Fact]
+    public async Task Handle_ConnectionAlreadyMigrated_ExcludedFromPending_NoApiProbe()
+    {
+        var ctx = CreateContext();
+        var userId = Guid.NewGuid();
+
+        var connection = new BankConnection
+        {
+            Id = 11,
+            UserId = userId,
+            ProviderId = "akahu",
+            IsActive = true,
+            ExternalAccountId = NewAccountId,
+            ExternalAccountName = "ANZ Everyday",
+            LastMigratedAt = new DateTime(2026, 5, 15, 0, 0, 0, DateTimeKind.Utc)
+        };
+
+        ctx.BankConnectionRepository.GetByUserIdAsync(userId, Arg.Any<CancellationToken>())
+            .Returns(new[] { connection });
+
+        var result = await ctx.Handler.Handle(new GetAkahuMigrationStatusQuery(userId), CancellationToken.None);
+
+        result.PendingConnections.Should().BeEmpty();
+
+        // Already-migrated connections are excluded up front, so the Akahu API probe is skipped.
+        await ctx.CredentialRepository.DidNotReceive().GetByUserIdAsync(
+            Arg.Any<Guid>(), Arg.Any<CancellationToken>());
+        await ctx.AkahuApiClient.DidNotReceive().GetAccountsWithCredentialsAsync(
+            Arg.Any<string>(), Arg.Any<string>(), Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task Handle_OneMigratedOneUnmigrated_OnlyUnmigratedConsidered()
+    {
+        var ctx = CreateContext();
+        var userId = Guid.NewGuid();
+
+        var migrated = new BankConnection
+        {
+            Id = 1,
+            UserId = userId,
+            ProviderId = "akahu",
+            IsActive = true,
+            ExternalAccountId = "acc_already_migrated",
+            LastMigratedAt = new DateTime(2026, 5, 15, 0, 0, 0, DateTimeKind.Utc)
+        };
+        var pending = new BankConnection
+        {
+            Id = 2,
+            UserId = userId,
+            ProviderId = "akahu",
+            IsActive = true,
+            ExternalAccountId = OldAccountId,
+            ExternalAccountName = "ANZ Everyday",
+            LastMigratedAt = null
+        };
+
+        ctx.BankConnectionRepository.GetByUserIdAsync(userId, Arg.Any<CancellationToken>())
+            .Returns(new[] { migrated, pending });
+
+        ctx.CredentialRepository.GetByUserIdAsync(userId, Arg.Any<CancellationToken>())
+            .Returns(new AkahuUserCredential
+            {
+                Id = 1,
+                UserId = userId,
+                EncryptedAppToken = "enc_app",
+                EncryptedUserToken = "enc_user"
+            });
+
+        ctx.EncryptionService.DecryptSettings<string>("enc_app").Returns("app_token");
+        ctx.EncryptionService.DecryptSettings<string>("enc_user").Returns("user_token");
+
+        ctx.AkahuApiClient.GetAccountsWithCredentialsAsync("app_token", "user_token", Arg.Any<CancellationToken>())
+            .Returns(new[]
+            {
+                new AkahuAccountInfo { Id = NewAccountId, Migrated = OldAccountId }
+            });
+
+        var result = await ctx.Handler.Handle(new GetAkahuMigrationStatusQuery(userId), CancellationToken.None);
+
+        result.PendingConnections.Should().HaveCount(1);
+        result.PendingConnections[0].ConnectionId.Should().Be(2);
+    }
+
+    [Fact]
+    public async Task Handle_NoPendingMigration_ReturnsEmptyList()
+    {
+        var ctx = CreateContext();
+        var userId = Guid.NewGuid();
+
+        var connection = new BankConnection
+        {
+            Id = 7,
+            UserId = userId,
+            ProviderId = "akahu",
+            IsActive = true,
+            ExternalAccountId = OldAccountId
+        };
+
+        ctx.BankConnectionRepository.GetByUserIdAsync(userId, Arg.Any<CancellationToken>())
+            .Returns(new[] { connection });
+
+        ctx.CredentialRepository.GetByUserIdAsync(userId, Arg.Any<CancellationToken>())
+            .Returns(new AkahuUserCredential
+            {
+                Id = 1,
+                UserId = userId,
+                EncryptedAppToken = "enc_app",
+                EncryptedUserToken = "enc_user"
+            });
+
+        ctx.EncryptionService.DecryptSettings<string>("enc_app").Returns("app_token");
+        ctx.EncryptionService.DecryptSettings<string>("enc_user").Returns("user_token");
+
+        // None of the returned accounts carry a _migrated pointing at the user's classic account
+        ctx.AkahuApiClient.GetAccountsWithCredentialsAsync("app_token", "user_token", Arg.Any<CancellationToken>())
+            .Returns(new[]
+            {
+                new AkahuAccountInfo { Id = "acc_other", Migrated = null }
+            });
+
+        var result = await ctx.Handler.Handle(new GetAkahuMigrationStatusQuery(userId), CancellationToken.None);
+
+        result.PendingConnections.Should().BeEmpty();
+    }
+
+    [Fact]
+    public async Task Handle_AkahuApiUnauthorized_ReturnsEmptyListGracefully()
+    {
+        var ctx = CreateContext();
+        var userId = Guid.NewGuid();
+
+        var connection = new BankConnection
+        {
+            Id = 7,
+            UserId = userId,
+            ProviderId = "akahu",
+            IsActive = true,
+            ExternalAccountId = OldAccountId
+        };
+
+        ctx.BankConnectionRepository.GetByUserIdAsync(userId, Arg.Any<CancellationToken>())
+            .Returns(new[] { connection });
+
+        ctx.CredentialRepository.GetByUserIdAsync(userId, Arg.Any<CancellationToken>())
+            .Returns(new AkahuUserCredential
+            {
+                Id = 1,
+                UserId = userId,
+                EncryptedAppToken = "enc_app",
+                EncryptedUserToken = "enc_user"
+            });
+
+        ctx.EncryptionService.DecryptSettings<string>("enc_app").Returns("app_token");
+        ctx.EncryptionService.DecryptSettings<string>("enc_user").Returns("user_token");
+
+        ctx.AkahuApiClient.GetAccountsWithCredentialsAsync("app_token", "user_token", Arg.Any<CancellationToken>())
+            .ThrowsAsync(new UnauthorizedAccessException("token expired"));
+
+        var result = await ctx.Handler.Handle(new GetAkahuMigrationStatusQuery(userId), CancellationToken.None);
+
+        result.PendingConnections.Should().BeEmpty();
+    }
+
+    [Fact]
+    public async Task Handle_CredentialMissing_ReturnsEmptyList()
+    {
+        var ctx = CreateContext();
+        var userId = Guid.NewGuid();
+
+        ctx.BankConnectionRepository.GetByUserIdAsync(userId, Arg.Any<CancellationToken>())
+            .Returns(new[]
+            {
+                new BankConnection
+                {
+                    Id = 1,
+                    UserId = userId,
+                    ProviderId = "akahu",
+                    IsActive = true,
+                    ExternalAccountId = OldAccountId
+                }
+            });
+
+        ctx.CredentialRepository.GetByUserIdAsync(userId, Arg.Any<CancellationToken>())
+            .Returns((AkahuUserCredential?)null);
+
+        var result = await ctx.Handler.Handle(new GetAkahuMigrationStatusQuery(userId), CancellationToken.None);
+
+        result.PendingConnections.Should().BeEmpty();
+        await ctx.AkahuApiClient.DidNotReceive().GetAccountsWithCredentialsAsync(
+            Arg.Any<string>(), Arg.Any<string>(), Arg.Any<CancellationToken>());
+    }
+
+    private static HandlerContext CreateContext()
+    {
+        var bankConnectionRepository = Substitute.For<IBankConnectionRepository>();
+        var credentialRepository = Substitute.For<IAkahuUserCredentialRepository>();
+        var akahuApiClient = Substitute.For<IAkahuApiClient>();
+        var encryptionService = Substitute.For<ISettingsEncryptionService>();
+        var logger = Substitute.For<IApplicationLogger<GetAkahuMigrationStatusQueryHandler>>();
+
+        var handler = new GetAkahuMigrationStatusQueryHandler(
+            bankConnectionRepository,
+            credentialRepository,
+            akahuApiClient,
+            encryptionService,
+            logger);
+
+        return new HandlerContext(handler, bankConnectionRepository, credentialRepository, akahuApiClient, encryptionService);
+    }
+
+    private sealed record HandlerContext(
+        GetAkahuMigrationStatusQueryHandler Handler,
+        IBankConnectionRepository BankConnectionRepository,
+        IAkahuUserCredentialRepository CredentialRepository,
+        IAkahuApiClient AkahuApiClient,
+        ISettingsEncryptionService EncryptionService);
+}

--- a/tests/MyMascada.Tests.Unit/Queries/GetAkahuMigrationStatusQueryHandlerTests.cs
+++ b/tests/MyMascada.Tests.Unit/Queries/GetAkahuMigrationStatusQueryHandlerTests.cs
@@ -249,6 +249,54 @@ public class GetAkahuMigrationStatusQueryHandlerTests
     }
 
     [Fact]
+    public async Task Handle_AwaitingReauthInactiveConnection_StillSurfacedInPendingList()
+    {
+        // Regression: a connection that the migrate command disabled with
+        // LastSyncError = "Awaiting re-authorisation" must keep showing up in the
+        // banner. Filtering on IsActive == true alone would silently hide the row
+        // exactly when the user needs to act.
+        var ctx = CreateContext();
+        var userId = Guid.NewGuid();
+
+        var connection = new BankConnection
+        {
+            Id = 22,
+            UserId = userId,
+            ProviderId = "akahu",
+            IsActive = false,
+            LastSyncError = "Awaiting re-authorisation",
+            ExternalAccountId = OldAccountId,
+            ExternalAccountName = "ANZ Everyday"
+        };
+
+        ctx.BankConnectionRepository.GetByUserIdAsync(userId, Arg.Any<CancellationToken>())
+            .Returns(new[] { connection });
+
+        ctx.CredentialRepository.GetByUserIdAsync(userId, Arg.Any<CancellationToken>())
+            .Returns(new AkahuUserCredential
+            {
+                Id = 1,
+                UserId = userId,
+                EncryptedAppToken = "enc_app",
+                EncryptedUserToken = "enc_user"
+            });
+
+        ctx.EncryptionService.DecryptSettings<string>("enc_app").Returns("app_token");
+        ctx.EncryptionService.DecryptSettings<string>("enc_user").Returns("user_token");
+
+        ctx.AkahuApiClient.GetAccountsWithCredentialsAsync("app_token", "user_token", Arg.Any<CancellationToken>())
+            .Returns(new[]
+            {
+                new AkahuAccountInfo { Id = NewAccountId, Migrated = OldAccountId, Name = "ANZ Everyday (Official)" }
+            });
+
+        var result = await ctx.Handler.Handle(new GetAkahuMigrationStatusQuery(userId), CancellationToken.None);
+
+        result.PendingConnections.Should().HaveCount(1);
+        result.PendingConnections[0].ConnectionId.Should().Be(22);
+    }
+
+    [Fact]
     public async Task Handle_CredentialMissing_ReturnsEmptyList()
     {
         var ctx = CreateContext();

--- a/tests/MyMascada.Tests.Unit/Services/AkahuApiClientTests.cs
+++ b/tests/MyMascada.Tests.Unit/Services/AkahuApiClientTests.cs
@@ -280,7 +280,28 @@ public class AkahuApiClientTests
             await client.SubscribeToWebhookAsync(TestAppToken, "user_token", "TOKEN", "user_guid");
 
         var ex = await act.Should().ThrowAsync<AkahuApiException>();
-        ex.Which.Message.Should().Contain("did not include a webhook ID");
+        ex.Which.Message.Should().Contain("unexpected shape");
+    }
+
+    [Fact]
+    public async Task SubscribeToWebhook_ResponseWithoutId_ExceptionMessageDoesNotIncludeBody()
+    {
+        // The Akahu response body echoes the request state (= user GUID). It must not bleed
+        // into the exception message; the structured logger receives it instead.
+        var stateValue = "user_guid_12345_secret";
+        var responseJson = "{\"success\":true,\"item\":{\"webhook_type\":\"TOKEN\",\"state\":\"" + stateValue + "\"}}";
+        var handler = new DelegatingHandlerStub((_, _) => Task.FromResult(new HttpResponseMessage(HttpStatusCode.OK)
+        {
+            Content = new StringContent(responseJson, Encoding.UTF8, "application/json")
+        }));
+        var client = CreateClient(handler);
+
+        Func<Task> act = async () =>
+            await client.SubscribeToWebhookAsync(TestAppToken, "user_token", "TOKEN", stateValue);
+
+        var ex = await act.Should().ThrowAsync<AkahuApiException>();
+        ex.Which.Message.Should().NotContain(stateValue);
+        ex.Which.Message.Should().NotContain("success");
     }
 
     private static AkahuApiClient CreateClient(DelegatingHandlerStub handler)

--- a/tests/MyMascada.Tests.Unit/Services/AkahuApiClientTests.cs
+++ b/tests/MyMascada.Tests.Unit/Services/AkahuApiClientTests.cs
@@ -210,6 +210,79 @@ public class AkahuApiClientTests
                  value.Contains(sensitiveTokenFragment, StringComparison.Ordinal)));
     }
 
+    [Fact]
+    public async Task SubscribeToWebhook_ItemIdResponseShape_ReturnsParsedSubscription()
+    {
+        // Empirically confirmed shape returned by Akahu's POST /webhooks (2026-05-17):
+        // { "success": true, "item_id": "hook_xxx" }
+        var responseJson = "{\"success\":true,\"item_id\":\"hook_realworld_1\"}";
+        var handler = new DelegatingHandlerStub((_, _) => Task.FromResult(new HttpResponseMessage(HttpStatusCode.OK)
+        {
+            Content = new StringContent(responseJson, Encoding.UTF8, "application/json")
+        }));
+        var client = CreateClient(handler);
+
+        var result = await client.SubscribeToWebhookAsync(TestAppToken, "user_token", "TOKEN", "user_guid");
+
+        result.Id.Should().Be("hook_realworld_1");
+        result.WebhookType.Should().Be("TOKEN");
+        result.State.Should().Be("user_guid");
+    }
+
+    [Fact]
+    public async Task SubscribeToWebhook_EnvelopeResponseShape_ReturnsParsedSubscription()
+    {
+        // Akahu's documented response: { "success": true, "item": { "_id": ..., "webhook_type": ..., "state": ... } }
+        var responseJson = "{\"success\":true,\"item\":{\"_id\":\"whk_envelope_1\",\"webhook_type\":\"ACCOUNT\",\"state\":\"user_guid\"}}";
+        var handler = new DelegatingHandlerStub((_, _) => Task.FromResult(new HttpResponseMessage(HttpStatusCode.OK)
+        {
+            Content = new StringContent(responseJson, Encoding.UTF8, "application/json")
+        }));
+        var client = CreateClient(handler);
+
+        var result = await client.SubscribeToWebhookAsync(TestAppToken, "user_token", "ACCOUNT", "user_guid");
+
+        result.Id.Should().Be("whk_envelope_1");
+        result.WebhookType.Should().Be("ACCOUNT");
+        result.State.Should().Be("user_guid");
+    }
+
+    [Fact]
+    public async Task SubscribeToWebhook_BareObjectResponseShape_ReturnsParsedSubscription()
+    {
+        // Regression: previously a bare-object response caused ObjectDisposedException because the
+        // code re-read response.Content after the envelope attempt had consumed the stream.
+        var responseJson = "{\"_id\":\"whk_bare_2\",\"webhook_type\":\"TRANSACTION\",\"state\":\"user_guid\"}";
+        var handler = new DelegatingHandlerStub((_, _) => Task.FromResult(new HttpResponseMessage(HttpStatusCode.OK)
+        {
+            Content = new StringContent(responseJson, Encoding.UTF8, "application/json")
+        }));
+        var client = CreateClient(handler);
+
+        var result = await client.SubscribeToWebhookAsync(TestAppToken, "user_token", "TRANSACTION", "user_guid");
+
+        result.Id.Should().Be("whk_bare_2");
+        result.WebhookType.Should().Be("TRANSACTION");
+        result.State.Should().Be("user_guid");
+    }
+
+    [Fact]
+    public async Task SubscribeToWebhook_ResponseWithoutId_ThrowsAkahuApiException()
+    {
+        var responseJson = "{\"success\":true,\"item\":{\"webhook_type\":\"TOKEN\"}}";
+        var handler = new DelegatingHandlerStub((_, _) => Task.FromResult(new HttpResponseMessage(HttpStatusCode.OK)
+        {
+            Content = new StringContent(responseJson, Encoding.UTF8, "application/json")
+        }));
+        var client = CreateClient(handler);
+
+        Func<Task> act = async () =>
+            await client.SubscribeToWebhookAsync(TestAppToken, "user_token", "TOKEN", "user_guid");
+
+        var ex = await act.Should().ThrowAsync<AkahuApiException>();
+        ex.Which.Message.Should().Contain("did not include a webhook ID");
+    }
+
     private static AkahuApiClient CreateClient(DelegatingHandlerStub handler)
     {
         return CreateClientWithLogger(handler).Client;

--- a/tests/MyMascada.Tests.Unit/Services/AkahuWebhookSignatureServiceTests.cs
+++ b/tests/MyMascada.Tests.Unit/Services/AkahuWebhookSignatureServiceTests.cs
@@ -1,0 +1,87 @@
+using System.Net;
+using System.Security.Cryptography;
+using System.Text;
+using System.Text.Json;
+using Microsoft.Extensions.Caching.Memory;
+using Microsoft.Extensions.Options;
+using MyMascada.Application.Common.Interfaces;
+using MyMascada.Infrastructure.Services.BankIntegration.Providers;
+
+namespace MyMascada.Tests.Unit.Services;
+
+public class AkahuWebhookSignatureServiceTests
+{
+    private const string KeyId = "key_test123";
+    private const string Body = """{"webhook_type":"ACCOUNT","webhook_code":"MIGRATE"}""";
+
+    [Fact]
+    public async Task VerifySignatureAsync_WhenKeysEndpointReturnsBareStringItem_VerifiesValidSignature()
+    {
+        using var rsa = RSA.Create(2048);
+        var signature = Convert.ToBase64String(rsa.SignData(
+            Encoding.UTF8.GetBytes(Body), HashAlgorithmName.SHA256, RSASignaturePadding.Pkcs1));
+
+        // Akahu returns the PEM public key as a bare string in "item".
+        var keysResponse = JsonSerializer.Serialize(new { success = true, item = rsa.ExportRSAPublicKeyPem() });
+        var service = CreateService(keysResponse);
+
+        var result = await service.VerifySignatureAsync(Body, signature, KeyId);
+
+        result.Should().BeTrue();
+    }
+
+    [Fact]
+    public async Task VerifySignatureAsync_WhenItemIsNotAString_ReturnsFalseWithoutThrowing()
+    {
+        using var rsa = RSA.Create(2048);
+        var signature = Convert.ToBase64String(rsa.SignData(
+            Encoding.UTF8.GetBytes(Body), HashAlgorithmName.SHA256, RSASignaturePadding.Pkcs1));
+
+        // Unexpected shape — "item" wrapped in an object. Must fail closed, not throw.
+        var keysResponse = JsonSerializer.Serialize(new { success = true, item = new { key = rsa.ExportRSAPublicKeyPem() } });
+        var service = CreateService(keysResponse);
+
+        var result = await service.VerifySignatureAsync(Body, signature, KeyId);
+
+        result.Should().BeFalse();
+    }
+
+    private static AkahuWebhookSignatureService CreateService(string keysResponseJson)
+    {
+        var handler = new DelegatingHandlerStub((request, _) =>
+        {
+            request.RequestUri!.AbsolutePath.Should().Contain("/keys/");
+            return Task.FromResult(new HttpResponseMessage(HttpStatusCode.OK)
+            {
+                Content = new StringContent(keysResponseJson, Encoding.UTF8, "application/json")
+            });
+        });
+
+        var options = Options.Create(new AkahuOptions
+        {
+            ApiBaseUrl = "https://api.akahu.io/v1/",
+            WebhookSigningKeysCacheMinutes = 1440
+        });
+
+        return new AkahuWebhookSignatureService(
+            new HttpClient(handler),
+            new MemoryCache(new MemoryCacheOptions()),
+            options,
+            Substitute.For<IApplicationLogger<AkahuWebhookSignatureService>>());
+    }
+
+    private class DelegatingHandlerStub : DelegatingHandler
+    {
+        private readonly Func<HttpRequestMessage, CancellationToken, Task<HttpResponseMessage>> _handler;
+
+        public DelegatingHandlerStub(Func<HttpRequestMessage, CancellationToken, Task<HttpResponseMessage>> handler)
+        {
+            _handler = handler;
+        }
+
+        protected override Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken cancellationToken)
+        {
+            return _handler(request, cancellationToken);
+        }
+    }
+}

--- a/tests/MyMascada.Tests.Unit/Services/AkahuWebhookSubscriptionServiceTests.cs
+++ b/tests/MyMascada.Tests.Unit/Services/AkahuWebhookSubscriptionServiceTests.cs
@@ -235,6 +235,41 @@ public class AkahuWebhookSubscriptionServiceTests
     }
 
     [Fact]
+    public async Task EnsureSubscriptionsAsync_ListWebhooksThrows_AbortsWithoutDeletingLocalRows()
+    {
+        // Regression: treating an unreachable Akahu as "remote has no subscriptions" used
+        // to tear down perfectly-good local rows. We must abort the reconcile and let the
+        // next cycle pick it up instead.
+        var ctx = CreateContext();
+        var userId = Guid.NewGuid();
+        SetupHappyCredentials(ctx, userId);
+
+        var localToken = new AkahuWebhookSubscription
+        {
+            Id = 7,
+            UserId = userId,
+            AkahuUserCredentialId = 1,
+            WebhookId = "whk_existing_token",
+            WebhookType = AkahuWebhookTypes.Token
+        };
+        ctx.SubscriptionRepository.GetByUserIdAsync(userId, Arg.Any<CancellationToken>())
+            .Returns(new[] { localToken });
+
+        ctx.AkahuApiClient.ListWebhooksAsync(AppToken, UserToken, Arg.Any<CancellationToken>())
+            .ThrowsAsync(new HttpRequestException("Akahu unreachable"));
+
+        var result = await ctx.Service.EnsureSubscriptionsAsync(userId);
+
+        // Every required webhook type is reported as failed so callers can surface the issue.
+        result.FailedTypes.Should().NotBeEmpty();
+        // No destructive operations should have run.
+        await ctx.SubscriptionRepository.DidNotReceive().DeleteByIdAsync(Arg.Any<int>(), Arg.Any<CancellationToken>());
+        await ctx.SubscriptionRepository.DidNotReceive().DeleteByUserIdAsync(Arg.Any<Guid>(), Arg.Any<CancellationToken>());
+        await ctx.AkahuApiClient.DidNotReceive().SubscribeToWebhookAsync(
+            Arg.Any<string>(), Arg.Any<string>(), Arg.Any<string>(), Arg.Any<string>(), Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
     public async Task EnsureSubscriptionsAsync_LocalRowMissingAtAkahu_ReSubscribes()
     {
         var ctx = CreateContext();

--- a/tests/MyMascada.Tests.Unit/Services/AkahuWebhookSubscriptionServiceTests.cs
+++ b/tests/MyMascada.Tests.Unit/Services/AkahuWebhookSubscriptionServiceTests.cs
@@ -1,0 +1,312 @@
+using MyMascada.Application.Common.Interfaces;
+using MyMascada.Application.Features.BankConnections.DTOs;
+using MyMascada.Domain.Entities;
+using MyMascada.Infrastructure.Services.BankIntegration.Providers;
+using NSubstitute.ExceptionExtensions;
+
+namespace MyMascada.Tests.Unit.Services;
+
+public class AkahuWebhookSubscriptionServiceTests
+{
+    private const string AppToken = "app_token";
+    private const string UserToken = "user_token";
+
+    [Fact]
+    public async Task EnsureSubscriptionsAsync_NoExistingSubscriptions_SubscribesAllThreeTypes()
+    {
+        var ctx = CreateContext();
+        var userId = Guid.NewGuid();
+        SetupHappyCredentials(ctx, userId);
+
+        ctx.SubscriptionRepository.GetByUserIdAsync(userId, Arg.Any<CancellationToken>())
+            .Returns(Array.Empty<AkahuWebhookSubscription>());
+
+        ctx.AkahuApiClient.ListWebhooksAsync(AppToken, UserToken, Arg.Any<CancellationToken>())
+            .Returns(Array.Empty<AkahuWebhookSubscriptionInfo>());
+
+        SetupSubscribeReturns(ctx);
+
+        var result = await ctx.Service.EnsureSubscriptionsAsync(userId);
+
+        result.SubscribedTypes.Should().BeEquivalentTo(new[]
+        {
+            AkahuWebhookTypes.Token,
+            AkahuWebhookTypes.Account,
+            AkahuWebhookTypes.Transaction
+        });
+        result.AdoptedTypes.Should().BeEmpty();
+        result.AlreadyHealthyTypes.Should().BeEmpty();
+        result.FailedTypes.Should().BeEmpty();
+
+        await ctx.SubscriptionRepository.Received(3).AddAsync(
+            Arg.Any<AkahuWebhookSubscription>(), Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task EnsureSubscriptionsAsync_OneTypeAlreadySubscribed_SubscribesOnlyMissing()
+    {
+        var ctx = CreateContext();
+        var userId = Guid.NewGuid();
+        SetupHappyCredentials(ctx, userId);
+
+        var existing = new AkahuWebhookSubscription
+        {
+            Id = 10,
+            UserId = userId,
+            AkahuUserCredentialId = 1,
+            WebhookId = "whk_token",
+            WebhookType = AkahuWebhookTypes.Token,
+            State = userId.ToString("N")
+        };
+
+        ctx.SubscriptionRepository.GetByUserIdAsync(userId, Arg.Any<CancellationToken>())
+            .Returns(new[] { existing });
+
+        ctx.AkahuApiClient.ListWebhooksAsync(AppToken, UserToken, Arg.Any<CancellationToken>())
+            .Returns(new[]
+            {
+                new AkahuWebhookSubscriptionInfo { Id = "whk_token", WebhookType = AkahuWebhookTypes.Token, State = userId.ToString("N") }
+            });
+
+        SetupSubscribeReturns(ctx);
+
+        var result = await ctx.Service.EnsureSubscriptionsAsync(userId);
+
+        result.AlreadyHealthyTypes.Should().Contain(AkahuWebhookTypes.Token);
+        result.SubscribedTypes.Should().BeEquivalentTo(new[] { AkahuWebhookTypes.Account, AkahuWebhookTypes.Transaction });
+        result.FailedTypes.Should().BeEmpty();
+
+        await ctx.AkahuApiClient.DidNotReceive().SubscribeToWebhookAsync(
+            AppToken, UserToken, AkahuWebhookTypes.Token, Arg.Any<string>(), Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task EnsureSubscriptionsAsync_AllPresentInAkahuButNotLocal_AdoptsRowsWithoutPosting()
+    {
+        var ctx = CreateContext();
+        var userId = Guid.NewGuid();
+        SetupHappyCredentials(ctx, userId);
+
+        ctx.SubscriptionRepository.GetByUserIdAsync(userId, Arg.Any<CancellationToken>())
+            .Returns(Array.Empty<AkahuWebhookSubscription>());
+
+        ctx.AkahuApiClient.ListWebhooksAsync(AppToken, UserToken, Arg.Any<CancellationToken>())
+            .Returns(new[]
+            {
+                new AkahuWebhookSubscriptionInfo { Id = "whk_token", WebhookType = AkahuWebhookTypes.Token, State = userId.ToString("N") },
+                new AkahuWebhookSubscriptionInfo { Id = "whk_acc", WebhookType = AkahuWebhookTypes.Account, State = userId.ToString("N") },
+                new AkahuWebhookSubscriptionInfo { Id = "whk_tx", WebhookType = AkahuWebhookTypes.Transaction, State = userId.ToString("N") }
+            });
+
+        var result = await ctx.Service.EnsureSubscriptionsAsync(userId);
+
+        result.AdoptedTypes.Should().BeEquivalentTo(new[]
+        {
+            AkahuWebhookTypes.Token,
+            AkahuWebhookTypes.Account,
+            AkahuWebhookTypes.Transaction
+        });
+        result.SubscribedTypes.Should().BeEmpty();
+
+        await ctx.AkahuApiClient.DidNotReceive().SubscribeToWebhookAsync(
+            Arg.Any<string>(), Arg.Any<string>(), Arg.Any<string>(), Arg.Any<string>(), Arg.Any<CancellationToken>());
+
+        await ctx.SubscriptionRepository.Received(3).AddAsync(Arg.Any<AkahuWebhookSubscription>(), Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task EnsureSubscriptionsAsync_TransactionSubscribeFails_OtherTwoStillPersisted()
+    {
+        var ctx = CreateContext();
+        var userId = Guid.NewGuid();
+        SetupHappyCredentials(ctx, userId);
+
+        ctx.SubscriptionRepository.GetByUserIdAsync(userId, Arg.Any<CancellationToken>())
+            .Returns(Array.Empty<AkahuWebhookSubscription>());
+
+        ctx.AkahuApiClient.ListWebhooksAsync(AppToken, UserToken, Arg.Any<CancellationToken>())
+            .Returns(Array.Empty<AkahuWebhookSubscriptionInfo>());
+
+        ctx.AkahuApiClient.SubscribeToWebhookAsync(AppToken, UserToken, AkahuWebhookTypes.Token, Arg.Any<string>(), Arg.Any<CancellationToken>())
+            .Returns(new AkahuWebhookSubscriptionInfo { Id = "whk_token", WebhookType = AkahuWebhookTypes.Token });
+
+        ctx.AkahuApiClient.SubscribeToWebhookAsync(AppToken, UserToken, AkahuWebhookTypes.Account, Arg.Any<string>(), Arg.Any<CancellationToken>())
+            .Returns(new AkahuWebhookSubscriptionInfo { Id = "whk_acc", WebhookType = AkahuWebhookTypes.Account });
+
+        ctx.AkahuApiClient.SubscribeToWebhookAsync(AppToken, UserToken, AkahuWebhookTypes.Transaction, Arg.Any<string>(), Arg.Any<CancellationToken>())
+            .ThrowsAsync(new HttpRequestException("Service Unavailable"));
+
+        var result = await ctx.Service.EnsureSubscriptionsAsync(userId);
+
+        result.SubscribedTypes.Should().BeEquivalentTo(new[] { AkahuWebhookTypes.Token, AkahuWebhookTypes.Account });
+        result.FailedTypes.Should().ContainKey(AkahuWebhookTypes.Transaction);
+
+        await ctx.SubscriptionRepository.Received(2).AddAsync(Arg.Any<AkahuWebhookSubscription>(), Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task EnsureSubscriptionsAsync_CredentialNotFound_NoOp()
+    {
+        var ctx = CreateContext();
+        var userId = Guid.NewGuid();
+
+        ctx.CredentialRepository.GetByUserIdAsync(userId, Arg.Any<CancellationToken>())
+            .Returns((AkahuUserCredential?)null);
+
+        var result = await ctx.Service.EnsureSubscriptionsAsync(userId);
+
+        result.SubscribedTypes.Should().BeEmpty();
+        result.AdoptedTypes.Should().BeEmpty();
+        result.AlreadyHealthyTypes.Should().BeEmpty();
+        result.FailedTypes.Should().BeEmpty();
+
+        await ctx.AkahuApiClient.DidNotReceive().SubscribeToWebhookAsync(
+            Arg.Any<string>(), Arg.Any<string>(), Arg.Any<string>(), Arg.Any<string>(), Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task EnsureSubscriptionsAsync_RegistersStateAsUserGuid()
+    {
+        var ctx = CreateContext();
+        var userId = Guid.NewGuid();
+        SetupHappyCredentials(ctx, userId);
+
+        ctx.SubscriptionRepository.GetByUserIdAsync(userId, Arg.Any<CancellationToken>())
+            .Returns(Array.Empty<AkahuWebhookSubscription>());
+
+        ctx.AkahuApiClient.ListWebhooksAsync(AppToken, UserToken, Arg.Any<CancellationToken>())
+            .Returns(Array.Empty<AkahuWebhookSubscriptionInfo>());
+
+        SetupSubscribeReturns(ctx);
+
+        await ctx.Service.EnsureSubscriptionsAsync(userId);
+
+        await ctx.AkahuApiClient.Received(1).SubscribeToWebhookAsync(
+            AppToken, UserToken, AkahuWebhookTypes.Token, userId.ToString("N"), Arg.Any<CancellationToken>());
+        await ctx.AkahuApiClient.Received(1).SubscribeToWebhookAsync(
+            AppToken, UserToken, AkahuWebhookTypes.Account, userId.ToString("N"), Arg.Any<CancellationToken>());
+        await ctx.AkahuApiClient.Received(1).SubscribeToWebhookAsync(
+            AppToken, UserToken, AkahuWebhookTypes.Transaction, userId.ToString("N"), Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task TearDownSubscriptionsAsync_CallsDeleteForEachRow_ThenDeletesLocalRows()
+    {
+        var ctx = CreateContext();
+        var userId = Guid.NewGuid();
+        SetupHappyCredentials(ctx, userId);
+
+        ctx.SubscriptionRepository.GetByUserIdAsync(userId, Arg.Any<CancellationToken>())
+            .Returns(new[]
+            {
+                new AkahuWebhookSubscription { Id = 1, UserId = userId, AkahuUserCredentialId = 1, WebhookId = "whk_a", WebhookType = AkahuWebhookTypes.Token },
+                new AkahuWebhookSubscription { Id = 2, UserId = userId, AkahuUserCredentialId = 1, WebhookId = "whk_b", WebhookType = AkahuWebhookTypes.Account },
+                new AkahuWebhookSubscription { Id = 3, UserId = userId, AkahuUserCredentialId = 1, WebhookId = "whk_c", WebhookType = AkahuWebhookTypes.Transaction }
+            });
+
+        await ctx.Service.TearDownSubscriptionsAsync(userId);
+
+        await ctx.AkahuApiClient.Received(1).UnsubscribeFromWebhookAsync(AppToken, UserToken, "whk_a", Arg.Any<CancellationToken>());
+        await ctx.AkahuApiClient.Received(1).UnsubscribeFromWebhookAsync(AppToken, UserToken, "whk_b", Arg.Any<CancellationToken>());
+        await ctx.AkahuApiClient.Received(1).UnsubscribeFromWebhookAsync(AppToken, UserToken, "whk_c", Arg.Any<CancellationToken>());
+
+        await ctx.SubscriptionRepository.Received(1).DeleteByUserIdAsync(userId, Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task TearDownSubscriptionsAsync_AkahuUnauthorized_DeletesLocalRowsAnyway()
+    {
+        var ctx = CreateContext();
+        var userId = Guid.NewGuid();
+        SetupHappyCredentials(ctx, userId);
+
+        ctx.SubscriptionRepository.GetByUserIdAsync(userId, Arg.Any<CancellationToken>())
+            .Returns(new[]
+            {
+                new AkahuWebhookSubscription { Id = 1, UserId = userId, AkahuUserCredentialId = 1, WebhookId = "whk_a", WebhookType = AkahuWebhookTypes.Token }
+            });
+
+        ctx.AkahuApiClient.UnsubscribeFromWebhookAsync(AppToken, UserToken, "whk_a", Arg.Any<CancellationToken>())
+            .ThrowsAsync(new UnauthorizedAccessException("expired"));
+
+        await ctx.Service.TearDownSubscriptionsAsync(userId);
+
+        await ctx.SubscriptionRepository.Received(1).DeleteByUserIdAsync(userId, Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task EnsureSubscriptionsAsync_LocalRowMissingAtAkahu_ReSubscribes()
+    {
+        var ctx = CreateContext();
+        var userId = Guid.NewGuid();
+        SetupHappyCredentials(ctx, userId);
+
+        ctx.SubscriptionRepository.GetByUserIdAsync(userId, Arg.Any<CancellationToken>())
+            .Returns(new[]
+            {
+                new AkahuWebhookSubscription { Id = 5, UserId = userId, AkahuUserCredentialId = 1, WebhookId = "whk_stale_token", WebhookType = AkahuWebhookTypes.Token }
+            });
+
+        ctx.AkahuApiClient.ListWebhooksAsync(AppToken, UserToken, Arg.Any<CancellationToken>())
+            .Returns(Array.Empty<AkahuWebhookSubscriptionInfo>());
+
+        SetupSubscribeReturns(ctx);
+
+        var result = await ctx.Service.EnsureSubscriptionsAsync(userId);
+
+        result.SubscribedTypes.Should().Contain(AkahuWebhookTypes.Token);
+        await ctx.SubscriptionRepository.Received(1).DeleteByIdAsync(5, Arg.Any<CancellationToken>());
+        await ctx.AkahuApiClient.Received(1).SubscribeToWebhookAsync(
+            AppToken, UserToken, AkahuWebhookTypes.Token, userId.ToString("N"), Arg.Any<CancellationToken>());
+    }
+
+    private static void SetupHappyCredentials(Context ctx, Guid userId)
+    {
+        ctx.CredentialRepository.GetByUserIdAsync(userId, Arg.Any<CancellationToken>())
+            .Returns(new AkahuUserCredential
+            {
+                Id = 1,
+                UserId = userId,
+                EncryptedAppToken = "enc_app",
+                EncryptedUserToken = "enc_user"
+            });
+
+        ctx.EncryptionService.DecryptSettings<string>("enc_app").Returns(AppToken);
+        ctx.EncryptionService.DecryptSettings<string>("enc_user").Returns(UserToken);
+    }
+
+    private static void SetupSubscribeReturns(Context ctx)
+    {
+        ctx.AkahuApiClient.SubscribeToWebhookAsync(AppToken, UserToken, AkahuWebhookTypes.Token, Arg.Any<string>(), Arg.Any<CancellationToken>())
+            .Returns(new AkahuWebhookSubscriptionInfo { Id = "whk_token_new", WebhookType = AkahuWebhookTypes.Token });
+        ctx.AkahuApiClient.SubscribeToWebhookAsync(AppToken, UserToken, AkahuWebhookTypes.Account, Arg.Any<string>(), Arg.Any<CancellationToken>())
+            .Returns(new AkahuWebhookSubscriptionInfo { Id = "whk_acc_new", WebhookType = AkahuWebhookTypes.Account });
+        ctx.AkahuApiClient.SubscribeToWebhookAsync(AppToken, UserToken, AkahuWebhookTypes.Transaction, Arg.Any<string>(), Arg.Any<CancellationToken>())
+            .Returns(new AkahuWebhookSubscriptionInfo { Id = "whk_tx_new", WebhookType = AkahuWebhookTypes.Transaction });
+    }
+
+    private static Context CreateContext()
+    {
+        var akahuApiClient = Substitute.For<IAkahuApiClient>();
+        var credentialRepository = Substitute.For<IAkahuUserCredentialRepository>();
+        var subscriptionRepository = Substitute.For<IAkahuWebhookSubscriptionRepository>();
+        var encryptionService = Substitute.For<ISettingsEncryptionService>();
+        var logger = Substitute.For<IApplicationLogger<AkahuWebhookSubscriptionService>>();
+
+        var service = new AkahuWebhookSubscriptionService(
+            akahuApiClient,
+            credentialRepository,
+            subscriptionRepository,
+            encryptionService,
+            logger);
+
+        return new Context(service, akahuApiClient, credentialRepository, subscriptionRepository, encryptionService);
+    }
+
+    private sealed record Context(
+        AkahuWebhookSubscriptionService Service,
+        IAkahuApiClient AkahuApiClient,
+        IAkahuUserCredentialRepository CredentialRepository,
+        IAkahuWebhookSubscriptionRepository SubscriptionRepository,
+        ISettingsEncryptionService EncryptionService);
+}

--- a/tests/MyMascada.Tests.Unit/Services/SettingsEncryptionServiceTests.cs
+++ b/tests/MyMascada.Tests.Unit/Services/SettingsEncryptionServiceTests.cs
@@ -1,5 +1,6 @@
 using Microsoft.AspNetCore.DataProtection;
 using MyMascada.Application.Common.Interfaces;
+using MyMascada.Application.Features.BankConnections.DTOs;
 using MyMascada.Infrastructure.Services.Security;
 using MyMascada.Infrastructure.Services.BankIntegration.Providers;
 


### PR DESCRIPTION
## Summary

Ships the end-to-end Akahu migration support for the 24 May 2026 cutoff. Without this, classic ANZ/ASB/BNZ/Westpac connections silently break and re-imported transactions duplicate.

**Core migration:** `MigrateAkahuConnectionCommand` (rewrites stored `acc_*` and `trans_*` IDs via Akahu's `_migrated` correlation), `ACCOUNT/MIGRATE` webhook handler, post-OAuth migration sweep, `GET /api/bankconnections/akahu/migration-status` endpoint, new `LastMigratedAt` column on `BankConnection` (EF migration included), and a dedup safety net that loosens tolerance for connections migrated within the last 30 days.

**Webhook subscriptions:** brand-new `AkahuWebhookSubscription` entity + service (EF migration included). Subscriptions auto-created in `ExchangeAkahuCodeQuery` and `SaveAkahuCredentialsCommand`; torn down on disconnect / account-delete / TOKEN-DELETE webhook. Daily Hangfire reconciliation job (`reconcile-akahu-webhook-subscriptions`) heals drift.

**Frontend:** `AkahuMigrationBanner` on `/settings/bank-connections` and dashboard, with per-day localStorage dismissal. Full en + pt-BR translations.

**Bug fixes found while validating end-to-end against the Akahu dev sandbox** (all integral to the migration code working in practice):
- Callback page rejected `event=UPDATE` (Akahu's re-consent signal) as denial
- `UpdateAccountDto.IsActive` was non-nullable + frontend TS type omitted `isActive` → editing any account silently archived it
- `InitiateAkahuConnectionCommand` always re-OAuthed even when valid credentials existed; now reuses credentials and falls through to OAuth only on revoke/decrypt failure
- `AkahuApiClient.SubscribeToWebhookAsync` read `response.Content` twice → `ObjectDisposedException`; also Akahu actually returns `{success, item_id}` rather than the documented envelope shape, parser now handles all three observed shapes

## Test plan
- [x] `dotnet build` clean (0 errors, 0 warnings)
- [x] `dotnet test` — 1075 unit tests passing (+~30 new)
- [x] `npm run build` clean
- [x] Playwright E2E: 5 scenarios for the migration banner (empty, pending, pt-BR, dismiss, upgrade nav)
- [x] Tier 1 local regression smoke (login, dashboard, bank-connections, transactions — zero console errors)
- [x] Tier 2 live OAuth round-trip against Akahu's dev sandbox: credential persisted, 3 webhook subscriptions created with real `hook_*` IDs from Akahu, BankConnection linked, migration-status endpoint correctly empty
- [ ] Tier 3 (real classic→official migration) — requires a classic connection to actually migrate; not feasible in the sandbox. Production validation: deploy, then upgrade a real classic NZ bank connection via `my.akahu.nz` and observe.

## Deployment notes
- Two EF migrations apply automatically on startup (`AddAkahuWebhookSubscription`, `AddBankConnectionLastMigratedAt`)
- New recurring Hangfire job registered on startup (daily, 04:00 UTC)
- New `Akahu:MigrationFallbackEnabled` config option (defaults true)
- For existing prod users on Personal App mode: re-save tokens once to seed webhook subscriptions, or wait for the daily reconciliation job
- Akahu must be able to reach `/api/webhooks/akahu` publicly for the `ACCOUNT/MIGRATE` webhook to land

## Design docs
- `docs/plans/akahu-migration-impact.md` — full code audit and remediation plan
- `docs/plans/akahu-webhook-subscription-wiring.md` — webhook subscription design
- `docs/plans/akahu-accreditation-pack.md` — accreditation evidence gap analysis
- `docs/plans/akahu-consumer-info-page-draft.md` — copy for the consumer info page Akahu requires for accreditation

---
Labels: `agent:claude`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Akahu migration banners on Dashboard and Bank Connections with per-connection “upgrade” actions; migration status API with deadline and pending list; background migration processing and automated webhook subscription management.

* **Improvements**
  * OAuth callback accepts migration/re-consent outcomes; account updates preserve active state when omitted; duplicate-detection loosened temporarily for recently-migrated Akahu connections; localization for migration flows added.

* **Documentation**
  * Added Akahu accreditation pack, consumer info page draft, migration impact and webhook wiring guides.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/digaomatias/mymascada/pull/317?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->