### PR TITLE
fix: standardize Quick-Categorize page header

### DIFF
--- a/frontend/src/app/transactions/categorize/page.tsx
+++ b/frontend/src/app/transactions/categorize/page.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { useAuth } from '@/contexts/auth-context';
+import { useAuthGuard } from '@/hooks/use-auth-guard';
 import { AiSuggestionsProvider } from '@/contexts/ai-suggestions-context';
 import { useRouter } from 'next/navigation';
 import { useEffect, useState, useCallback, useMemo } from 'react';
@@ -17,7 +17,6 @@ import {
   CalendarIcon,
   TagIcon,
   BuildingOffice2Icon,
-  WalletIcon,
   ArrowTrendingUpIcon,
   ArrowTrendingDownIcon,
   CheckIcon
@@ -50,7 +49,7 @@ interface Transaction {
 }
 
 export default function CategorizePage() {
-  const { isAuthenticated, isLoading } = useAuth();
+  const { shouldRender, isAuthResolved } = useAuthGuard();
   const { isMobile } = useDeviceDetect();
   const router = useRouter();
   const t = useTranslations('transactions');
@@ -98,14 +97,8 @@ export default function CategorizePage() {
   // Batch fetch AI suggestions for all visible transactions
   const transactionCandidates = useTransactionCandidates({
     queryParams: candidatesQueryParams,
-    enabled: isAuthenticated && transactions.length > 0
+    enabled: isAuthResolved && transactions.length > 0
   });
-
-  useEffect(() => {
-    if (!isLoading && !isAuthenticated) {
-      router.push('/auth/login');
-    }
-  }, [isAuthenticated, isLoading, router]);
 
   const fetchUncategorizedTransactions = useCallback(async (page = 1, search = '', accountId = selectedAccountId) => {
     try {
@@ -160,10 +153,10 @@ export default function CategorizePage() {
   }, [selectedAccountId, pageSize, showAll, updatePagination]);
 
   useEffect(() => {
-    if (isAuthenticated) {
+    if (isAuthResolved) {
       fetchUncategorizedTransactions(currentPage, searchTerm, selectedAccountId);
     }
-  }, [isAuthenticated, currentPage, pageSize, searchTerm, selectedAccountId, showAll, fetchUncategorizedTransactions]);
+  }, [isAuthResolved, currentPage, pageSize, searchTerm, selectedAccountId, showAll, fetchUncategorizedTransactions]);
 
   const handleSearch = (value: string) => {
     setSearchTerm(value);
@@ -193,11 +186,11 @@ export default function CategorizePage() {
 
   // Load initial data when authenticated
   useEffect(() => {
-    if (isAuthenticated) {
+    if (isAuthResolved) {
       loadCategories();
       loadAccounts();
     }
-  }, [isAuthenticated]);
+  }, [isAuthResolved]);
 
   const handleApplyFilters = () => {
     handlePageChange(1);
@@ -263,20 +256,7 @@ export default function CategorizePage() {
     }
   };
 
-  if (isLoading) {
-    return (
-      <div className="min-h-screen bg-surface-alt flex items-center justify-center">
-        <div className="text-center">
-          <div className="w-16 h-16 bg-gradient-to-br from-primary-500 to-primary-400 rounded-2xl shadow-2xl flex items-center justify-center animate-pulse mx-auto">
-            <WalletIcon className="w-8 h-8 text-white" />
-          </div>
-          <div className="mt-6 text-ink-700 font-medium">{t('loading')}</div>
-        </div>
-      </div>
-    );
-  }
-
-  if (!isAuthenticated) {
+  if (!shouldRender) {
     return null;
   }
 

--- a/frontend/src/app/transactions/quick-categorize/page.tsx
+++ b/frontend/src/app/transactions/quick-categorize/page.tsx
@@ -300,12 +300,16 @@ export default function QuickCategorizePage() {
     return null;
   }
 
+  const pageHeader = (
+    <header className="mb-5 flex flex-wrap items-center justify-between gap-4">
+      <BackButton href="/transactions" label={t('backToTransactions')} />
+    </header>
+  );
+
   if (loading) {
     return (
       <AppLayout>
-        <header className="mb-5 flex flex-wrap items-center justify-between gap-4">
-          <BackButton href="/transactions" label={t('backToTransactions')} />
-        </header>
+        {pageHeader}
         <div className="rounded-2xl border border-ink-200 bg-white/90 p-12 text-center text-ink-500">
           {t('loading')}
         </div>
@@ -319,9 +323,7 @@ export default function QuickCategorizePage() {
   if (loadError) {
     return (
       <AppLayout>
-        <header className="mb-5 flex flex-wrap items-center justify-between gap-4">
-          <BackButton href="/transactions" label={t('backToTransactions')} />
-        </header>
+        {pageHeader}
         <div
           className="rounded-2xl border border-ink-200 bg-white/90 p-12 text-center shadow-lg"
           data-testid="quick-categorize-load-error"
@@ -346,10 +348,7 @@ export default function QuickCategorizePage() {
 
   return (
     <AppLayout>
-      <header className="mb-5 flex flex-wrap items-center justify-between gap-4">
-        <BackButton href="/transactions" label={t('backToTransactions')} />
-      </header>
-
+      {pageHeader}
       <div className="mb-6">
         <h1 className="font-[var(--font-dash-sans)] text-3xl font-semibold tracking-[-0.03em] text-ink-900 sm:text-[2.1rem]">
           {t('title')}

--- a/frontend/src/app/transactions/quick-categorize/page.tsx
+++ b/frontend/src/app/transactions/quick-categorize/page.tsx
@@ -5,7 +5,6 @@ import { useRouter } from 'next/navigation';
 import { useTranslations } from 'next-intl';
 import { toast } from 'sonner';
 import {
-  SparklesIcon,
   ArrowRightIcon,
   CheckBadgeIcon,
 } from '@heroicons/react/24/outline';
@@ -304,8 +303,10 @@ export default function QuickCategorizePage() {
   if (loading) {
     return (
       <AppLayout>
-        <BackButton href="/transactions" label={t('backToTransactions')} />
-        <div className="mt-6 rounded-2xl border border-ink-200 bg-white/90 p-12 text-center text-ink-500">
+        <header className="mb-5 flex flex-wrap items-center justify-between gap-4">
+          <BackButton href="/transactions" label={t('backToTransactions')} />
+        </header>
+        <div className="rounded-2xl border border-ink-200 bg-white/90 p-12 text-center text-ink-500">
           {t('loading')}
         </div>
       </AppLayout>
@@ -318,9 +319,11 @@ export default function QuickCategorizePage() {
   if (loadError) {
     return (
       <AppLayout>
-        <BackButton href="/transactions" label={t('backToTransactions')} />
+        <header className="mb-5 flex flex-wrap items-center justify-between gap-4">
+          <BackButton href="/transactions" label={t('backToTransactions')} />
+        </header>
         <div
-          className="mt-6 rounded-2xl border border-ink-200 bg-white/90 p-12 text-center shadow-lg"
+          className="rounded-2xl border border-ink-200 bg-white/90 p-12 text-center shadow-lg"
           data-testid="quick-categorize-load-error"
         >
           <h2 className="font-[var(--font-dash-sans)] text-xl font-semibold text-ink-900">
@@ -343,18 +346,15 @@ export default function QuickCategorizePage() {
 
   return (
     <AppLayout>
-      <BackButton href="/transactions" label={t('backToTransactions')} />
+      <header className="mb-5 flex flex-wrap items-center justify-between gap-4">
+        <BackButton href="/transactions" label={t('backToTransactions')} />
+      </header>
 
-      <div className="mt-4 mb-6">
-        <div className="flex items-center gap-3">
-          <div className="flex h-10 w-10 items-center justify-center rounded-xl bg-gradient-to-br from-primary-500 to-primary-400 shadow-lg">
-            <SparklesIcon className="h-5 w-5 text-white" />
-          </div>
-          <h1 className="font-[var(--font-dash-sans)] text-3xl font-semibold tracking-[-0.03em] text-ink-900 sm:text-[2.1rem]">
-            {t('title')}
-          </h1>
-        </div>
-        <p className="mt-2 text-[15px] text-ink-500">{t('subtitle')}</p>
+      <div className="mb-6">
+        <h1 className="font-[var(--font-dash-sans)] text-3xl font-semibold tracking-[-0.03em] text-ink-900 sm:text-[2.1rem]">
+          {t('title')}
+        </h1>
+        <p className="mt-1.5 text-[15px] text-ink-500">{t('subtitle')}</p>
       </div>
 
       {finished && groups.length === 0 && (


### PR DESCRIPTION
## Summary
Two header/layout consistency fixes for the transaction categorization screens.

### 1. Quick-Categorize page header (`/transactions/quick-categorize`)
Brought in line with the standard sub-page pattern (`/transactions/new`, `/transactions/categorize`, `/budgets/new`). Previously it had a bare back button, a decorative gradient icon box in front of the title, and the `<h1>` nested in a flex wrapper.
- Wrap the back button in the standard `<header className="mb-5 flex flex-wrap items-center justify-between gap-4">` element
- Remove the gradient icon box + `SparklesIcon`
- Render the `<h1>` directly with standard `mt-1.5` subtitle spacing
- Applied across the loading, error, and main render states

### 2. Categorize page auth/loading (`/transactions/categorize`)
The categorize page used the legacy `useAuth` + full-page spinner pattern — a standalone `WalletIcon` spinner rendered *outside* `AppLayout` while auth resolved, inconsistent with every other page.
- Switch to the standard `useAuthGuard` pattern (`shouldRender` / `isAuthResolved`)
- Page shell now renders immediately inside `AppLayout`; auth redirect handled by the hook
- Data fetches gate on `isAuthResolved`

## Changes
- `frontend/src/app/transactions/quick-categorize/page.tsx`
- `frontend/src/app/transactions/categorize/page.tsx`

## Test plan
- [x] `npx tsc --noEmit` passes
- [x] `npm run build` succeeds
- [x] Quick-Categorize header matches the categorize page (back button, plain title, no icon)
- [x] Categorize page verified post-refactor: 31 transactions load, pagination + CategoryPickers work, no console errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added page headers with back buttons to transaction categorization pages for improved navigation between views.

* **Style**
  * Refined page layouts and spacing consistency across transaction categorization screens for a more polished interface.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/digaomatias/mymascada/pull/320?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->