### PR TITLE
fix: prevent duplicate sign-in toast on Google OAuth callback

### DIFF
--- a/frontend/src/app/dashboard/page.tsx
+++ b/frontend/src/app/dashboard/page.tsx
@@ -2,7 +2,7 @@
 
 import { useAuth } from '@/contexts/auth-context';
 import { useRouter, useSearchParams } from 'next/navigation';
-import { useEffect, Suspense } from 'react';
+import { useEffect, useRef, Suspense } from 'react';
 import { toast } from 'sonner';
 import { AppLayout } from '@/components/app-layout';
 import { apiClient } from '@/lib/api-client';
@@ -20,28 +20,32 @@ function DashboardContent() {
   const router = useRouter();
   const searchParams = useSearchParams();
   const tToasts = useTranslations('toasts');
+  const oauthExchangeStarted = useRef(false);
 
   // Handle Google OAuth code from URL
   useEffect(() => {
     const code = searchParams.get('code');
-    if (code && !isAuthResolved) {
-      apiClient
-        .exchangeCode(code)
-        .then((result) => loginWithToken(result.token))
-        .then((success) => {
-          if (success) {
-            toast.success(tToasts('signedIn'));
-            router.replace('/dashboard');
-          } else {
-            toast.error(tToasts('error.generic'));
-            router.push('/auth/login');
-          }
-        })
-        .catch(() => {
+    if (!code || isAuthResolved || oauthExchangeStarted.current) {
+      return;
+    }
+    oauthExchangeStarted.current = true;
+
+    apiClient
+      .exchangeCode(code)
+      .then((result) => loginWithToken(result.token))
+      .then((success) => {
+        if (success) {
+          toast.success(tToasts('signedIn'));
+          router.replace('/dashboard');
+        } else {
           toast.error(tToasts('error.generic'));
           router.push('/auth/login');
-        });
-    }
+        }
+      })
+      .catch(() => {
+        toast.error(tToasts('error.generic'));
+        router.push('/auth/login');
+      });
   }, [searchParams, isAuthResolved, loginWithToken, router, tToasts]);
 
   // Onboarding redirect


### PR DESCRIPTION
## Summary
- The dashboard's OAuth-code exchange `useEffect` fired twice under React 18 StrictMode (dev double-mount) and on dep-driven re-runs from fresh `loginWithToken` / `router` / `tToasts` references, exchanging the single-use OAuth code twice and showing two toasts on login.
- Added a `useRef` guard so the exchange runs at most once per mount; preserves all existing behaviour (redirect, error handling, login-with-token).
- File touched: `frontend/src/app/dashboard/page.tsx`.

## Test plan
- [ ] In dev (`npm run dev`), trigger Google sign-in and confirm only one "signed in" toast appears.
- [ ] Force the failure path (e.g., revoke the OAuth code) and confirm only one error toast appears, plus redirect to `/auth/login`.
- [ ] Verify a logged-in user landing on `/dashboard` without `?code=` shows no auth toast.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Google OAuth login flow to prevent duplicate token exchanges, ensuring more reliable and consistent authentication.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/digaomatias/mymascada/pull/318?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->