### PR TITLE
feat: manual Akahu migration trigger for Personal App mode

### DIFF
--- a/frontend/messages/en.json
+++ b/frontend/messages/en.json
@@ -3073,7 +3073,7 @@
       "heading": "Action required: re-authorise your bank connections",
       "body": "Akahu is migrating ANZ, ASB, BNZ and Westpac to official open banking. Re-authorise each connection below to keep your transactions syncing. {daysRemaining, plural, =0 {Deadline is today.} =1 {1 day remaining.} other {# days remaining.}}",
       "upgrade": "Upgrade",
-      "upgrading": "Opening Akahu...",
+      "upgrading": "Migrating...",
       "dismiss": "Dismiss for today",
       "row": {
         "unknownBank": "Bank connection",
@@ -3083,7 +3083,8 @@
       "toasts": {
         "initiateFailed": "Could not start the Akahu upgrade. Please try again.",
         "credentialsMissing": "Set up your Akahu credentials on this page first, then click Upgrade again.",
-        "personalAppFallback": "Open the Connect Bank flow above to relink your migrated account."
+        "migrationSuccess": "{bankName} migrated. {count, plural, =0 {No transactions needed remapping.} =1 {1 transaction remapped.} other {# transactions remapped.}}",
+        "migrationFailed": "Could not migrate {bankName}. {error}"
       }
     }
   },

--- a/frontend/messages/pt-BR.json
+++ b/frontend/messages/pt-BR.json
@@ -3073,7 +3073,7 @@
       "heading": "Ação necessária: reautorize suas conexões bancárias",
       "body": "O Akahu está migrando ANZ, ASB, BNZ e Westpac para o open banking oficial. Reautorize cada conexão abaixo para continuar sincronizando suas transações. {daysRemaining, plural, =0 {O prazo é hoje.} =1 {Falta 1 dia.} other {Faltam # dias.}}",
       "upgrade": "Reautorizar",
-      "upgrading": "Abrindo o Akahu...",
+      "upgrading": "Migrando...",
       "dismiss": "Dispensar por hoje",
       "row": {
         "unknownBank": "Conexão bancária",
@@ -3083,7 +3083,8 @@
       "toasts": {
         "initiateFailed": "Não foi possível iniciar a atualização do Akahu. Tente novamente.",
         "credentialsMissing": "Configure suas credenciais do Akahu nesta página primeiro e clique em Reautorizar novamente.",
-        "personalAppFallback": "Abra o fluxo Conectar Banco acima para revincular sua conta migrada."
+        "migrationSuccess": "{bankName} migrado. {count, plural, =0 {Nenhuma transação precisou ser remapeada.} =1 {1 transação remapeada.} other {# transações remapeadas.}}",
+        "migrationFailed": "Não foi possível migrar {bankName}. {error}"
       }
     }
   },

--- a/frontend/src/components/bank-connections/akahu-migration-banner.tsx
+++ b/frontend/src/components/bank-connections/akahu-migration-banner.tsx
@@ -133,10 +133,33 @@ export function AkahuMigrationBanner({ className }: AkahuMigrationBannerProps) {
         return;
       }
 
-      // Personal App mode returns availableAccounts inline. The actual
-      // re-link UX lives on the bank-connections page; nudge the user to
-      // the standard Connect-Bank flow they already know.
-      toast.info(t('toasts.personalAppFallback'));
+      // Personal App mode — no OAuth redirect. Trigger the classic→official
+      // migration directly; the user has already completed the upgrade on
+      // Akahu's side (my.akahu.nz).
+      const bankName = connection.bankName ?? t('row.unknownBank');
+      const migration = await apiClient.migrateAkahuConnection(connection.connectionId);
+
+      if (migration.success) {
+        toast.success(
+          t('toasts.migrationSuccess', {
+            bankName,
+            count: migration.transactionsRemapped,
+          }),
+        );
+        // Refresh so the migrated connection drops off the banner.
+        try {
+          setStatus(await apiClient.getAkahuMigrationStatus());
+        } catch {
+          // Non-fatal — the row clears on the next page load.
+        }
+      } else {
+        toast.error(
+          t('toasts.migrationFailed', {
+            bankName,
+            error: migration.errorMessage ?? '',
+          }),
+        );
+      }
     } catch (error) {
       console.error('Failed to initiate Akahu upgrade', error);
       toast.error(t('toasts.initiateFailed'));

--- a/frontend/src/lib/api-client.ts
+++ b/frontend/src/lib/api-client.ts
@@ -14,6 +14,7 @@ import {
   SaveAkahuCredentialsRequest,
   SaveAkahuCredentialsResult,
   AkahuMigrationStatus,
+  MigrateAkahuConnectionResult,
 } from '@/types/bank-connections';
 import {
   BudgetSummary,
@@ -1638,6 +1639,17 @@ class ApiClient {
    */
   async getAkahuMigrationStatus(): Promise<AkahuMigrationStatus> {
     return this.request('/api/BankConnections/akahu/migration-status');
+  }
+
+  /**
+   * Triggers the classic→official migration for a single Akahu connection.
+   * Used by the migration banner in Personal App mode (no OAuth re-auth step).
+   * Backed by POST /api/BankConnections/akahu/connections/{id}/migrate.
+   */
+  async migrateAkahuConnection(connectionId: number): Promise<MigrateAkahuConnectionResult> {
+    return this.request(`/api/BankConnections/akahu/connections/${connectionId}/migrate`, {
+      method: 'POST',
+    });
   }
 
   async saveAkahuCredentials(request: SaveAkahuCredentialsRequest): Promise<SaveAkahuCredentialsResult> {

--- a/frontend/src/types/bank-connections.ts
+++ b/frontend/src/types/bank-connections.ts
@@ -139,3 +139,12 @@ export interface SaveAkahuCredentialsResult {
   errorMessage?: string;
   availableAccounts?: AkahuAccount[];
 }
+
+// Result of triggering the classic → official migration for one connection.
+export interface MigrateAkahuConnectionResult {
+  success: boolean;
+  oldExternalAccountId: string | null;
+  newExternalAccountId: string | null;
+  transactionsRemapped: number;
+  errorMessage: string | null;
+}

--- a/src/WebAPI/MyMascada.WebAPI/Controllers/BankConnectionsController.cs
+++ b/src/WebAPI/MyMascada.WebAPI/Controllers/BankConnectionsController.cs
@@ -129,6 +129,22 @@ public class BankConnectionsController : ControllerBase
     }
 
     /// <summary>
+    /// Triggers the Akahu classic→official migration for a single bank connection.
+    /// Drives the migration banner's upgrade button in Personal App mode, where there
+    /// is no OAuth re-authorisation step — the user completes the upgrade on Akahu's
+    /// side (my.akahu.nz), then this endpoint rewrites the stored account and
+    /// transaction IDs to their official open-banking equivalents.
+    /// </summary>
+    [HttpPost("akahu/connections/{id}/migrate")]
+    [ProducesResponseType(typeof(MigrateAkahuConnectionResult), StatusCodes.Status200OK)]
+    public async Task<ActionResult<MigrateAkahuConnectionResult>> MigrateAkahuConnection(int id)
+    {
+        var command = new MigrateAkahuConnectionCommand(_currentUserService.GetUserId(), id);
+        var result = await _mediator.Send(command);
+        return Ok(result);
+    }
+
+    /// <summary>
     /// Saves or updates the user's Akahu credentials.
     /// Validates the credentials against the Akahu API before saving.
     /// </summary>


### PR DESCRIPTION
## Summary

Fixes a dead-end in the Akahu migration banner found during real Tier 3 validation: the **Upgrade** button does nothing for Personal App mode users.

The banner's button only worked in OAuth mode (redirect to Akahu's auth page). In **Personal App mode — the only mode production uses** — there is no OAuth step, so the button fell through to a "relink your account" toast that pointed nowhere. `MigrateAkahuConnectionCommand` had no caller outside the `ACCOUNT/MIGRATE` webhook and the OAuth sweep, so a Personal App user had no way to complete the classic→official migration from the UI.

- **Backend** — new endpoint `POST /api/BankConnections/akahu/connections/{id}/migrate` dispatches `MigrateAkahuConnectionCommand` and returns its result.
- **Frontend** — the banner's Upgrade button, in Personal App mode, calls the endpoint directly and refreshes the banner on success so the migrated row drops off. en + pt-BR toasts for success (with remapped-transaction count) and failure.

The user completes the upgrade on Akahu's side (`my.akahu.nz`) first; this endpoint then rewrites the stored `acc_*` / `trans_*` IDs to their official open-banking equivalents via Akahu's `_migrated` correlation.

## Test plan
- [x] `dotnet build` clean (0 errors)
- [x] `dotnet test` — 1085 unit tests pass (`MigrateAkahuConnectionCommand` itself is already covered)
- [x] `npm run build` clean (types + lint)
- [ ] Manual: in Personal App mode, click **Upgrade** on a connection already migrated on Akahu's side → toast confirms migration + banner row clears. **Not E2E-tested by the agent** — exercising the success path performs a real, irreversible migration against the user's live Akahu account, so this is left for the deploy-time Tier 3 validation.

## Notes
- The migration banner's visual layout is unchanged — only the button's click behaviour changed, so there is no new screenshot to add.
- `MigrateAkahuConnectionCommand` marks a connection "Awaiting re-authorisation" if Akahu has no `_migrated` account for it yet (i.e. the user clicked before completing the upgrade on Akahu's side). Existing behaviour, unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)