### PR TITLE
fix: SSR-seed feature flags so Google login button shows instantly

### DIFF
--- a/frontend/src/app/layout.tsx
+++ b/frontend/src/app/layout.tsx
@@ -4,6 +4,7 @@ import './globals.css';
 import { AuthProvider } from '@/contexts/auth-context';
 import { AiSuggestionsProvider } from '@/contexts/ai-suggestions-context';
 import { FeaturesProvider } from '@/contexts/features-context';
+import { getFeaturesServerSide } from '@/lib/features-server';
 import { LocaleWrapper } from '@/components/locale-wrapper';
 import { CookieConsent } from '@/components/cookie-consent';
 import { Toaster } from 'sonner';
@@ -44,12 +45,13 @@ export default async function RootLayout({
 }) {
   const locale = await getLocale();
   const messages = await getMessages();
+  const initialFeatures = await getFeaturesServerSide();
 
   return (
     <html lang={locale}>
       <body className={`${plusJakarta.className} ${plusJakarta.variable} ${dmMono.variable} ${instrumentSerif.variable}`}>
         <NextIntlClientProvider messages={messages}>
-          <FeaturesProvider>
+          <FeaturesProvider initialFeatures={initialFeatures}>
           <AuthProvider>
             <LocaleWrapper>
               <AiSuggestionsProvider>

--- a/frontend/src/app/layout.tsx
+++ b/frontend/src/app/layout.tsx
@@ -43,9 +43,13 @@ export default async function RootLayout({
 }: {
   children: React.ReactNode;
 }) {
-  const locale = await getLocale();
-  const messages = await getMessages();
-  const initialFeatures = await getFeaturesServerSide();
+  // Resolve independent server data concurrently so the feature-flag fetch adds
+  // no latency beyond the locale/messages the layout already awaits.
+  const [locale, messages, initialFeatures] = await Promise.all([
+    getLocale(),
+    getMessages(),
+    getFeaturesServerSide(),
+  ]);
 
   return (
     <html lang={locale}>

--- a/frontend/src/contexts/features-context.tsx
+++ b/frontend/src/contexts/features-context.tsx
@@ -1,21 +1,12 @@
 'use client';
 
 import React, { createContext, useContext, useEffect, useState, ReactNode } from 'react';
-import { apiClient, FeatureFlags } from '@/lib/api-client';
+import { apiClient, defaultFeatures, FeatureFlags } from '@/lib/api-client';
 
 interface FeaturesContextType {
   features: FeatureFlags;
   isLoading: boolean;
 }
-
-const defaultFeatures: FeatureFlags = {
-  aiCategorization: false,
-  googleOAuth: false,
-  bankSync: false,
-  emailNotifications: false,
-  accountSharing: false,
-  stripeBilling: false,
-};
 
 const FeaturesContext = createContext<FeaturesContextType>({
   features: defaultFeatures,

--- a/frontend/src/contexts/features-context.tsx
+++ b/frontend/src/contexts/features-context.tsx
@@ -24,11 +24,15 @@ const FeaturesContext = createContext<FeaturesContextType>({
 
 interface FeaturesProviderProps {
   children: ReactNode;
+  // Flags fetched server-side and used to seed state, so flag-gated UI renders
+  // correctly on the first paint without waiting for a client round-trip.
+  initialFeatures?: FeatureFlags;
 }
 
-export function FeaturesProvider({ children }: FeaturesProviderProps) {
-  const [features, setFeatures] = useState<FeatureFlags>(defaultFeatures);
-  const [isLoading, setIsLoading] = useState(true);
+export function FeaturesProvider({ children, initialFeatures }: FeaturesProviderProps) {
+  const [features, setFeatures] = useState<FeatureFlags>(initialFeatures ?? defaultFeatures);
+  // When seeded from the server we already have flags — don't block on the client fetch.
+  const [isLoading, setIsLoading] = useState(initialFeatures === undefined);
 
   useEffect(() => {
     let cancelled = false;

--- a/frontend/src/lib/api-client.ts
+++ b/frontend/src/lib/api-client.ts
@@ -2109,6 +2109,16 @@ export interface FeatureFlags {
   stripeBilling: boolean;
 }
 
+/** All flags disabled — the safe baseline used until real flags load. */
+export const defaultFeatures: FeatureFlags = {
+  aiCategorization: false,
+  googleOAuth: false,
+  bankSync: false,
+  emailNotifications: false,
+  accountSharing: false,
+  stripeBilling: false,
+};
+
 // Billing Types
 export interface BillingStatusResponse {
   planName: string;

--- a/frontend/src/lib/features-server.ts
+++ b/frontend/src/lib/features-server.ts
@@ -1,31 +1,26 @@
-import type { FeatureFlags } from '@/lib/api-client';
+import { defaultFeatures, type FeatureFlags } from '@/lib/api-client';
 
 // Server-only module: imported solely from the root layout (a server component).
 // Uses INTERNAL_API_URL, so it must never be pulled into a client bundle.
 
-export const defaultFeatures: FeatureFlags = {
-  aiCategorization: false,
-  googleOAuth: false,
-  bankSync: false,
-  emailNotifications: false,
-  accountSharing: false,
-  stripeBilling: false,
-};
-
 // Server-side address (Docker-internal) preferred; falls back to the public URL.
-const SERVER_API_URL =
-  process.env.INTERNAL_API_URL || process.env.NEXT_PUBLIC_API_URL || 'http://localhost:5126';
+// Strip any trailing slash so the URL join can't produce a double slash.
+const SERVER_API_URL = (
+  process.env.INTERNAL_API_URL || process.env.NEXT_PUBLIC_API_URL || 'http://localhost:5126'
+).replace(/\/+$/, '');
 
-// Short timeout so a cold/slow backend can never block the page render.
-const FETCH_TIMEOUT_MS = 2000;
+// Short timeout: this runs in the (force-dynamic) root layout, so it gates the
+// initial render. Keep it tight so a cold/slow backend can't stall the page.
+const FETCH_TIMEOUT_MS = 1000;
 
 /**
  * Fetch feature flags server-side so they can seed FeaturesProvider's initial
  * state. This removes the post-hydration client round-trip that otherwise keeps
  * flag-gated UI (e.g. the Google sign-in button) hidden for a few seconds.
  *
- * Never throws: on timeout or error it returns all-disabled defaults, and the
- * client-side provider revalidates to self-heal once the backend is warm.
+ * Never throws: on timeout, error, or an unexpected payload it returns
+ * all-disabled defaults, and the client-side provider revalidates to self-heal
+ * once the backend is warm.
  */
 export async function getFeaturesServerSide(): Promise<FeatureFlags> {
   const controller = new AbortController();
@@ -42,10 +37,15 @@ export async function getFeaturesServerSide(): Promise<FeatureFlags> {
       return defaultFeatures;
     }
 
-    const data = (await res.json()) as Partial<FeatureFlags>;
-    return { ...defaultFeatures, ...data };
-  } catch {
+    const data = await res.json();
+    // Guard against non-object payloads (string/array/null) before spreading.
+    if (data && typeof data === 'object' && !Array.isArray(data)) {
+      return { ...defaultFeatures, ...(data as Partial<FeatureFlags>) };
+    }
+    return defaultFeatures;
+  } catch (error) {
     // Cold backend, network error, or timeout — fall back to defaults.
+    console.warn('[getFeaturesServerSide] Failed to fetch feature flags:', error);
     return defaultFeatures;
   } finally {
     clearTimeout(timeout);

--- a/frontend/src/lib/features-server.ts
+++ b/frontend/src/lib/features-server.ts
@@ -1,0 +1,53 @@
+import type { FeatureFlags } from '@/lib/api-client';
+
+// Server-only module: imported solely from the root layout (a server component).
+// Uses INTERNAL_API_URL, so it must never be pulled into a client bundle.
+
+export const defaultFeatures: FeatureFlags = {
+  aiCategorization: false,
+  googleOAuth: false,
+  bankSync: false,
+  emailNotifications: false,
+  accountSharing: false,
+  stripeBilling: false,
+};
+
+// Server-side address (Docker-internal) preferred; falls back to the public URL.
+const SERVER_API_URL =
+  process.env.INTERNAL_API_URL || process.env.NEXT_PUBLIC_API_URL || 'http://localhost:5126';
+
+// Short timeout so a cold/slow backend can never block the page render.
+const FETCH_TIMEOUT_MS = 2000;
+
+/**
+ * Fetch feature flags server-side so they can seed FeaturesProvider's initial
+ * state. This removes the post-hydration client round-trip that otherwise keeps
+ * flag-gated UI (e.g. the Google sign-in button) hidden for a few seconds.
+ *
+ * Never throws: on timeout or error it returns all-disabled defaults, and the
+ * client-side provider revalidates to self-heal once the backend is warm.
+ */
+export async function getFeaturesServerSide(): Promise<FeatureFlags> {
+  const controller = new AbortController();
+  const timeout = setTimeout(() => controller.abort(), FETCH_TIMEOUT_MS);
+
+  try {
+    const res = await fetch(`${SERVER_API_URL}/api/latest/Features`, {
+      signal: controller.signal,
+      cache: 'no-store',
+      headers: { Accept: 'application/json' },
+    });
+
+    if (!res.ok) {
+      return defaultFeatures;
+    }
+
+    const data = (await res.json()) as Partial<FeatureFlags>;
+    return { ...defaultFeatures, ...data };
+  } catch {
+    // Cold backend, network error, or timeout — fall back to defaults.
+    return defaultFeatures;
+  } finally {
+    clearTimeout(timeout);
+  }
+}


### PR DESCRIPTION
## Problem

Whenever the app loads, the Google sign-in button on the login page takes a few seconds to appear.

**Root cause:** the button is gated behind `features.googleOAuth`, which started as `false` and only flipped to `true` after a **post-hydration client-side fetch** of `/api/Features`:

1. Page renders with all flags defaulted to `false` → button hidden
2. React mounts → `useEffect` fires → `GET /api/Features`
3. Response returns → flag flips → button finally appears

That round-trip (slow when the self-hosted backend is cold) is the delay — for a value that is fixed at backend startup and never changes at runtime.

## Fix (SSR-seed)

Fetch the flags **server-side** in the root layout (already an `async` server component with `force-dynamic`) and seed `FeaturesProvider` with them, so flag-gated UI is correct on the **first paint** — no client round-trip, no flash.

- **`features-server.ts`** (new) — server-side fetch via the Docker-internal `INTERNAL_API_URL` with a 2s timeout, falling back to all-disabled so a cold backend can never block render
- **`FeaturesProvider`** — accepts `initialFeatures` to seed state; the existing client fetch stays as a background revalidation so an SSR-fallback self-heals once the backend is warm
- **`layout.tsx`** — fetches flags server-side and passes them to the provider

Toggling the flag still needs no rebuild — it's read fresh per request.

## Verification

- `tsc --noEmit` clean
- `next build` succeeds (login page + layout render dynamically as expected)
- No backend / config / `.env` changes

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Feature flags are now initialized on the server, eliminating initial loading delays and improving overall page performance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->