### PR TITLE
fix(dashboard): make displayed-period summary fields internally consistent

### DIFF
--- a/src/Core/MyMascada.Application/Features/Reports/Queries/GetDashboardSummaryQuery.cs
+++ b/src/Core/MyMascada.Application/Features/Reports/Queries/GetDashboardSummaryQuery.cs
@@ -103,16 +103,22 @@ public class GetDashboardSummaryQueryHandler : IRequestHandler<GetDashboardSumma
             .Where(t => t.Amount < 0 && !t.TransferId.HasValue)
             .Sum(t => t.Amount));
 
-        // 3-month rolling average runway calculation
+        // Net saved and savings rate must describe the SAME displayed period as
+        // monthlyIncome/monthlyExpenses. When falling back to a previous month,
+        // these are derived from that fallback month's figures (not the empty
+        // current month, and not the 3-month averages).
+        var netSaved = monthlyIncome - monthlyExpenses;
+        var savingsRate = monthlyIncome > 0
+            ? Math.Round((netSaved / monthlyIncome) * 100, 0)
+            : 0m;
+
+        // 3-month rolling average runway calculation (intentionally separate
+        // from the displayed-period figures above).
         var (avgMonthlyIncome, avgMonthlyExpenses) = await CalculateRollingAveragesAsync(
             request.UserId, now);
 
-        var netSaved = avgMonthlyIncome - avgMonthlyExpenses;
         var runwayMonths = avgMonthlyExpenses > 0
             ? Math.Max(0m, Math.Round(totalBalance / avgMonthlyExpenses, 1))
-            : 0m;
-        var savingsRate = avgMonthlyIncome > 0
-            ? Math.Round((netSaved / avgMonthlyIncome) * 100, 0)
             : 0m;
 
         // Get recent transactions (last 5)

--- a/tests/MyMascada.Tests.Unit/Queries/GetDashboardSummaryQueryHandlerTests.cs
+++ b/tests/MyMascada.Tests.Unit/Queries/GetDashboardSummaryQueryHandlerTests.cs
@@ -1,0 +1,151 @@
+using FluentAssertions;
+using MyMascada.Application.Common.Interfaces;
+using MyMascada.Application.Features.Reports.Queries;
+using MyMascada.Domain.Common;
+using MyMascada.Domain.Entities;
+using NSubstitute;
+using Xunit;
+
+namespace MyMascada.Tests.Unit.Queries;
+
+/// <summary>
+/// Regression tests for the dashboard summary. The key invariant being protected
+/// here is that the displayed-period figures (MonthlyIncome, MonthlyExpenses,
+/// NetSaved, SavingsRate) must all describe the SAME period. When the current
+/// month is empty and the handler falls back to a previous month, NetSaved and
+/// SavingsRate must be derived from the displayed (fallback) month's
+/// income/expenses — NOT from the empty current month, and NOT from the
+/// 3-month rolling averages.
+/// </summary>
+public class GetDashboardSummaryQueryHandlerTests
+{
+    private readonly ITransactionRepository _transactionRepository;
+    private readonly IAccountRepository _accountRepository;
+    private readonly GetDashboardSummaryQueryHandler _handler;
+
+    public GetDashboardSummaryQueryHandlerTests()
+    {
+        _transactionRepository = Substitute.For<ITransactionRepository>();
+        _accountRepository = Substitute.For<IAccountRepository>();
+        _handler = new GetDashboardSummaryQueryHandler(_accountRepository, _transactionRepository);
+    }
+
+    [Fact]
+    public async Task Handle_WhenCurrentMonthEmpty_FallsBackAndKeepsDisplayedFiguresConsistent()
+    {
+        // Arrange
+        var userId = Guid.NewGuid();
+        var now = DateTimeProvider.UtcNow;
+
+        var currentMonthStart = new DateTime(now.Year, now.Month, 1, 0, 0, 0, DateTimeKind.Utc);
+        var fallbackMonthStart = currentMonthStart.AddMonths(-1);
+
+        _accountRepository.GetByUserIdAsync(userId).Returns(new List<Account>());
+        _transactionRepository.GetAccountBalancesAsync(userId)
+            .Returns(new Dictionary<int, decimal>());
+        _transactionRepository.GetRecentAsync(userId, 5).Returns(new List<Transaction>());
+        _transactionRepository.GetCountByUserIdAsync(userId).Returns(2);
+
+        // Fallback (previous) month has income 2000 and expenses 573 => netSaved 1427.
+        var fallbackTransactions = new List<Transaction>
+        {
+            new() { Id = 1, AccountId = 1, Amount = 2000m, TransactionDate = fallbackMonthStart.AddDays(2), Description = "Salary" },
+            new() { Id = 2, AccountId = 1, Amount = -573m, TransactionDate = fallbackMonthStart.AddDays(5), Description = "Rent" },
+        };
+
+        // Route repository calls by the start date the handler passes in:
+        //  - current month start  => empty (triggers fallback)
+        //  - fallback month start  => the populated fallback transactions
+        //  - any other range (3-month averages) => empty
+        _transactionRepository
+            .GetByDateRangeAsync(userId, Arg.Any<DateTime>(), Arg.Any<DateTime>())
+            .Returns(callInfo =>
+            {
+                var start = callInfo.ArgAt<DateTime>(1);
+                if (start == currentMonthStart)
+                {
+                    return Task.FromResult<IEnumerable<Transaction>>(new List<Transaction>());
+                }
+                if (start == fallbackMonthStart)
+                {
+                    return Task.FromResult<IEnumerable<Transaction>>(fallbackTransactions);
+                }
+                return Task.FromResult<IEnumerable<Transaction>>(new List<Transaction>());
+            });
+
+        var query = new GetDashboardSummaryQuery { UserId = userId };
+
+        // Act
+        var result = await _handler.Handle(query, CancellationToken.None);
+
+        // Assert — fallback engaged and pointing at the previous month
+        result.IsUsingFallbackMonth.Should().BeTrue("the current month has no non-transfer transactions");
+        result.DisplayMonth.Should().Be(fallbackMonthStart.Month);
+        result.DisplayYear.Should().Be(fallbackMonthStart.Year);
+
+        // Assert — displayed figures come from the fallback month, not the empty current month
+        result.MonthlyIncome.Should().Be(2000m);
+        result.MonthlyExpenses.Should().Be(573m);
+
+        // CRITICAL invariant: NetSaved == displayed income - displayed expenses
+        result.NetSaved.Should().Be(result.MonthlyIncome - result.MonthlyExpenses);
+        result.NetSaved.Should().Be(1427m);
+
+        // CRITICAL invariant: SavingsRate is derived from the same displayed figures
+        var expectedSavingsRate = Math.Round((result.NetSaved / result.MonthlyIncome) * 100, 0);
+        result.SavingsRate.Should().Be(expectedSavingsRate);
+    }
+
+    [Fact]
+    public async Task Handle_WhenCurrentMonthHasTransactions_UsesCurrentMonthConsistently()
+    {
+        // Arrange
+        var userId = Guid.NewGuid();
+        var now = DateTimeProvider.UtcNow;
+        var currentMonthStart = new DateTime(now.Year, now.Month, 1, 0, 0, 0, DateTimeKind.Utc);
+
+        _accountRepository.GetByUserIdAsync(userId).Returns(new List<Account>());
+        _transactionRepository.GetAccountBalancesAsync(userId)
+            .Returns(new Dictionary<int, decimal>());
+        _transactionRepository.GetRecentAsync(userId, 5).Returns(new List<Transaction>());
+        _transactionRepository.GetCountByUserIdAsync(userId).Returns(2);
+
+        var currentTransactions = new List<Transaction>
+        {
+            new() { Id = 1, AccountId = 1, Amount = 1000m, TransactionDate = now, Description = "Salary" },
+            new() { Id = 2, AccountId = 1, Amount = -250m, TransactionDate = now, Description = "Groceries" },
+        };
+
+        _transactionRepository
+            .GetByDateRangeAsync(userId, Arg.Any<DateTime>(), Arg.Any<DateTime>())
+            .Returns(callInfo =>
+            {
+                var start = callInfo.ArgAt<DateTime>(1);
+                if (start == currentMonthStart)
+                {
+                    return Task.FromResult<IEnumerable<Transaction>>(currentTransactions);
+                }
+                return Task.FromResult<IEnumerable<Transaction>>(new List<Transaction>());
+            });
+
+        var query = new GetDashboardSummaryQuery { UserId = userId };
+
+        // Act
+        var result = await _handler.Handle(query, CancellationToken.None);
+
+        // Assert
+        result.IsUsingFallbackMonth.Should().BeFalse("the current month has non-transfer transactions");
+        result.DisplayMonth.Should().Be(now.Month);
+        result.DisplayYear.Should().Be(now.Year);
+
+        result.MonthlyIncome.Should().Be(1000m);
+        result.MonthlyExpenses.Should().Be(250m);
+
+        // Invariant holds for the non-fallback path too
+        result.NetSaved.Should().Be(result.MonthlyIncome - result.MonthlyExpenses);
+        result.NetSaved.Should().Be(750m);
+
+        var expectedSavingsRate = Math.Round((result.NetSaved / result.MonthlyIncome) * 100, 0);
+        result.SavingsRate.Should().Be(expectedSavingsRate);
+    }
+}

--- a/tests/MyMascada.Tests.Unit/Queries/GetDashboardSummaryQueryHandlerTests.cs
+++ b/tests/MyMascada.Tests.Unit/Queries/GetDashboardSummaryQueryHandlerTests.cs
@@ -30,15 +30,15 @@ public class GetDashboardSummaryQueryHandlerTests
         _handler = new GetDashboardSummaryQueryHandler(_accountRepository, _transactionRepository);
     }
 
+    // Returns the first day (UTC midnight) of the month that contains the given date.
+    private static DateTime MonthStart(DateTime date) =>
+        new(date.Year, date.Month, 1, 0, 0, 0, DateTimeKind.Utc);
+
     [Fact]
     public async Task Handle_WhenCurrentMonthEmpty_FallsBackAndKeepsDisplayedFiguresConsistent()
     {
         // Arrange
         var userId = Guid.NewGuid();
-        var now = DateTimeProvider.UtcNow;
-
-        var currentMonthStart = new DateTime(now.Year, now.Month, 1, 0, 0, 0, DateTimeKind.Utc);
-        var fallbackMonthStart = currentMonthStart.AddMonths(-1);
 
         _accountRepository.GetByUserIdAsync(userId).Returns(new List<Account>());
         _transactionRepository.GetAccountBalancesAsync(userId)
@@ -46,30 +46,31 @@ public class GetDashboardSummaryQueryHandlerTests
         _transactionRepository.GetRecentAsync(userId, 5).Returns(new List<Transaction>());
         _transactionRepository.GetCountByUserIdAsync(userId).Returns(2);
 
-        // Fallback (previous) month has income 2000 and expenses 573 => netSaved 1427.
-        var fallbackTransactions = new List<Transaction>
-        {
-            new() { Id = 1, AccountId = 1, Amount = 2000m, TransactionDate = fallbackMonthStart.AddDays(2), Description = "Salary" },
-            new() { Id = 2, AccountId = 1, Amount = -573m, TransactionDate = fallbackMonthStart.AddDays(5), Description = "Rent" },
-        };
-
-        // Route repository calls by the start date the handler passes in:
-        //  - current month start  => empty (triggers fallback)
-        //  - fallback month start  => the populated fallback transactions
-        //  - any other range (3-month averages) => empty
+        // Route repository calls relative to the start date the handler passes in,
+        // derived from that argument (not from a separately captured "now"), so the
+        // test is deterministic even if the clock crosses a month boundary mid-test:
+        //  - the current month (start == this month's 1st) => empty (triggers fallback)
+        //  - the immediately preceding month               => populated fallback data
+        //  - any other range (3-month averages)            => empty
+        // The fallback month has income 2000 and expenses 573 => netSaved 1427.
         _transactionRepository
             .GetByDateRangeAsync(userId, Arg.Any<DateTime>(), Arg.Any<DateTime>())
             .Returns(callInfo =>
             {
                 var start = callInfo.ArgAt<DateTime>(1);
-                if (start == currentMonthStart)
-                {
-                    return Task.FromResult<IEnumerable<Transaction>>(new List<Transaction>());
-                }
+                var currentMonthStart = MonthStart(DateTimeProvider.UtcNow);
+                var fallbackMonthStart = currentMonthStart.AddMonths(-1);
+
                 if (start == fallbackMonthStart)
                 {
+                    var fallbackTransactions = new List<Transaction>
+                    {
+                        new() { Id = 1, AccountId = 1, Amount = 2000m, TransactionDate = fallbackMonthStart.AddDays(2), Description = "Salary" },
+                        new() { Id = 2, AccountId = 1, Amount = -573m, TransactionDate = fallbackMonthStart.AddDays(5), Description = "Rent" },
+                    };
                     return Task.FromResult<IEnumerable<Transaction>>(fallbackTransactions);
                 }
+
                 return Task.FromResult<IEnumerable<Transaction>>(new List<Transaction>());
             });
 
@@ -79,9 +80,10 @@ public class GetDashboardSummaryQueryHandlerTests
         var result = await _handler.Handle(query, CancellationToken.None);
 
         // Assert — fallback engaged and pointing at the previous month
+        var expectedFallback = MonthStart(DateTimeProvider.UtcNow).AddMonths(-1);
         result.IsUsingFallbackMonth.Should().BeTrue("the current month has no non-transfer transactions");
-        result.DisplayMonth.Should().Be(fallbackMonthStart.Month);
-        result.DisplayYear.Should().Be(fallbackMonthStart.Year);
+        result.DisplayMonth.Should().Be(expectedFallback.Month);
+        result.DisplayYear.Should().Be(expectedFallback.Year);
 
         // Assert — displayed figures come from the fallback month, not the empty current month
         result.MonthlyIncome.Should().Be(2000m);
@@ -101,8 +103,6 @@ public class GetDashboardSummaryQueryHandlerTests
     {
         // Arrange
         var userId = Guid.NewGuid();
-        var now = DateTimeProvider.UtcNow;
-        var currentMonthStart = new DateTime(now.Year, now.Month, 1, 0, 0, 0, DateTimeKind.Utc);
 
         _accountRepository.GetByUserIdAsync(userId).Returns(new List<Account>());
         _transactionRepository.GetAccountBalancesAsync(userId)
@@ -110,21 +110,26 @@ public class GetDashboardSummaryQueryHandlerTests
         _transactionRepository.GetRecentAsync(userId, 5).Returns(new List<Transaction>());
         _transactionRepository.GetCountByUserIdAsync(userId).Returns(2);
 
-        var currentTransactions = new List<Transaction>
-        {
-            new() { Id = 1, AccountId = 1, Amount = 1000m, TransactionDate = now, Description = "Salary" },
-            new() { Id = 2, AccountId = 1, Amount = -250m, TransactionDate = now, Description = "Groceries" },
-        };
-
+        // Populate the current month (income 1000, expenses 250). Routing is derived
+        // from the start argument relative to the current month, so it stays
+        // deterministic across a month boundary.
         _transactionRepository
             .GetByDateRangeAsync(userId, Arg.Any<DateTime>(), Arg.Any<DateTime>())
             .Returns(callInfo =>
             {
                 var start = callInfo.ArgAt<DateTime>(1);
+                var currentMonthStart = MonthStart(DateTimeProvider.UtcNow);
+
                 if (start == currentMonthStart)
                 {
+                    var currentTransactions = new List<Transaction>
+                    {
+                        new() { Id = 1, AccountId = 1, Amount = 1000m, TransactionDate = currentMonthStart.AddDays(1), Description = "Salary" },
+                        new() { Id = 2, AccountId = 1, Amount = -250m, TransactionDate = currentMonthStart.AddDays(1), Description = "Groceries" },
+                    };
                     return Task.FromResult<IEnumerable<Transaction>>(currentTransactions);
                 }
+
                 return Task.FromResult<IEnumerable<Transaction>>(new List<Transaction>());
             });
 
@@ -134,9 +139,10 @@ public class GetDashboardSummaryQueryHandlerTests
         var result = await _handler.Handle(query, CancellationToken.None);
 
         // Assert
+        var expectedCurrent = MonthStart(DateTimeProvider.UtcNow);
         result.IsUsingFallbackMonth.Should().BeFalse("the current month has non-transfer transactions");
-        result.DisplayMonth.Should().Be(now.Month);
-        result.DisplayYear.Should().Be(now.Year);
+        result.DisplayMonth.Should().Be(expectedCurrent.Month);
+        result.DisplayYear.Should().Be(expectedCurrent.Year);
 
         result.MonthlyIncome.Should().Be(1000m);
         result.MonthlyExpenses.Should().Be(250m);


### PR DESCRIPTION
## The bug

The dashboard summary endpoint (`GET /api/v1/reports/dashboard-summary`, built by `GetDashboardSummaryQueryHandler`) returned **internally inconsistent** figures when the current month has no transactions and the API falls back to showing a previous month.

Observed in the mobile app's "Insights" card and reproduced against the local backend:

```
monthlyIncome:  0
monthlyExpenses: 0       <- displayed (fallback) period
netSaved:       1427.46  <- derived from 3-month AVERAGES
savingsRate:    41        <- derived from 3-month AVERAGES
isUsingFallbackMonth: true
displayMonth/Year: 5 / 2026
```

Some fields described the displayed period while `netSaved`/`savingsRate` came from a different basis, so the card contradicted itself.

## Root cause

In `src/Core/MyMascada.Application/Features/Reports/Queries/GetDashboardSummaryQuery.cs`, `netSaved` and `savingsRate` were computed from the **3-month rolling averages** (`avgMonthlyIncome`/`avgMonthlyExpenses`) rather than from the displayed-period `monthlyIncome`/`monthlyExpenses`. The displayed-period income/expenses correctly switch to the fallback month, but the derived savings figures did not.

## The fix

Derive `netSaved` and `savingsRate` from the displayed-period `monthlyIncome`/`monthlyExpenses`, so every displayed-period field describes the same month (current or fallback):

- `netSaved = monthlyIncome - monthlyExpenses`
- `savingsRate = monthlyIncome > 0 ? round(netSaved / monthlyIncome * 100) : 0`

The 3-month rolling averages (`avgMonthlyIncome`, `avgMonthlyExpenses`) and `runwayMonths` remain intentionally separate — their meaning is unchanged.

## How it was verified

**Live backend** (`http://localhost:5126`, fixed build):

| Field | Before | After |
| --- | --- | --- |
| monthlyIncome | 0 | 0 |
| monthlyExpenses | 0 | 0 |
| netSaved | **1427.46** | **0** |
| savingsRate | **41** | **0** |
| avgMonthlyIncome | 3500.0 | 3500.0 |
| avgMonthlyExpenses | 2072.54 | 2072.54 |

After the fix `netSaved == monthlyIncome - monthlyExpenses` holds and `savingsRate` is consistent with the displayed period, while the 3-month averages are untouched.

**Regression tests** added in `tests/MyMascada.Tests.Unit/Queries/GetDashboardSummaryQueryHandlerTests.cs`:
- Fallback-month path: current month empty, fallback month has income 2000 / expenses 573 -> asserts `netSaved == 1427` and `savingsRate` derived from those displayed figures.
- Normal current-month path: asserts the same invariant.

**Test suite:** `dotnet test tests/MyMascada.Tests.Unit` -> all 1092 tests pass. `dotnet build` clean (no new warnings).

Backend-only change; no UI files touched, so no screenshots.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed dashboard savings metrics calculation to use displayed month figures instead of rolling averages, ensuring consistency across net saved and savings rate calculations
  * Improved fallback behavior when the current month has no non-transfer transactions by properly using previous month data

<!-- end of auto-generated comment: release notes by coderabbit.ai -->