### PR TITLE
feat: mobile push notification pipeline (device registry + FCM sending)

### DIFF
--- a/docs/push-notifications.md
+++ b/docs/push-notifications.md
@@ -7,7 +7,7 @@ existing in-app notification system — every push corresponds to an in-app
 
 ## Architecture
 
-```
+```text
 NotificationService.CreateNotificationAsync
   ├─ preference / quiet-hours / rate-limit checks (existing)
   ├─ creates in-app Notification row (existing)
@@ -18,7 +18,8 @@ NotificationService.CreateNotificationAsync
        └─ IPushNotificationService (FirebasePushNotificationService)
             ├─ loads the user's devices (UserDevices table)
             ├─ IFcmClient (FirebaseFcmClient) — FirebaseAdmin SDK multicast send
-            └─ prunes tokens FCM reports as Unregistered/InvalidArgument
+            └─ prunes tokens FCM reports as Unregistered (and only Unregistered —
+                InvalidArgument can mean a malformed message, not a bad token)
 ```
 
 ## Device registration API
@@ -69,6 +70,16 @@ Per-type push toggles reuse the existing `NotificationPreference.ChannelPreferen
 JSON (`{ "BudgetExceeded": { "inApp": true, "push": false }, ... }`). Push is
 enabled by default and skipped only when explicitly set to `false`. Quiet hours
 and rate limits apply before any channel dispatch, so they cover push too.
+
+## Known limitations
+
+- **No "push only" mode.** Every push corresponds to an in-app `Notification`
+  row (the push payload deep-links to it via `notificationId`), so disabling
+  `inApp` for a type also suppresses push for that type. Supporting push
+  without an in-app row would require a separate content/deep-link path and is
+  deliberately out of scope for this iteration.
+- Push dispatch is awaited inline (single FCM multicast HTTP call, fail-soft).
+  Offloading to a background queue is a possible future optimization.
 
 ## Localization caveat
 

--- a/docs/push-notifications.md
+++ b/docs/push-notifications.md
@@ -1,0 +1,79 @@
+# Mobile Push Notifications (FCM)
+
+The backend delivers push notifications to the MyMascada mobile app via Firebase
+Cloud Messaging. Push is an additional delivery channel layered on top of the
+existing in-app notification system — every push corresponds to an in-app
+`Notification` row created through `INotificationService.CreateNotificationAsync`.
+
+## Architecture
+
+```
+NotificationService.CreateNotificationAsync
+  ├─ preference / quiet-hours / rate-limit checks (existing)
+  ├─ creates in-app Notification row (existing)
+  └─ push dispatch (new, fail-soft)
+       ├─ skipped when ChannelPreferences[type].push == false
+       ├─ PushContentFormatter — expands i18n template keys to English copy,
+       │   builds data payload with a mobile "route" hint
+       └─ IPushNotificationService (FirebasePushNotificationService)
+            ├─ loads the user's devices (UserDevices table)
+            ├─ IFcmClient (FirebaseFcmClient) — FirebaseAdmin SDK multicast send
+            └─ prunes tokens FCM reports as Unregistered/InvalidArgument
+```
+
+## Device registration API
+
+| Endpoint | Description |
+|---|---|
+| `POST /api/v1/devices` `{ "token": "<fcm token>", "platform": "ios"\|"android" }` | Idempotent upsert. Re-registering refreshes `LastSeenAt`; a token previously owned by another user is reassigned. Auth required. |
+| `DELETE /api/v1/devices/{token}` | Unregister on logout. Idempotent, only removes tokens owned by the caller. |
+
+The mobile app should call `POST /api/v1/devices` after login and on every
+`onTokenRefresh` callback, and `DELETE /api/v1/devices/{token}` on logout.
+
+## Data payload (deep linking)
+
+Each push carries a data payload consumed by the mobile tap handler
+(`lib/core/services/notification_service.dart`):
+
+- `route` — GoRouter path the app navigates to (e.g. `/transactions`,
+  `/dashboard/budgets`, `/dashboard/rules/suggestions`)
+- `notificationId` — the in-app notification id
+- `notificationType` — e.g. `BudgetExceeded`
+
+## Configuration
+
+Firebase credentials are resolved in this order (first match wins):
+
+1. **`Firebase:ServiceAccountJson`** configuration value — env var
+   **`Firebase__ServiceAccountJson`**. Accepts either the raw Firebase service
+   account JSON or a path to the JSON file. On fly.io:
+
+   ```bash
+   fly secrets set Firebase__ServiceAccountJson="$(cat service-account.json)"
+   ```
+
+2. **`GOOGLE_APPLICATION_CREDENTIALS`** env var pointing at the service account
+   JSON file (standard Google application-default credentials).
+
+When neither is set the service is **fail-soft**: a warning is logged once and
+push delivery is skipped, so development environments work without Firebase.
+
+The service account is created in the Firebase console for the same Firebase
+project the mobile app's `google-services.json` / `GoogleService-Info.plist`
+belong to (Project settings → Service accounts → Generate new private key).
+
+## User preferences
+
+Per-type push toggles reuse the existing `NotificationPreference.ChannelPreferences`
+JSON (`{ "BudgetExceeded": { "inApp": true, "push": false }, ... }`). Push is
+enabled by default and skipped only when explicitly set to `false`. Quiet hours
+and rate limits apply before any channel dispatch, so they cover push too.
+
+## Localization caveat
+
+Trigger-generated notifications store i18n template keys instead of copy
+(`CategorizationReminder`, `TransactionReminder`, `RuleSuggestionsAvailable`).
+`PushContentFormatter` expands these to English at send time because the OS
+renders the push body. Localized push copy would require data-only messages
+rendered client-side — not implemented.

--- a/docs/push-notifications.md
+++ b/docs/push-notifications.md
@@ -26,10 +26,10 @@ NotificationService.CreateNotificationAsync
 | Endpoint | Description |
 |---|---|
 | `POST /api/v1/devices` `{ "token": "<fcm token>", "platform": "ios"\|"android" }` | Idempotent upsert. Re-registering refreshes `LastSeenAt`; a token previously owned by another user is reassigned. Auth required. |
-| `DELETE /api/v1/devices/{token}` | Unregister on logout. Idempotent, only removes tokens owned by the caller. |
+| `DELETE /api/v1/devices` `{ "token": "<fcm token>" }` | Unregister on logout. Idempotent, only removes tokens owned by the caller. The token travels in the request body so it never appears in URL/edge-proxy logs. |
 
 The mobile app should call `POST /api/v1/devices` after login and on every
-`onTokenRefresh` callback, and `DELETE /api/v1/devices/{token}` on logout.
+`onTokenRefresh` callback, and `DELETE /api/v1/devices` (token in body) on logout.
 
 ## Data payload (deep linking)
 

--- a/src/Core/MyMascada.Application/Common/Interfaces/IPushNotificationService.cs
+++ b/src/Core/MyMascada.Application/Common/Interfaces/IPushNotificationService.cs
@@ -1,0 +1,23 @@
+namespace MyMascada.Application.Common.Interfaces;
+
+public interface IPushNotificationService
+{
+    /// <summary>
+    /// Sends a push notification to all devices registered for the user.
+    /// Fail-soft: logs and returns without throwing when push is not configured
+    /// or delivery fails. Tokens reported as unregistered by FCM are pruned.
+    /// </summary>
+    /// <param name="userId">Target user.</param>
+    /// <param name="title">Human-readable notification title.</param>
+    /// <param name="body">Human-readable notification body.</param>
+    /// <param name="data">
+    /// Data payload delivered to the app. The mobile client navigates using the
+    /// "route" key (an app route path such as "/transactions").
+    /// </param>
+    Task SendToUserAsync(
+        Guid userId,
+        string title,
+        string body,
+        IReadOnlyDictionary<string, string>? data = null,
+        CancellationToken cancellationToken = default);
+}

--- a/src/Core/MyMascada.Application/Common/Interfaces/IPushNotificationService.cs
+++ b/src/Core/MyMascada.Application/Common/Interfaces/IPushNotificationService.cs
@@ -5,7 +5,8 @@ public interface IPushNotificationService
     /// <summary>
     /// Sends a push notification to all devices registered for the user.
     /// Fail-soft: logs and returns without throwing when push is not configured
-    /// or delivery fails. Tokens reported as unregistered by FCM are pruned.
+    /// or delivery fails — only <see cref="OperationCanceledException"/> for the
+    /// caller's token propagates. Tokens reported as unregistered by FCM are pruned.
     /// </summary>
     /// <param name="userId">Target user.</param>
     /// <param name="title">Human-readable notification title.</param>

--- a/src/Core/MyMascada.Application/Common/Interfaces/IUserDataDeletionService.cs
+++ b/src/Core/MyMascada.Application/Common/Interfaces/IUserDataDeletionService.cs
@@ -37,6 +37,7 @@ public class UserDeletionResultDto
     public int ChatMessagesDeleted { get; set; }
     public int NotificationsDeleted { get; set; }
     public int NotificationPreferencesDeleted { get; set; }
+    public int UserDevicesDeleted { get; set; }
     public int DashboardNudgeDismissalsDeleted { get; set; }
     public int BankCategoryMappingsDeleted { get; set; }
     public int DuplicateExclusionsDeleted { get; set; }

--- a/src/Core/MyMascada.Application/Common/Interfaces/IUserDeviceRepository.cs
+++ b/src/Core/MyMascada.Application/Common/Interfaces/IUserDeviceRepository.cs
@@ -1,0 +1,27 @@
+using MyMascada.Domain.Entities;
+
+namespace MyMascada.Application.Common.Interfaces;
+
+public interface IUserDeviceRepository
+{
+    /// <summary>
+    /// Idempotently registers a device token for a user. If the token already exists
+    /// (for this or another user) the row is updated/reassigned and LastSeenAt refreshed.
+    /// </summary>
+    Task<UserDevice> UpsertAsync(Guid userId, string fcmToken, string platform, CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// Removes a device token registration owned by the given user. No-op if not found.
+    /// </summary>
+    Task DeleteByTokenAsync(Guid userId, string fcmToken, CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// Returns all active (non-deleted) devices registered for the user.
+    /// </summary>
+    Task<List<UserDevice>> GetByUserIdAsync(Guid userId, CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// Removes device rows for tokens FCM reported as no longer valid (unregistered).
+    /// </summary>
+    Task RemoveTokensAsync(IReadOnlyCollection<string> fcmTokens, CancellationToken cancellationToken = default);
+}

--- a/src/Core/MyMascada.Application/Features/Devices/Commands/RegisterDeviceCommand.cs
+++ b/src/Core/MyMascada.Application/Features/Devices/Commands/RegisterDeviceCommand.cs
@@ -1,0 +1,53 @@
+using MediatR;
+using MyMascada.Application.Common.Interfaces;
+using MyMascada.Application.Features.Devices.DTOs;
+
+namespace MyMascada.Application.Features.Devices.Commands;
+
+/// <summary>
+/// Idempotently registers (upserts) an FCM device token for push notifications.
+/// </summary>
+public class RegisterDeviceCommand : IRequest<DeviceDto>
+{
+    public Guid UserId { get; set; }
+    public string Token { get; set; } = string.Empty;
+    public string Platform { get; set; } = string.Empty;
+}
+
+public class RegisterDeviceCommandHandler : IRequestHandler<RegisterDeviceCommand, DeviceDto>
+{
+    /// <summary>FCM tokens are well under this; guards the DB column limit.</summary>
+    public const int MaxTokenLength = 512;
+    public const int MaxPlatformLength = 20;
+
+    private static readonly string[] AllowedPlatforms = { "ios", "android" };
+
+    private readonly IUserDeviceRepository _repository;
+
+    public RegisterDeviceCommandHandler(IUserDeviceRepository repository)
+    {
+        _repository = repository;
+    }
+
+    public async Task<DeviceDto> Handle(RegisterDeviceCommand request, CancellationToken cancellationToken)
+    {
+        var token = request.Token?.Trim() ?? string.Empty;
+        if (string.IsNullOrEmpty(token))
+            throw new ArgumentException("Device token is required.", nameof(request));
+        if (token.Length > MaxTokenLength)
+            throw new ArgumentException($"Device token exceeds maximum length of {MaxTokenLength}.", nameof(request));
+
+        var platform = request.Platform?.Trim().ToLowerInvariant() ?? string.Empty;
+        if (string.IsNullOrEmpty(platform) || platform.Length > MaxPlatformLength || !AllowedPlatforms.Contains(platform))
+            throw new ArgumentException("Platform must be one of: ios, android.", nameof(request));
+
+        var device = await _repository.UpsertAsync(request.UserId, token, platform, cancellationToken);
+
+        return new DeviceDto
+        {
+            Id = device.Id,
+            Platform = device.Platform,
+            LastSeenAt = device.LastSeenAt
+        };
+    }
+}

--- a/src/Core/MyMascada.Application/Features/Devices/Commands/UnregisterDeviceCommand.cs
+++ b/src/Core/MyMascada.Application/Features/Devices/Commands/UnregisterDeviceCommand.cs
@@ -1,0 +1,33 @@
+using MediatR;
+using MyMascada.Application.Common.Interfaces;
+
+namespace MyMascada.Application.Features.Devices.Commands;
+
+/// <summary>
+/// Removes an FCM device token registration (e.g. on logout). Idempotent —
+/// succeeds even if the token is not registered.
+/// </summary>
+public class UnregisterDeviceCommand : IRequest
+{
+    public Guid UserId { get; set; }
+    public string Token { get; set; } = string.Empty;
+}
+
+public class UnregisterDeviceCommandHandler : IRequestHandler<UnregisterDeviceCommand>
+{
+    private readonly IUserDeviceRepository _repository;
+
+    public UnregisterDeviceCommandHandler(IUserDeviceRepository repository)
+    {
+        _repository = repository;
+    }
+
+    public async Task Handle(UnregisterDeviceCommand request, CancellationToken cancellationToken)
+    {
+        var token = request.Token?.Trim() ?? string.Empty;
+        if (string.IsNullOrEmpty(token))
+            throw new ArgumentException("Device token is required.", nameof(request));
+
+        await _repository.DeleteByTokenAsync(request.UserId, token, cancellationToken);
+    }
+}

--- a/src/Core/MyMascada.Application/Features/Devices/DTOs/DeviceDtos.cs
+++ b/src/Core/MyMascada.Application/Features/Devices/DTOs/DeviceDtos.cs
@@ -9,6 +9,15 @@ public class RegisterDeviceRequest
     public string Platform { get; set; } = string.Empty;
 }
 
+public class UnregisterDeviceRequest
+{
+    /// <summary>
+    /// Firebase Cloud Messaging registration token to remove. Sent in the body
+    /// (not the URL) so the token never appears in edge/proxy request logs.
+    /// </summary>
+    public string Token { get; set; } = string.Empty;
+}
+
 public class DeviceDto
 {
     public Guid Id { get; set; }

--- a/src/Core/MyMascada.Application/Features/Devices/DTOs/DeviceDtos.cs
+++ b/src/Core/MyMascada.Application/Features/Devices/DTOs/DeviceDtos.cs
@@ -1,0 +1,17 @@
+namespace MyMascada.Application.Features.Devices.DTOs;
+
+public class RegisterDeviceRequest
+{
+    /// <summary>Firebase Cloud Messaging registration token.</summary>
+    public string Token { get; set; } = string.Empty;
+
+    /// <summary>Device platform, e.g. "ios" or "android".</summary>
+    public string Platform { get; set; } = string.Empty;
+}
+
+public class DeviceDto
+{
+    public Guid Id { get; set; }
+    public string Platform { get; set; } = string.Empty;
+    public DateTime LastSeenAt { get; set; }
+}

--- a/src/Core/MyMascada.Domain/Entities/UserDevice.cs
+++ b/src/Core/MyMascada.Domain/Entities/UserDevice.cs
@@ -1,0 +1,29 @@
+using MyMascada.Domain.Common;
+
+namespace MyMascada.Domain.Entities;
+
+/// <summary>
+/// A mobile device registered for push notifications via Firebase Cloud Messaging.
+/// One row per FCM token; a user may have multiple devices.
+/// </summary>
+public class UserDevice : BaseEntity<Guid>
+{
+    public Guid UserId { get; set; }
+
+    /// <summary>
+    /// Firebase Cloud Messaging registration token. Globally unique —
+    /// if a different user logs in on the same device the row is reassigned.
+    /// </summary>
+    public string FcmToken { get; set; } = string.Empty;
+
+    /// <summary>
+    /// Device platform, e.g. "ios" or "android".
+    /// </summary>
+    public string Platform { get; set; } = string.Empty;
+
+    /// <summary>
+    /// UTC timestamp of the last registration ping from this device.
+    /// Used to expire stale device registrations.
+    /// </summary>
+    public DateTime LastSeenAt { get; set; } = DateTime.UtcNow;
+}

--- a/src/Infrastructure/MyMascada.Infrastructure/Data/ApplicationDbContext.cs
+++ b/src/Infrastructure/MyMascada.Infrastructure/Data/ApplicationDbContext.cs
@@ -55,6 +55,7 @@ public class ApplicationDbContext : DbContext
     public DbSet<UserSubscription> UserSubscriptions => Set<UserSubscription>();
     public DbSet<Notification> Notifications => Set<Notification>();
     public DbSet<NotificationPreference> NotificationPreferences => Set<NotificationPreference>();
+    public DbSet<UserDevice> UserDevices => Set<UserDevice>();
     public DbSet<CategorizationHistory> CategorizationHistories => Set<CategorizationHistory>();
     public DbSet<AiCategorizationUsage> AiCategorizationUsages => Set<AiCategorizationUsage>();
 
@@ -1024,6 +1025,26 @@ public class ApplicationDbContext : DbContext
 
             // One preference record per user
             entity.HasIndex(e => e.UserId).IsUnique();
+
+            entity.HasQueryFilter(e => !e.IsDeleted);
+        });
+
+        // UserDevice configuration (FCM push notification device registry)
+        modelBuilder.Entity<UserDevice>(entity =>
+        {
+            entity.HasKey(e => e.Id);
+            entity.Property(e => e.UserId).IsRequired();
+            entity.HasOne<User>()
+                .WithMany()
+                .HasForeignKey(e => e.UserId)
+                .OnDelete(DeleteBehavior.Cascade);
+            entity.Property(e => e.FcmToken).IsRequired().HasMaxLength(512);
+            entity.Property(e => e.Platform).IsRequired().HasMaxLength(20);
+            entity.Property(e => e.LastSeenAt).IsRequired();
+
+            // One row per FCM token regardless of user — registration reassigns ownership.
+            entity.HasIndex(e => e.FcmToken).IsUnique();
+            entity.HasIndex(e => e.UserId);
 
             entity.HasQueryFilter(e => !e.IsDeleted);
         });

--- a/src/Infrastructure/MyMascada.Infrastructure/MyMascada.Infrastructure.csproj
+++ b/src/Infrastructure/MyMascada.Infrastructure/MyMascada.Infrastructure.csproj
@@ -6,6 +6,7 @@
 
   <ItemGroup>
     <PackageReference Include="CsvHelper" Version="33.1.0" />
+    <PackageReference Include="FirebaseAdmin" Version="3.5.0" />
     <PackageReference Include="Npgsql" Version="10.0.2" />
     <PackageReference Include="Google.Apis.Auth" Version="1.73.0" />
     <PackageReference Include="Hangfire.Core" Version="1.8.23" />

--- a/src/Infrastructure/MyMascada.Infrastructure/Repositories/UserDeviceRepository.cs
+++ b/src/Infrastructure/MyMascada.Infrastructure/Repositories/UserDeviceRepository.cs
@@ -48,7 +48,15 @@ public class UserDeviceRepository : IUserDeviceRepository
                 _context.Entry(device).State = EntityState.Detached;
                 existing = await _context.UserDevices
                     .IgnoreQueryFilters()
-                    .FirstAsync(d => d.FcmToken == fcmToken, cancellationToken);
+                    .FirstOrDefaultAsync(d => d.FcmToken == fcmToken, cancellationToken);
+
+                // No winner row means the failure was NOT the FcmToken unique index
+                // (e.g. FK violation, connection drop). Rethrow the original exception
+                // instead of masking it with "sequence contains no elements".
+                if (existing == null)
+                {
+                    throw;
+                }
             }
         }
 

--- a/src/Infrastructure/MyMascada.Infrastructure/Repositories/UserDeviceRepository.cs
+++ b/src/Infrastructure/MyMascada.Infrastructure/Repositories/UserDeviceRepository.cs
@@ -33,8 +33,23 @@ public class UserDeviceRepository : IUserDeviceRepository
                 LastSeenAt = DateTime.UtcNow
             };
             _context.UserDevices.Add(device);
-            await _context.SaveChangesAsync(cancellationToken);
-            return device;
+
+            try
+            {
+                await _context.SaveChangesAsync(cancellationToken);
+                return device;
+            }
+            catch (DbUpdateException)
+            {
+                // Concurrent first registration of the same token (the mobile client
+                // races login registration against onTokenRefresh) lost to the unique
+                // index on FcmToken. Fall through to update the winner's row so the
+                // operation stays idempotent.
+                _context.Entry(device).State = EntityState.Detached;
+                existing = await _context.UserDevices
+                    .IgnoreQueryFilters()
+                    .FirstAsync(d => d.FcmToken == fcmToken, cancellationToken);
+            }
         }
 
         // Reassign if a different user logged in on the same device, revive soft-deleted rows.

--- a/src/Infrastructure/MyMascada.Infrastructure/Repositories/UserDeviceRepository.cs
+++ b/src/Infrastructure/MyMascada.Infrastructure/Repositories/UserDeviceRepository.cs
@@ -1,0 +1,92 @@
+using Microsoft.EntityFrameworkCore;
+using MyMascada.Application.Common.Interfaces;
+using MyMascada.Domain.Entities;
+using MyMascada.Infrastructure.Data;
+
+namespace MyMascada.Infrastructure.Repositories;
+
+public class UserDeviceRepository : IUserDeviceRepository
+{
+    private readonly ApplicationDbContext _context;
+
+    public UserDeviceRepository(ApplicationDbContext context)
+    {
+        _context = context;
+    }
+
+    public async Task<UserDevice> UpsertAsync(Guid userId, string fcmToken, string platform, CancellationToken cancellationToken = default)
+    {
+        // FcmToken has a unique index; use IgnoreQueryFilters so a soft-deleted row
+        // does not block re-registration of the same token.
+        var existing = await _context.UserDevices
+            .IgnoreQueryFilters()
+            .FirstOrDefaultAsync(d => d.FcmToken == fcmToken, cancellationToken);
+
+        if (existing == null)
+        {
+            var device = new UserDevice
+            {
+                Id = Guid.NewGuid(),
+                UserId = userId,
+                FcmToken = fcmToken,
+                Platform = platform,
+                LastSeenAt = DateTime.UtcNow
+            };
+            _context.UserDevices.Add(device);
+            await _context.SaveChangesAsync(cancellationToken);
+            return device;
+        }
+
+        // Reassign if a different user logged in on the same device, revive soft-deleted rows.
+        existing.UserId = userId;
+        existing.Platform = platform;
+        existing.LastSeenAt = DateTime.UtcNow;
+        existing.IsDeleted = false;
+        existing.DeletedAt = null;
+        existing.UpdatedAt = DateTime.UtcNow;
+        await _context.SaveChangesAsync(cancellationToken);
+        return existing;
+    }
+
+    public async Task DeleteByTokenAsync(Guid userId, string fcmToken, CancellationToken cancellationToken = default)
+    {
+        var device = await _context.UserDevices
+            .FirstOrDefaultAsync(d => d.UserId == userId && d.FcmToken == fcmToken, cancellationToken);
+
+        if (device == null)
+            return;
+
+        device.IsDeleted = true;
+        device.DeletedAt = DateTime.UtcNow;
+        device.UpdatedAt = DateTime.UtcNow;
+        await _context.SaveChangesAsync(cancellationToken);
+    }
+
+    public async Task<List<UserDevice>> GetByUserIdAsync(Guid userId, CancellationToken cancellationToken = default)
+    {
+        return await _context.UserDevices
+            .Where(d => d.UserId == userId)
+            .OrderByDescending(d => d.LastSeenAt)
+            .ToListAsync(cancellationToken);
+    }
+
+    public async Task RemoveTokensAsync(IReadOnlyCollection<string> fcmTokens, CancellationToken cancellationToken = default)
+    {
+        if (fcmTokens.Count == 0)
+            return;
+
+        var devices = await _context.UserDevices
+            .Where(d => fcmTokens.Contains(d.FcmToken))
+            .ToListAsync(cancellationToken);
+
+        var now = DateTime.UtcNow;
+        foreach (var device in devices)
+        {
+            device.IsDeleted = true;
+            device.DeletedAt = now;
+            device.UpdatedAt = now;
+        }
+
+        await _context.SaveChangesAsync(cancellationToken);
+    }
+}

--- a/src/Infrastructure/MyMascada.Infrastructure/Services/Notifications/NotificationService.cs
+++ b/src/Infrastructure/MyMascada.Infrastructure/Services/Notifications/NotificationService.cs
@@ -2,6 +2,7 @@ using Microsoft.Extensions.Logging;
 using MyMascada.Application.Common.Interfaces;
 using MyMascada.Domain.Entities;
 using MyMascada.Domain.Enums;
+using MyMascada.Infrastructure.Services.Push;
 
 namespace MyMascada.Infrastructure.Services.Notifications;
 
@@ -9,6 +10,7 @@ public class NotificationService : INotificationService
 {
     private readonly INotificationRepository _notificationRepository;
     private readonly INotificationPreferenceRepository _preferenceRepository;
+    private readonly IPushNotificationService _pushNotificationService;
     private readonly ILogger<NotificationService> _logger;
 
     // Rate limit: max notifications per type per day
@@ -17,10 +19,12 @@ public class NotificationService : INotificationService
     public NotificationService(
         INotificationRepository notificationRepository,
         INotificationPreferenceRepository preferenceRepository,
+        IPushNotificationService pushNotificationService,
         ILogger<NotificationService> logger)
     {
         _notificationRepository = notificationRepository;
         _preferenceRepository = preferenceRepository;
+        _pushNotificationService = pushNotificationService;
         _logger = logger;
     }
 
@@ -78,27 +82,10 @@ public class NotificationService : INotificationService
             }
 
             // Enforce per-type channel preferences (inApp toggle)
-            if (preferences.ChannelPreferences != null)
+            if (IsChannelExplicitlyDisabled(preferences.ChannelPreferences, type, "inApp", userId))
             {
-                try
-                {
-                    var channelPrefs = System.Text.Json.JsonSerializer.Deserialize<Dictionary<string, System.Text.Json.JsonElement>>(
-                        preferences.ChannelPreferences);
-                    var typeName = type.ToString();
-                    if (channelPrefs != null &&
-                        channelPrefs.TryGetValue(typeName, out var typePrefs) &&
-                        typePrefs.ValueKind == System.Text.Json.JsonValueKind.Object &&
-                        typePrefs.TryGetProperty("inApp", out var inAppProp) &&
-                        inAppProp.ValueKind == System.Text.Json.JsonValueKind.False)
-                    {
-                        _logger.LogDebug("Skipping in-app notification for user {UserId}, type {Type} — disabled by user preference", userId, type);
-                        return;
-                    }
-                }
-                catch (System.Text.Json.JsonException ex)
-                {
-                    _logger.LogWarning(ex, "Failed to parse ChannelPreferences for user {UserId}; proceeding with notification delivery", userId);
-                }
+                _logger.LogDebug("Skipping in-app notification for user {UserId}, type {Type} — disabled by user preference", userId, type);
+                return;
             }
         }
 
@@ -126,6 +113,68 @@ public class NotificationService : INotificationService
 
         _logger.LogInformation("Created {Type} notification for user {UserId}", type, userId);
 
-        // Future: dispatch to other delivery channels (push, email, etc.) based on preferences
+        // Dispatch to push channel unless the user explicitly disabled push for this type.
+        // Push failures must never roll back the in-app notification, so this is fail-soft.
+        if (!IsChannelExplicitlyDisabled(preferences?.ChannelPreferences, type, "push", userId))
+        {
+            await TrySendPushAsync(created, cancellationToken);
+        }
+        else
+        {
+            _logger.LogDebug("Skipping push notification for user {UserId}, type {Type} — disabled by user preference", userId, type);
+        }
+    }
+
+    /// <summary>
+    /// Sends the push counterpart of an in-app notification to the user's registered
+    /// devices. Never throws — push delivery is best-effort.
+    /// </summary>
+    private async Task TrySendPushAsync(Notification notification, CancellationToken cancellationToken)
+    {
+        try
+        {
+            var (title, body) = PushContentFormatter.FormatContent(
+                notification.Title, notification.Body, notification.Data);
+            var data = PushContentFormatter.BuildDataPayload(notification.Type, notification.Id);
+
+            await _pushNotificationService.SendToUserAsync(
+                notification.UserId, title, body, data, cancellationToken);
+        }
+        catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)
+        {
+            throw;
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(ex, "Failed to send push notification {NotificationId} to user {UserId}",
+                notification.Id, notification.UserId);
+        }
+    }
+
+    /// <summary>
+    /// Returns true when the user's ChannelPreferences JSON explicitly disables the
+    /// given channel ("inApp"/"push"/"email") for the notification type.
+    /// Missing or malformed preferences default to enabled.
+    /// </summary>
+    private bool IsChannelExplicitlyDisabled(string? channelPreferencesJson, NotificationType type, string channel, Guid userId)
+    {
+        if (string.IsNullOrEmpty(channelPreferencesJson))
+            return false;
+
+        try
+        {
+            var channelPrefs = System.Text.Json.JsonSerializer.Deserialize<Dictionary<string, System.Text.Json.JsonElement>>(
+                channelPreferencesJson);
+            return channelPrefs != null &&
+                   channelPrefs.TryGetValue(type.ToString(), out var typePrefs) &&
+                   typePrefs.ValueKind == System.Text.Json.JsonValueKind.Object &&
+                   typePrefs.TryGetProperty(channel, out var channelProp) &&
+                   channelProp.ValueKind == System.Text.Json.JsonValueKind.False;
+        }
+        catch (System.Text.Json.JsonException ex)
+        {
+            _logger.LogWarning(ex, "Failed to parse ChannelPreferences for user {UserId}; proceeding with notification delivery", userId);
+            return false;
+        }
     }
 }

--- a/src/Infrastructure/MyMascada.Infrastructure/Services/Notifications/NotificationService.cs
+++ b/src/Infrastructure/MyMascada.Infrastructure/Services/Notifications/NotificationService.cs
@@ -81,10 +81,15 @@ public class NotificationService : INotificationService
                 }
             }
 
-            // Enforce per-type channel preferences (inApp toggle)
+            // Enforce per-type channel preferences (inApp toggle).
+            // KNOWN LIMITATION (intentional for this iteration): every push corresponds
+            // to an in-app Notification row — the push payload deep-links to it via
+            // notificationId — so disabling inApp for a type also suppresses push for
+            // that type. "Push only, no in-app" is not supported.
+            // See docs/push-notifications.md ("Known limitations").
             if (IsChannelExplicitlyDisabled(preferences.ChannelPreferences, type, "inApp", userId))
             {
-                _logger.LogDebug("Skipping in-app notification for user {UserId}, type {Type} — disabled by user preference", userId, type);
+                _logger.LogDebug("Skipping in-app notification (and its push counterpart) for user {UserId}, type {Type} — inApp disabled by user preference", userId, type);
                 return;
             }
         }

--- a/src/Infrastructure/MyMascada.Infrastructure/Services/Push/FirebaseFcmClient.cs
+++ b/src/Infrastructure/MyMascada.Infrastructure/Services/Push/FirebaseFcmClient.cs
@@ -1,0 +1,133 @@
+using FirebaseAdmin;
+using FirebaseAdmin.Messaging;
+using Google.Apis.Auth.OAuth2;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.Logging;
+
+namespace MyMascada.Infrastructure.Services.Push;
+
+/// <summary>
+/// FCM client backed by the FirebaseAdmin SDK.
+///
+/// Credential resolution (first match wins):
+/// 1. <c>Firebase:ServiceAccountJson</c> configuration value
+///    (env var <c>Firebase__ServiceAccountJson</c>) — either the raw service
+///    account JSON or a path to the JSON file.
+/// 2. <c>GOOGLE_APPLICATION_CREDENTIALS</c> env var pointing to the JSON file
+///    (standard Google application-default credentials).
+///
+/// When neither is configured the client is fail-soft: <see cref="IsConfigured"/>
+/// is false, a warning is logged once, and sends are skipped so development
+/// environments work without Firebase.
+/// </summary>
+public class FirebaseFcmClient : IFcmClient
+{
+    private readonly ILogger<FirebaseFcmClient> _logger;
+    private readonly Lazy<FirebaseMessaging?> _messaging;
+
+    public FirebaseFcmClient(IConfiguration configuration, ILogger<FirebaseFcmClient> logger)
+    {
+        _logger = logger;
+        _messaging = new Lazy<FirebaseMessaging?>(
+            () => InitializeMessaging(configuration),
+            LazyThreadSafetyMode.ExecutionAndPublication);
+    }
+
+    public bool IsConfigured => _messaging.Value != null;
+
+    public async Task<IReadOnlyList<FcmSendResult>> SendAsync(
+        IReadOnlyList<string> tokens,
+        string title,
+        string body,
+        IReadOnlyDictionary<string, string> data,
+        CancellationToken cancellationToken = default)
+    {
+        var messaging = _messaging.Value;
+        if (messaging == null || tokens.Count == 0)
+            return Array.Empty<FcmSendResult>();
+
+        var message = new MulticastMessage
+        {
+            Tokens = tokens.ToList(),
+            Notification = new Notification
+            {
+                Title = title,
+                Body = body
+            },
+            Data = data.ToDictionary(kv => kv.Key, kv => kv.Value)
+        };
+
+        var batchResponse = await messaging.SendEachForMulticastAsync(message, cancellationToken);
+
+        var results = new List<FcmSendResult>(tokens.Count);
+        for (var i = 0; i < tokens.Count; i++)
+        {
+            var response = batchResponse.Responses[i];
+            if (response.IsSuccess)
+            {
+                results.Add(new FcmSendResult { Token = tokens[i], Success = true });
+                continue;
+            }
+
+            var messagingError = (response.Exception as FirebaseMessagingException)?.MessagingErrorCode;
+            var isTokenInvalid = messagingError is MessagingErrorCode.Unregistered or MessagingErrorCode.InvalidArgument;
+            results.Add(new FcmSendResult
+            {
+                Token = tokens[i],
+                Success = false,
+                IsTokenInvalid = isTokenInvalid,
+                Error = response.Exception?.Message
+            });
+        }
+
+        return results;
+    }
+
+    private FirebaseMessaging? InitializeMessaging(IConfiguration configuration)
+    {
+        try
+        {
+            var credential = ResolveCredential(configuration);
+            if (credential == null)
+            {
+                _logger.LogWarning(
+                    "Firebase push notifications are not configured. Set Firebase__ServiceAccountJson " +
+                    "(raw service account JSON or a file path) or GOOGLE_APPLICATION_CREDENTIALS to enable push delivery.");
+                return null;
+            }
+
+            var app = FirebaseApp.DefaultInstance ?? FirebaseApp.Create(new AppOptions
+            {
+                Credential = credential
+            });
+
+            _logger.LogInformation("Firebase push notification client initialized");
+            return FirebaseMessaging.GetMessaging(app);
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(ex, "Failed to initialize Firebase push notification client. Push delivery is disabled");
+            return null;
+        }
+    }
+
+    private static GoogleCredential? ResolveCredential(IConfiguration configuration)
+    {
+        var serviceAccountJson = configuration["Firebase:ServiceAccountJson"];
+        if (!string.IsNullOrWhiteSpace(serviceAccountJson))
+        {
+            var trimmed = serviceAccountJson.Trim();
+            return trimmed.StartsWith('{')
+                ? GoogleCredential.FromJson(trimmed)
+                : GoogleCredential.FromFile(trimmed);
+        }
+
+        var defaultCredentialsPath = Environment.GetEnvironmentVariable("GOOGLE_APPLICATION_CREDENTIALS");
+        if (!string.IsNullOrWhiteSpace(defaultCredentialsPath) && File.Exists(defaultCredentialsPath))
+        {
+            return GoogleCredential.FromFile(defaultCredentialsPath);
+        }
+
+        return null;
+    }
+}

--- a/src/Infrastructure/MyMascada.Infrastructure/Services/Push/FirebaseFcmClient.cs
+++ b/src/Infrastructure/MyMascada.Infrastructure/Services/Push/FirebaseFcmClient.cs
@@ -69,8 +69,12 @@ public class FirebaseFcmClient : IFcmClient
                 continue;
             }
 
+            // Prune ONLY on Unregistered. InvalidArgument is ambiguous: FCM also returns
+            // INVALID_ARGUMENT for malformed *messages* (oversized payload, reserved data
+            // keys), so treating it as token-invalid would let a payload regression wipe
+            // every user's valid device registrations.
             var messagingError = (response.Exception as FirebaseMessagingException)?.MessagingErrorCode;
-            var isTokenInvalid = messagingError is MessagingErrorCode.Unregistered or MessagingErrorCode.InvalidArgument;
+            var isTokenInvalid = messagingError is MessagingErrorCode.Unregistered;
             results.Add(new FcmSendResult
             {
                 Token = tokens[i],

--- a/src/Infrastructure/MyMascada.Infrastructure/Services/Push/FirebaseFcmClient.cs
+++ b/src/Infrastructure/MyMascada.Infrastructure/Services/Push/FirebaseFcmClient.cs
@@ -22,6 +22,9 @@ namespace MyMascada.Infrastructure.Services.Push;
 /// </summary>
 public class FirebaseFcmClient : IFcmClient
 {
+    /// <summary>FCM rejects multicast requests with more than 500 tokens.</summary>
+    private const int MaxTokensPerMulticast = 500;
+
     private readonly ILogger<FirebaseFcmClient> _logger;
     private readonly Lazy<FirebaseMessaging?> _messaging;
 
@@ -46,42 +49,49 @@ public class FirebaseFcmClient : IFcmClient
         if (messaging == null || tokens.Count == 0)
             return Array.Empty<FcmSendResult>();
 
-        var message = new MulticastMessage
-        {
-            Tokens = tokens.ToList(),
-            Notification = new Notification
-            {
-                Title = title,
-                Body = body
-            },
-            Data = data.ToDictionary(kv => kv.Key, kv => kv.Value)
-        };
-
-        var batchResponse = await messaging.SendEachForMulticastAsync(message, cancellationToken);
-
+        var payload = data.ToDictionary(kv => kv.Key, kv => kv.Value);
         var results = new List<FcmSendResult>(tokens.Count);
-        for (var i = 0; i < tokens.Count; i++)
-        {
-            var response = batchResponse.Responses[i];
-            if (response.IsSuccess)
-            {
-                results.Add(new FcmSendResult { Token = tokens[i], Success = true });
-                continue;
-            }
 
-            // Prune ONLY on Unregistered. InvalidArgument is ambiguous: FCM also returns
-            // INVALID_ARGUMENT for malformed *messages* (oversized payload, reserved data
-            // keys), so treating it as token-invalid would let a payload regression wipe
-            // every user's valid device registrations.
-            var messagingError = (response.Exception as FirebaseMessagingException)?.MessagingErrorCode;
-            var isTokenInvalid = messagingError is MessagingErrorCode.Unregistered;
-            results.Add(new FcmSendResult
+        // FCM rejects multicast requests with more than 500 tokens, so send in chunks
+        // and aggregate the per-token results (still ordered to match `tokens`).
+        foreach (var chunk in tokens.Chunk(MaxTokensPerMulticast))
+        {
+            var message = new MulticastMessage
             {
-                Token = tokens[i],
-                Success = false,
-                IsTokenInvalid = isTokenInvalid,
-                Error = response.Exception?.Message
-            });
+                Tokens = chunk.ToList(),
+                Notification = new Notification
+                {
+                    Title = title,
+                    Body = body
+                },
+                Data = payload
+            };
+
+            var batchResponse = await messaging.SendEachForMulticastAsync(message, cancellationToken);
+
+            for (var i = 0; i < chunk.Length; i++)
+            {
+                var response = batchResponse.Responses[i];
+                if (response.IsSuccess)
+                {
+                    results.Add(new FcmSendResult { Token = chunk[i], Success = true });
+                    continue;
+                }
+
+                // Prune ONLY on Unregistered. InvalidArgument is ambiguous: FCM also returns
+                // INVALID_ARGUMENT for malformed *messages* (oversized payload, reserved data
+                // keys), so treating it as token-invalid would let a payload regression wipe
+                // every user's valid device registrations.
+                var messagingError = (response.Exception as FirebaseMessagingException)?.MessagingErrorCode;
+                var isTokenInvalid = messagingError is MessagingErrorCode.Unregistered;
+                results.Add(new FcmSendResult
+                {
+                    Token = chunk[i],
+                    Success = false,
+                    IsTokenInvalid = isTokenInvalid,
+                    Error = response.Exception?.Message
+                });
+            }
         }
 
         return results;

--- a/src/Infrastructure/MyMascada.Infrastructure/Services/Push/FirebasePushNotificationService.cs
+++ b/src/Infrastructure/MyMascada.Infrastructure/Services/Push/FirebasePushNotificationService.cs
@@ -30,6 +30,29 @@ public class FirebasePushNotificationService : IPushNotificationService
         IReadOnlyDictionary<string, string>? data = null,
         CancellationToken cancellationToken = default)
     {
+        // Push delivery is best-effort and must never break the calling flow
+        // (see IPushNotificationService contract). Only cancellation propagates.
+        try
+        {
+            await SendToUserCoreAsync(userId, title, body, data, cancellationToken);
+        }
+        catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)
+        {
+            throw;
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(ex, "Failed to send push notification to user {UserId}", userId);
+        }
+    }
+
+    private async Task SendToUserCoreAsync(
+        Guid userId,
+        string title,
+        string body,
+        IReadOnlyDictionary<string, string>? data,
+        CancellationToken cancellationToken)
+    {
         if (!_fcmClient.IsConfigured)
         {
             _logger.LogDebug("Skipping push for user {UserId} — Firebase is not configured", userId);

--- a/src/Infrastructure/MyMascada.Infrastructure/Services/Push/FirebasePushNotificationService.cs
+++ b/src/Infrastructure/MyMascada.Infrastructure/Services/Push/FirebasePushNotificationService.cs
@@ -1,0 +1,76 @@
+using Microsoft.Extensions.Logging;
+using MyMascada.Application.Common.Interfaces;
+
+namespace MyMascada.Infrastructure.Services.Push;
+
+/// <summary>
+/// Sends push notifications to all of a user's registered devices via FCM and
+/// prunes tokens that FCM reports as unregistered/invalid.
+/// </summary>
+public class FirebasePushNotificationService : IPushNotificationService
+{
+    private readonly IUserDeviceRepository _deviceRepository;
+    private readonly IFcmClient _fcmClient;
+    private readonly ILogger<FirebasePushNotificationService> _logger;
+
+    public FirebasePushNotificationService(
+        IUserDeviceRepository deviceRepository,
+        IFcmClient fcmClient,
+        ILogger<FirebasePushNotificationService> logger)
+    {
+        _deviceRepository = deviceRepository;
+        _fcmClient = fcmClient;
+        _logger = logger;
+    }
+
+    public async Task SendToUserAsync(
+        Guid userId,
+        string title,
+        string body,
+        IReadOnlyDictionary<string, string>? data = null,
+        CancellationToken cancellationToken = default)
+    {
+        if (!_fcmClient.IsConfigured)
+        {
+            _logger.LogDebug("Skipping push for user {UserId} — Firebase is not configured", userId);
+            return;
+        }
+
+        var devices = await _deviceRepository.GetByUserIdAsync(userId, cancellationToken);
+        if (devices.Count == 0)
+        {
+            _logger.LogDebug("Skipping push for user {UserId} — no registered devices", userId);
+            return;
+        }
+
+        var tokens = devices.Select(d => d.FcmToken).Distinct().ToList();
+        var results = await _fcmClient.SendAsync(
+            tokens, title, body, data ?? new Dictionary<string, string>(), cancellationToken);
+
+        var invalidTokens = results
+            .Where(r => !r.Success && r.IsTokenInvalid)
+            .Select(r => r.Token)
+            .ToList();
+
+        if (invalidTokens.Count > 0)
+        {
+            _logger.LogInformation(
+                "Pruning {Count} unregistered FCM token(s) for user {UserId}", invalidTokens.Count, userId);
+            await _deviceRepository.RemoveTokensAsync(invalidTokens, cancellationToken);
+        }
+
+        var successCount = results.Count(r => r.Success);
+        var transientFailures = results.Count(r => !r.Success && !r.IsTokenInvalid);
+        if (transientFailures > 0)
+        {
+            _logger.LogWarning(
+                "Push to user {UserId}: {Success}/{Total} delivered, {Failures} transient failure(s)",
+                userId, successCount, tokens.Count, transientFailures);
+        }
+        else
+        {
+            _logger.LogInformation(
+                "Push to user {UserId}: {Success}/{Total} delivered", userId, successCount, tokens.Count);
+        }
+    }
+}

--- a/src/Infrastructure/MyMascada.Infrastructure/Services/Push/IFcmClient.cs
+++ b/src/Infrastructure/MyMascada.Infrastructure/Services/Push/IFcmClient.cs
@@ -31,8 +31,10 @@ public sealed class FcmSendResult
     public required bool Success { get; init; }
 
     /// <summary>
-    /// True when FCM reported the token as unregistered/invalid and it should
-    /// be pruned from the device registry.
+    /// True when FCM reported the token as Unregistered and it should be pruned
+    /// from the device registry. Other error codes (including InvalidArgument,
+    /// which can indicate a malformed message rather than a bad token) are
+    /// treated as non-prunable failures.
     /// </summary>
     public bool IsTokenInvalid { get; init; }
 

--- a/src/Infrastructure/MyMascada.Infrastructure/Services/Push/IFcmClient.cs
+++ b/src/Infrastructure/MyMascada.Infrastructure/Services/Push/IFcmClient.cs
@@ -1,0 +1,40 @@
+namespace MyMascada.Infrastructure.Services.Push;
+
+/// <summary>
+/// Thin abstraction over the Firebase Cloud Messaging SDK so that push
+/// dispatch and token-pruning logic can be unit tested without Firebase.
+/// </summary>
+public interface IFcmClient
+{
+    /// <summary>
+    /// Whether Firebase credentials are configured. When false, sends are skipped
+    /// (fail-soft for development environments without Firebase).
+    /// </summary>
+    bool IsConfigured { get; }
+
+    /// <summary>
+    /// Sends a notification message to the given device tokens.
+    /// Returns one result per token, in the same order as <paramref name="tokens"/>.
+    /// </summary>
+    Task<IReadOnlyList<FcmSendResult>> SendAsync(
+        IReadOnlyList<string> tokens,
+        string title,
+        string body,
+        IReadOnlyDictionary<string, string> data,
+        CancellationToken cancellationToken = default);
+}
+
+/// <summary>Per-token outcome of an FCM multicast send.</summary>
+public sealed class FcmSendResult
+{
+    public required string Token { get; init; }
+    public required bool Success { get; init; }
+
+    /// <summary>
+    /// True when FCM reported the token as unregistered/invalid and it should
+    /// be pruned from the device registry.
+    /// </summary>
+    public bool IsTokenInvalid { get; init; }
+
+    public string? Error { get; init; }
+}

--- a/src/Infrastructure/MyMascada.Infrastructure/Services/Push/PushContentFormatter.cs
+++ b/src/Infrastructure/MyMascada.Infrastructure/Services/Push/PushContentFormatter.cs
@@ -1,0 +1,134 @@
+using System.Globalization;
+using System.Text.Json;
+using MyMascada.Domain.Enums;
+
+namespace MyMascada.Infrastructure.Services.Push;
+
+/// <summary>
+/// Builds push notification content and data payloads from in-app notifications.
+///
+/// In-app notifications created by <c>NotificationTriggerService</c> store i18n
+/// template keys (e.g. title "CategorizationReminder", body
+/// "CategorizationReminder.body") that web/mobile clients localise at render time.
+/// Push notifications are rendered by the OS, so known template keys are expanded
+/// to English copy here; non-template notifications pass through unchanged.
+/// </summary>
+public static class PushContentFormatter
+{
+    /// <summary>
+    /// Resolves human-readable (English) title/body for a notification, expanding
+    /// known template keys using values from the structured data payload.
+    /// </summary>
+    public static (string Title, string Body) FormatContent(string title, string body, string? dataJson)
+    {
+        var data = ParseData(dataJson);
+
+        switch (title)
+        {
+            case "CategorizationReminder":
+            {
+                var count = GetInt(data, "count") ?? 0;
+                return ("Transactions to categorize",
+                    count == 1
+                        ? "You have 1 uncategorized transaction"
+                        : $"You have {count} uncategorized transactions");
+            }
+            case "RuleSuggestionsAvailable":
+            {
+                var count = GetInt(data, "count") ?? 0;
+                return ("New rule suggestions",
+                    count == 1
+                        ? "1 new categorization rule suggestion is available"
+                        : $"{count} new categorization rule suggestions are available");
+            }
+            case "TransactionReminder":
+            {
+                var merchant = GetString(data, "merchantName") ?? "Upcoming payment";
+                var amountMinor = GetInt64(data, "amountMinorUnits");
+                var date = GetString(data, "dateIso");
+                var amountText = amountMinor.HasValue
+                    ? (amountMinor.Value / 100m).ToString("0.00", CultureInfo.InvariantCulture)
+                    : null;
+                var bodyText = merchant;
+                if (amountText != null) bodyText += $" — {amountText}";
+                if (date != null) bodyText += $" due on {date}";
+                return ("Upcoming transaction", bodyText);
+            }
+            default:
+                return (title, body);
+        }
+    }
+
+    /// <summary>
+    /// Builds the FCM data payload the mobile app uses to deep-link on tap.
+    /// The app's tap handler navigates using the "route" key (see
+    /// notification_service.dart in mymascada-mobile).
+    /// </summary>
+    public static Dictionary<string, string> BuildDataPayload(NotificationType type, Guid notificationId)
+    {
+        return new Dictionary<string, string>
+        {
+            ["route"] = MapMobileRoute(type),
+            ["notificationId"] = notificationId.ToString(),
+            ["notificationType"] = type.ToString()
+        };
+    }
+
+    /// <summary>
+    /// Maps a notification type to a mobile app route (GoRouter path).
+    /// Routes must exist in the mobile app's app_router.dart.
+    /// </summary>
+    public static string MapMobileRoute(NotificationType type) => type switch
+    {
+        NotificationType.TransactionReminder => "/transactions",
+        NotificationType.RecurringTransactionCreated => "/transactions",
+        NotificationType.CategorizationReminder => "/transactions",
+        NotificationType.LargeTransaction => "/transactions",
+
+        NotificationType.BudgetThreshold => "/dashboard/budgets",
+        NotificationType.BudgetExceeded => "/dashboard/budgets",
+        NotificationType.SpendingAnomaly => "/dashboard/budgets",
+
+        NotificationType.GoalMilestone => "/dashboard/goals",
+        NotificationType.GoalCompleted => "/dashboard/goals",
+        NotificationType.GoalDeadlineApproaching => "/dashboard/goals",
+
+        NotificationType.AccountSyncCompleted => "/dashboard/bank-connections",
+        NotificationType.AccountSyncFailed => "/dashboard/bank-connections",
+        NotificationType.AccountConnectionExpiring => "/dashboard/bank-connections",
+
+        NotificationType.RuleSuggestionsAvailable => "/dashboard/rules/suggestions",
+
+        _ => "/dashboard"
+    };
+
+    private static Dictionary<string, JsonElement>? ParseData(string? dataJson)
+    {
+        if (string.IsNullOrWhiteSpace(dataJson))
+            return null;
+
+        try
+        {
+            return JsonSerializer.Deserialize<Dictionary<string, JsonElement>>(dataJson);
+        }
+        catch (JsonException)
+        {
+            return null;
+        }
+    }
+
+    private static string? GetString(Dictionary<string, JsonElement>? data, string key)
+        => data != null && data.TryGetValue(key, out var el) && el.ValueKind == JsonValueKind.String
+            ? el.GetString()
+            : null;
+
+    private static int? GetInt(Dictionary<string, JsonElement>? data, string key)
+        => data != null && data.TryGetValue(key, out var el) && el.ValueKind == JsonValueKind.Number && el.TryGetInt32(out var v)
+            ? v
+            : null;
+
+    private static long? GetInt64(Dictionary<string, JsonElement>? data, string key)
+        => data != null && data.TryGetValue(key, out var el) && el.ValueKind == JsonValueKind.Number && el.TryGetInt64(out var v)
+            ? v
+            : null;
+}

--- a/src/Infrastructure/MyMascada.Infrastructure/Services/UserData/UserDataDeletionService.cs
+++ b/src/Infrastructure/MyMascada.Infrastructure/Services/UserData/UserDataDeletionService.cs
@@ -294,6 +294,12 @@ public class UserDataDeletionService : IUserDataDeletionService
                 .Where(np => np.UserId == userId)
                 .ExecuteDeleteAsync(cancellationToken);
 
+            // 23b. Delete UserDevices (FCM push notification tokens)
+            result.UserDevicesDeleted = await _context.UserDevices
+                .IgnoreQueryFilters()
+                .Where(ud => ud.UserId == userId)
+                .ExecuteDeleteAsync(cancellationToken);
+
             // 24. Delete DashboardNudgeDismissals
             result.DashboardNudgeDismissalsDeleted = await _context.DashboardNudgeDismissals
                 .IgnoreQueryFilters()
@@ -447,7 +453,8 @@ public class UserDataDeletionService : IUserDataDeletionService
                 "{Transfers} transfers, {Reconciliations} reconciliations, {BankConnections} bank connections, " +
                 "{Budgets} budgets, {Wallets} wallets, {RecurringPatterns} recurring patterns, {Goals} goals, " +
                 "{AccountShares} account shares, {ChatMessages} chat messages, {Notifications} notifications, " +
-                "{NotificationPreferences} notification preferences, {DashboardNudgeDismissals} nudge dismissals, " +
+                "{NotificationPreferences} notification preferences, {UserDevices} push devices, " +
+                "{DashboardNudgeDismissals} nudge dismissals, " +
                 "{BankCategoryMappings} bank category mappings, {DuplicateExclusions} duplicate exclusions, " +
                 "{RuleSuggestions} rule suggestions, {RefreshTokens} refresh tokens, {PasswordResetTokens} password reset tokens, " +
                 "{EmailVerificationTokens} email verification tokens, {AkahuUserCredentials} akahu credentials, " +
@@ -458,7 +465,8 @@ public class UserDataDeletionService : IUserDataDeletionService
                 result.TransfersDeleted, result.ReconciliationsDeleted, result.BankConnectionsDeleted,
                 result.BudgetsDeleted, result.WalletsDeleted, result.RecurringPatternsDeleted, result.GoalsDeleted,
                 result.AccountSharesDeleted, result.ChatMessagesDeleted, result.NotificationsDeleted,
-                result.NotificationPreferencesDeleted, result.DashboardNudgeDismissalsDeleted,
+                result.NotificationPreferencesDeleted, result.UserDevicesDeleted,
+                result.DashboardNudgeDismissalsDeleted,
                 result.BankCategoryMappingsDeleted, result.DuplicateExclusionsDeleted,
                 result.RuleSuggestionsDeleted, result.RefreshTokensDeleted, result.PasswordResetTokensDeleted,
                 result.EmailVerificationTokensDeleted, result.AkahuUserCredentialsDeleted,

--- a/src/WebAPI/MyMascada.WebAPI/Controllers/DevicesController.cs
+++ b/src/WebAPI/MyMascada.WebAPI/Controllers/DevicesController.cs
@@ -71,16 +71,19 @@ public class DevicesController : ControllerBase
 
     /// <summary>
     /// Unregister an FCM device token (e.g. on logout). Idempotent.
+    /// The token travels in the request body so it never appears in URL/proxy logs.
     /// </summary>
-    [HttpDelete("{token}")]
-    public async Task<ActionResult> UnregisterDevice(string token, CancellationToken cancellationToken = default)
+    [HttpDelete]
+    public async Task<ActionResult> UnregisterDevice(
+        [FromBody] UnregisterDeviceRequest request,
+        CancellationToken cancellationToken = default)
     {
         try
         {
             var command = new UnregisterDeviceCommand
             {
                 UserId = _currentUserService.GetUserId(),
-                Token = token
+                Token = request.Token
             };
 
             await _mediator.Send(command, cancellationToken);

--- a/src/WebAPI/MyMascada.WebAPI/Controllers/DevicesController.cs
+++ b/src/WebAPI/MyMascada.WebAPI/Controllers/DevicesController.cs
@@ -1,0 +1,107 @@
+using Asp.Versioning;
+using MediatR;
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Mvc;
+using MyMascada.Application.Common.Interfaces;
+using MyMascada.Application.Features.Devices.Commands;
+using MyMascada.Application.Features.Devices.DTOs;
+
+namespace MyMascada.WebAPI.Controllers;
+
+/// <summary>
+/// Mobile push notification device registry (FCM tokens).
+/// </summary>
+[ApiController]
+[ApiVersion("1.0")]
+[Route("api/v{version:apiVersion}/[controller]")]
+[Route("api/latest/[controller]")]
+[Authorize]
+public class DevicesController : ControllerBase
+{
+    private readonly IMediator _mediator;
+    private readonly ICurrentUserService _currentUserService;
+    private readonly ILogger<DevicesController> _logger;
+
+    public DevicesController(IMediator mediator, ICurrentUserService currentUserService, ILogger<DevicesController> logger)
+    {
+        _mediator = mediator;
+        _currentUserService = currentUserService;
+        _logger = logger;
+    }
+
+    /// <summary>
+    /// Register (or refresh) an FCM device token for the current user.
+    /// Idempotent — re-registering the same token updates its LastSeenAt.
+    /// </summary>
+    [HttpPost]
+    public async Task<ActionResult<DeviceDto>> RegisterDevice(
+        [FromBody] RegisterDeviceRequest request,
+        CancellationToken cancellationToken = default)
+    {
+        try
+        {
+            var command = new RegisterDeviceCommand
+            {
+                UserId = _currentUserService.GetUserId(),
+                Token = request.Token,
+                Platform = request.Platform
+            };
+
+            var result = await _mediator.Send(command, cancellationToken);
+            return Ok(result);
+        }
+        catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)
+        {
+            throw;
+        }
+        catch (ArgumentException ex)
+        {
+            return BadRequest(new { message = ex.Message });
+        }
+        catch (UnauthorizedAccessException ex)
+        {
+            return Unauthorized(new { message = ex.Message });
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(ex, "Error registering device for user");
+            return StatusCode(500, new { message = "An error occurred while registering the device." });
+        }
+    }
+
+    /// <summary>
+    /// Unregister an FCM device token (e.g. on logout). Idempotent.
+    /// </summary>
+    [HttpDelete("{token}")]
+    public async Task<ActionResult> UnregisterDevice(string token, CancellationToken cancellationToken = default)
+    {
+        try
+        {
+            var command = new UnregisterDeviceCommand
+            {
+                UserId = _currentUserService.GetUserId(),
+                Token = token
+            };
+
+            await _mediator.Send(command, cancellationToken);
+            return NoContent();
+        }
+        catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)
+        {
+            throw;
+        }
+        catch (ArgumentException ex)
+        {
+            return BadRequest(new { message = ex.Message });
+        }
+        catch (UnauthorizedAccessException ex)
+        {
+            return Unauthorized(new { message = ex.Message });
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(ex, "Error unregistering device for user");
+            return StatusCode(500, new { message = "An error occurred while unregistering the device." });
+        }
+    }
+}

--- a/src/WebAPI/MyMascada.WebAPI/Extensions/ApplicationServiceExtensions.cs
+++ b/src/WebAPI/MyMascada.WebAPI/Extensions/ApplicationServiceExtensions.cs
@@ -114,6 +114,13 @@ public static class ApplicationServiceExtensions
         services.AddScoped<INotificationService, MyMascada.Infrastructure.Services.Notifications.NotificationService>();
         services.AddScoped<INotificationTriggerService, MyMascada.Infrastructure.Services.Notifications.NotificationTriggerService>();
 
+        // Push notification services (FCM). The client is a singleton so the
+        // FirebaseApp/credentials are initialized once per process.
+        services.AddSingleton<MyMascada.Infrastructure.Services.Push.IFcmClient,
+            MyMascada.Infrastructure.Services.Push.FirebaseFcmClient>();
+        services.AddScoped<IPushNotificationService,
+            MyMascada.Infrastructure.Services.Push.FirebasePushNotificationService>();
+
         return services;
     }
 }

--- a/src/WebAPI/MyMascada.WebAPI/Extensions/RepositoryServiceExtensions.cs
+++ b/src/WebAPI/MyMascada.WebAPI/Extensions/RepositoryServiceExtensions.cs
@@ -65,6 +65,7 @@ public static class RepositoryServiceExtensions
         // Notification repositories
         services.AddScoped<INotificationRepository, NotificationRepository>();
         services.AddScoped<INotificationPreferenceRepository, NotificationPreferenceRepository>();
+        services.AddScoped<IUserDeviceRepository, UserDeviceRepository>();
 
         return services;
     }

--- a/src/WebAPI/MyMascada.WebAPI/Migrations/20260609233501_AddUserDevices.Designer.cs
+++ b/src/WebAPI/MyMascada.WebAPI/Migrations/20260609233501_AddUserDevices.Designer.cs
@@ -2,6 +2,7 @@
 using System;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using MyMascada.Infrastructure.Data;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
@@ -11,9 +12,11 @@ using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 namespace MyMascada.WebAPI.Migrations
 {
     [DbContext(typeof(ApplicationDbContext))]
-    partial class ApplicationDbContextModelSnapshot : ModelSnapshot
+    [Migration("20260609233501_AddUserDevices")]
+    partial class AddUserDevices
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/src/WebAPI/MyMascada.WebAPI/Migrations/20260609233501_AddUserDevices.cs
+++ b/src/WebAPI/MyMascada.WebAPI/Migrations/20260609233501_AddUserDevices.cs
@@ -1,0 +1,60 @@
+﻿using System;
+using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace MyMascada.WebAPI.Migrations
+{
+    /// <inheritdoc />
+    public partial class AddUserDevices : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.CreateTable(
+                name: "UserDevices",
+                columns: table => new
+                {
+                    Id = table.Column<Guid>(type: "uuid", nullable: false),
+                    UserId = table.Column<Guid>(type: "uuid", nullable: false),
+                    FcmToken = table.Column<string>(type: "character varying(512)", maxLength: 512, nullable: false),
+                    Platform = table.Column<string>(type: "character varying(20)", maxLength: 20, nullable: false),
+                    LastSeenAt = table.Column<DateTime>(type: "timestamp with time zone", nullable: false),
+                    CreatedAt = table.Column<DateTime>(type: "timestamp with time zone", nullable: false),
+                    UpdatedAt = table.Column<DateTime>(type: "timestamp with time zone", nullable: false),
+                    IsDeleted = table.Column<bool>(type: "boolean", nullable: false),
+                    DeletedAt = table.Column<DateTime>(type: "timestamp with time zone", nullable: true),
+                    CreatedBy = table.Column<string>(type: "text", nullable: true),
+                    UpdatedBy = table.Column<string>(type: "text", nullable: true)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_UserDevices", x => x.Id);
+                    table.ForeignKey(
+                        name: "FK_UserDevices_Users_UserId",
+                        column: x => x.UserId,
+                        principalTable: "Users",
+                        principalColumn: "Id",
+                        onDelete: ReferentialAction.Cascade);
+                });
+
+            migrationBuilder.CreateIndex(
+                name: "IX_UserDevices_FcmToken",
+                table: "UserDevices",
+                column: "FcmToken",
+                unique: true);
+
+            migrationBuilder.CreateIndex(
+                name: "IX_UserDevices_UserId",
+                table: "UserDevices",
+                column: "UserId");
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropTable(
+                name: "UserDevices");
+        }
+    }
+}

--- a/src/WebAPI/MyMascada.WebAPI/appsettings.json
+++ b/src/WebAPI/MyMascada.WebAPI/appsettings.json
@@ -89,6 +89,9 @@
   "Telegram": {
     "WebhookBaseUrl": ""
   },
+  "Firebase": {
+    "ServiceAccountJson": ""
+  },
   "EndpointValidation": {
     "AllowedAiProviderHosts": [
       "api.openai.com",

--- a/tests/MyMascada.Tests.Unit/Commands/RegisterDeviceCommandHandlerTests.cs
+++ b/tests/MyMascada.Tests.Unit/Commands/RegisterDeviceCommandHandlerTests.cs
@@ -1,0 +1,109 @@
+using MyMascada.Application.Common.Interfaces;
+using MyMascada.Application.Features.Devices.Commands;
+using MyMascada.Domain.Entities;
+
+namespace MyMascada.Tests.Unit.Commands;
+
+public class RegisterDeviceCommandHandlerTests
+{
+    private readonly IUserDeviceRepository _repository = Substitute.For<IUserDeviceRepository>();
+    private readonly RegisterDeviceCommandHandler _handler;
+    private readonly Guid _userId = Guid.NewGuid();
+
+    public RegisterDeviceCommandHandlerTests()
+    {
+        _handler = new RegisterDeviceCommandHandler(_repository);
+    }
+
+    private static UserDevice MakeDevice(Guid userId, string token, string platform) => new()
+    {
+        Id = Guid.NewGuid(),
+        UserId = userId,
+        FcmToken = token,
+        Platform = platform,
+        LastSeenAt = DateTime.UtcNow
+    };
+
+    [Fact]
+    public async Task Handle_ValidRequest_UpsertsAndReturnsDeviceDto()
+    {
+        var device = MakeDevice(_userId, "fcm-token-123", "ios");
+        _repository.UpsertAsync(_userId, "fcm-token-123", "ios", Arg.Any<CancellationToken>())
+            .Returns(device);
+
+        var result = await _handler.Handle(new RegisterDeviceCommand
+        {
+            UserId = _userId,
+            Token = "fcm-token-123",
+            Platform = "ios"
+        }, CancellationToken.None);
+
+        result.Id.Should().Be(device.Id);
+        result.Platform.Should().Be("ios");
+        result.LastSeenAt.Should().Be(device.LastSeenAt);
+        await _repository.Received(1).UpsertAsync(_userId, "fcm-token-123", "ios", Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task Handle_TrimsTokenAndNormalizesPlatformCasing()
+    {
+        var device = MakeDevice(_userId, "fcm-token-123", "android");
+        _repository.UpsertAsync(_userId, "fcm-token-123", "android", Arg.Any<CancellationToken>())
+            .Returns(device);
+
+        await _handler.Handle(new RegisterDeviceCommand
+        {
+            UserId = _userId,
+            Token = "  fcm-token-123  ",
+            Platform = "Android"
+        }, CancellationToken.None);
+
+        await _repository.Received(1).UpsertAsync(_userId, "fcm-token-123", "android", Arg.Any<CancellationToken>());
+    }
+
+    [Theory]
+    [InlineData("")]
+    [InlineData("   ")]
+    public async Task Handle_MissingToken_ThrowsArgumentException(string token)
+    {
+        var act = () => _handler.Handle(new RegisterDeviceCommand
+        {
+            UserId = _userId,
+            Token = token,
+            Platform = "ios"
+        }, CancellationToken.None);
+
+        await act.Should().ThrowAsync<ArgumentException>().WithMessage("*token*");
+        await _repository.DidNotReceiveWithAnyArgs().UpsertAsync(default, default!, default!, default);
+    }
+
+    [Fact]
+    public async Task Handle_TokenTooLong_ThrowsArgumentException()
+    {
+        var act = () => _handler.Handle(new RegisterDeviceCommand
+        {
+            UserId = _userId,
+            Token = new string('x', RegisterDeviceCommandHandler.MaxTokenLength + 1),
+            Platform = "ios"
+        }, CancellationToken.None);
+
+        await act.Should().ThrowAsync<ArgumentException>().WithMessage("*maximum length*");
+    }
+
+    [Theory]
+    [InlineData("")]
+    [InlineData("windows")]
+    [InlineData("web")]
+    public async Task Handle_InvalidPlatform_ThrowsArgumentException(string platform)
+    {
+        var act = () => _handler.Handle(new RegisterDeviceCommand
+        {
+            UserId = _userId,
+            Token = "fcm-token-123",
+            Platform = platform
+        }, CancellationToken.None);
+
+        await act.Should().ThrowAsync<ArgumentException>().WithMessage("*Platform*");
+        await _repository.DidNotReceiveWithAnyArgs().UpsertAsync(default, default!, default!, default);
+    }
+}

--- a/tests/MyMascada.Tests.Unit/Commands/UnregisterDeviceCommandHandlerTests.cs
+++ b/tests/MyMascada.Tests.Unit/Commands/UnregisterDeviceCommandHandlerTests.cs
@@ -1,0 +1,55 @@
+using MyMascada.Application.Common.Interfaces;
+using MyMascada.Application.Features.Devices.Commands;
+
+namespace MyMascada.Tests.Unit.Commands;
+
+public class UnregisterDeviceCommandHandlerTests
+{
+    private readonly IUserDeviceRepository _repository = Substitute.For<IUserDeviceRepository>();
+    private readonly UnregisterDeviceCommandHandler _handler;
+    private readonly Guid _userId = Guid.NewGuid();
+
+    public UnregisterDeviceCommandHandlerTests()
+    {
+        _handler = new UnregisterDeviceCommandHandler(_repository);
+    }
+
+    [Fact]
+    public async Task Handle_ValidToken_DeletesRegistration()
+    {
+        await _handler.Handle(new UnregisterDeviceCommand
+        {
+            UserId = _userId,
+            Token = "fcm-token-123"
+        }, CancellationToken.None);
+
+        await _repository.Received(1).DeleteByTokenAsync(_userId, "fcm-token-123", Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task Handle_TrimsToken()
+    {
+        await _handler.Handle(new UnregisterDeviceCommand
+        {
+            UserId = _userId,
+            Token = "  fcm-token-123 "
+        }, CancellationToken.None);
+
+        await _repository.Received(1).DeleteByTokenAsync(_userId, "fcm-token-123", Arg.Any<CancellationToken>());
+    }
+
+    [Theory]
+    [InlineData("")]
+    [InlineData("   ")]
+    public async Task Handle_MissingToken_ThrowsArgumentException(string token)
+    {
+        var act = () => _handler.Handle(new UnregisterDeviceCommand
+        {
+            UserId = _userId,
+            Token = token
+        }, CancellationToken.None);
+
+        await act.Should().ThrowAsync<ArgumentException>();
+        await _repository.DidNotReceiveWithAnyArgs().DeleteByTokenAsync(default, default!, default);
+    }
+}

--- a/tests/MyMascada.Tests.Unit/Repositories/UserDeviceRepositoryTests.cs
+++ b/tests/MyMascada.Tests.Unit/Repositories/UserDeviceRepositoryTests.cs
@@ -143,4 +143,87 @@ public class UserDeviceRepositoryTests : IDisposable
 
         (await _repository.GetByUserIdAsync(_userId)).Should().HaveCount(1);
     }
+
+    [Fact]
+    public async Task UpsertAsync_LostInsertRace_RecoversAndUpdatesWinnerRow()
+    {
+        var options = new DbContextOptionsBuilder<ApplicationDbContext>()
+            .UseInMemoryDatabase(databaseName: Guid.NewGuid().ToString())
+            .Options;
+
+        // Simulates the concurrent registration that won the FcmToken unique index.
+        async Task SeedWinnerRow()
+        {
+            using var winnerContext = new ApplicationDbContext(options);
+            winnerContext.UserDevices.Add(new UserDevice
+            {
+                Id = Guid.NewGuid(),
+                UserId = _otherUserId,
+                FcmToken = "raced-token",
+                Platform = "android",
+                LastSeenAt = DateTime.UtcNow
+            });
+            await winnerContext.SaveChangesAsync();
+        }
+
+        using var context = new FailingFirstSaveDbContext(options, SeedWinnerRow);
+        var repository = new UserDeviceRepository(context);
+
+        var device = await repository.UpsertAsync(_userId, "raced-token", "ios");
+
+        device.UserId.Should().Be(_userId);
+        device.Platform.Should().Be("ios");
+        using var verifyContext = new ApplicationDbContext(options);
+        (await verifyContext.UserDevices.IgnoreQueryFilters().CountAsync()).Should().Be(1);
+    }
+
+    [Fact]
+    public async Task UpsertAsync_SaveFailsWithNoConflictingRow_RethrowsOriginalException()
+    {
+        var options = new DbContextOptionsBuilder<ApplicationDbContext>()
+            .UseInMemoryDatabase(databaseName: Guid.NewGuid().ToString())
+            .Options;
+        using var context = new FailingFirstSaveDbContext(options, onFirstSaveFailure: null);
+        var repository = new UserDeviceRepository(context);
+
+        var act = () => repository.UpsertAsync(_userId, "token-1", "ios");
+
+        // A DbUpdateException with no conflicting row (e.g. FK violation, connection
+        // drop) must surface as-is, not as "sequence contains no elements".
+        await act.Should().ThrowAsync<DbUpdateException>()
+            .WithMessage("Simulated save failure*");
+    }
+
+    /// <summary>
+    /// Throws <see cref="DbUpdateException"/> on the first SaveChangesAsync call
+    /// (optionally running a callback first to simulate a concurrent writer) and
+    /// behaves normally afterwards.
+    /// </summary>
+    private sealed class FailingFirstSaveDbContext : ApplicationDbContext
+    {
+        private readonly Func<Task>? _onFirstSaveFailure;
+        private bool _hasFailed;
+
+        public FailingFirstSaveDbContext(DbContextOptions<ApplicationDbContext> options, Func<Task>? onFirstSaveFailure)
+            : base(options)
+        {
+            _onFirstSaveFailure = onFirstSaveFailure;
+        }
+
+        public override async Task<int> SaveChangesAsync(CancellationToken cancellationToken = default)
+        {
+            if (!_hasFailed)
+            {
+                _hasFailed = true;
+                if (_onFirstSaveFailure != null)
+                {
+                    await _onFirstSaveFailure();
+                }
+
+                throw new DbUpdateException("Simulated save failure (unique index violation)");
+            }
+
+            return await base.SaveChangesAsync(cancellationToken);
+        }
+    }
 }

--- a/tests/MyMascada.Tests.Unit/Repositories/UserDeviceRepositoryTests.cs
+++ b/tests/MyMascada.Tests.Unit/Repositories/UserDeviceRepositoryTests.cs
@@ -1,0 +1,146 @@
+using Microsoft.EntityFrameworkCore;
+using MyMascada.Domain.Entities;
+using MyMascada.Infrastructure.Data;
+using MyMascada.Infrastructure.Repositories;
+
+namespace MyMascada.Tests.Unit.Repositories;
+
+public class UserDeviceRepositoryTests : IDisposable
+{
+    private readonly ApplicationDbContext _context;
+    private readonly UserDeviceRepository _repository;
+    private readonly Guid _userId = Guid.NewGuid();
+    private readonly Guid _otherUserId = Guid.NewGuid();
+
+    public UserDeviceRepositoryTests()
+    {
+        var options = new DbContextOptionsBuilder<ApplicationDbContext>()
+            .UseInMemoryDatabase(databaseName: Guid.NewGuid().ToString())
+            .Options;
+
+        _context = new ApplicationDbContext(options);
+        _repository = new UserDeviceRepository(_context);
+    }
+
+    public void Dispose()
+    {
+        _context.Dispose();
+        GC.SuppressFinalize(this);
+    }
+
+    [Fact]
+    public async Task UpsertAsync_NewToken_CreatesDevice()
+    {
+        var device = await _repository.UpsertAsync(_userId, "token-1", "ios");
+
+        device.UserId.Should().Be(_userId);
+        device.FcmToken.Should().Be("token-1");
+        device.Platform.Should().Be("ios");
+
+        var stored = await _context.UserDevices.SingleAsync();
+        stored.Id.Should().Be(device.Id);
+    }
+
+    [Fact]
+    public async Task UpsertAsync_SameTokenTwice_IsIdempotent()
+    {
+        var first = await _repository.UpsertAsync(_userId, "token-1", "ios");
+        var second = await _repository.UpsertAsync(_userId, "token-1", "ios");
+
+        second.Id.Should().Be(first.Id);
+        (await _context.UserDevices.CountAsync()).Should().Be(1);
+        second.LastSeenAt.Should().BeOnOrAfter(first.LastSeenAt);
+    }
+
+    [Fact]
+    public async Task UpsertAsync_TokenOwnedByAnotherUser_ReassignsOwnership()
+    {
+        await _repository.UpsertAsync(_otherUserId, "shared-device-token", "android");
+
+        var device = await _repository.UpsertAsync(_userId, "shared-device-token", "android");
+
+        device.UserId.Should().Be(_userId);
+        (await _context.UserDevices.CountAsync()).Should().Be(1);
+        (await _repository.GetByUserIdAsync(_otherUserId)).Should().BeEmpty();
+    }
+
+    [Fact]
+    public async Task UpsertAsync_SoftDeletedToken_RevivesRow()
+    {
+        await _repository.UpsertAsync(_userId, "token-1", "ios");
+        await _repository.DeleteByTokenAsync(_userId, "token-1");
+
+        var revived = await _repository.UpsertAsync(_userId, "token-1", "ios");
+
+        revived.IsDeleted.Should().BeFalse();
+        revived.DeletedAt.Should().BeNull();
+        (await _repository.GetByUserIdAsync(_userId)).Should().HaveCount(1);
+    }
+
+    [Fact]
+    public async Task DeleteByTokenAsync_OwnedToken_SoftDeletes()
+    {
+        await _repository.UpsertAsync(_userId, "token-1", "ios");
+
+        await _repository.DeleteByTokenAsync(_userId, "token-1");
+
+        (await _repository.GetByUserIdAsync(_userId)).Should().BeEmpty();
+        var raw = await _context.UserDevices.IgnoreQueryFilters().SingleAsync();
+        raw.IsDeleted.Should().BeTrue();
+        raw.DeletedAt.Should().NotBeNull();
+    }
+
+    [Fact]
+    public async Task DeleteByTokenAsync_TokenOwnedByAnotherUser_IsNoOp()
+    {
+        await _repository.UpsertAsync(_otherUserId, "token-1", "ios");
+
+        await _repository.DeleteByTokenAsync(_userId, "token-1");
+
+        (await _repository.GetByUserIdAsync(_otherUserId)).Should().HaveCount(1);
+    }
+
+    [Fact]
+    public async Task DeleteByTokenAsync_UnknownToken_IsNoOp()
+    {
+        var act = () => _repository.DeleteByTokenAsync(_userId, "missing-token");
+        await act.Should().NotThrowAsync();
+    }
+
+    [Fact]
+    public async Task GetByUserIdAsync_ReturnsOnlyOwnActiveDevices()
+    {
+        await _repository.UpsertAsync(_userId, "token-1", "ios");
+        await _repository.UpsertAsync(_userId, "token-2", "android");
+        await _repository.UpsertAsync(_otherUserId, "token-3", "ios");
+        await _repository.DeleteByTokenAsync(_userId, "token-2");
+
+        var devices = await _repository.GetByUserIdAsync(_userId);
+
+        devices.Should().HaveCount(1);
+        devices[0].FcmToken.Should().Be("token-1");
+    }
+
+    [Fact]
+    public async Task RemoveTokensAsync_SoftDeletesMatchingTokensAcrossUsers()
+    {
+        await _repository.UpsertAsync(_userId, "stale-1", "ios");
+        await _repository.UpsertAsync(_otherUserId, "stale-2", "android");
+        await _repository.UpsertAsync(_userId, "healthy", "ios");
+
+        await _repository.RemoveTokensAsync(new[] { "stale-1", "stale-2" });
+
+        (await _repository.GetByUserIdAsync(_userId)).Select(d => d.FcmToken).Should().Equal("healthy");
+        (await _repository.GetByUserIdAsync(_otherUserId)).Should().BeEmpty();
+    }
+
+    [Fact]
+    public async Task RemoveTokensAsync_EmptyCollection_IsNoOp()
+    {
+        await _repository.UpsertAsync(_userId, "token-1", "ios");
+
+        await _repository.RemoveTokensAsync(Array.Empty<string>());
+
+        (await _repository.GetByUserIdAsync(_userId)).Should().HaveCount(1);
+    }
+}

--- a/tests/MyMascada.Tests.Unit/Services/FirebasePushNotificationServiceTests.cs
+++ b/tests/MyMascada.Tests.Unit/Services/FirebasePushNotificationServiceTests.cs
@@ -41,6 +41,33 @@ public class FirebasePushNotificationServiceTests
     }
 
     [Fact]
+    public async Task SendToUserAsync_DeliveryFailure_DoesNotThrow()
+    {
+        // Contract: push is best-effort and must never break the calling flow.
+        _fcmClient.IsConfigured.Returns(true);
+        _deviceRepository.GetByUserIdAsync(_userId, Arg.Any<CancellationToken>())
+            .Returns<List<UserDevice>>(_ => throw new InvalidOperationException("database unavailable"));
+
+        var act = () => _service.SendToUserAsync(_userId, "Title", "Body");
+
+        await act.Should().NotThrowAsync();
+    }
+
+    [Fact]
+    public async Task SendToUserAsync_CallerCancellation_Propagates()
+    {
+        _fcmClient.IsConfigured.Returns(true);
+        using var cts = new CancellationTokenSource();
+        cts.Cancel();
+        _deviceRepository.GetByUserIdAsync(_userId, Arg.Any<CancellationToken>())
+            .Returns<List<UserDevice>>(_ => throw new OperationCanceledException(cts.Token));
+
+        var act = () => _service.SendToUserAsync(_userId, "Title", "Body", null, cts.Token);
+
+        await act.Should().ThrowAsync<OperationCanceledException>();
+    }
+
+    [Fact]
     public async Task SendToUserAsync_NoDevices_DoesNotSend()
     {
         _fcmClient.IsConfigured.Returns(true);

--- a/tests/MyMascada.Tests.Unit/Services/FirebasePushNotificationServiceTests.cs
+++ b/tests/MyMascada.Tests.Unit/Services/FirebasePushNotificationServiceTests.cs
@@ -1,0 +1,129 @@
+using Microsoft.Extensions.Logging;
+using MyMascada.Application.Common.Interfaces;
+using MyMascada.Domain.Entities;
+using MyMascada.Infrastructure.Services.Push;
+
+namespace MyMascada.Tests.Unit.Services;
+
+public class FirebasePushNotificationServiceTests
+{
+    private readonly IUserDeviceRepository _deviceRepository = Substitute.For<IUserDeviceRepository>();
+    private readonly IFcmClient _fcmClient = Substitute.For<IFcmClient>();
+    private readonly FirebasePushNotificationService _service;
+    private readonly Guid _userId = Guid.NewGuid();
+
+    public FirebasePushNotificationServiceTests()
+    {
+        _service = new FirebasePushNotificationService(
+            _deviceRepository,
+            _fcmClient,
+            Substitute.For<ILogger<FirebasePushNotificationService>>());
+    }
+
+    private static UserDevice Device(Guid userId, string token) => new()
+    {
+        Id = Guid.NewGuid(),
+        UserId = userId,
+        FcmToken = token,
+        Platform = "ios",
+        LastSeenAt = DateTime.UtcNow
+    };
+
+    [Fact]
+    public async Task SendToUserAsync_FirebaseNotConfigured_SkipsWithoutQueryingDevices()
+    {
+        _fcmClient.IsConfigured.Returns(false);
+
+        await _service.SendToUserAsync(_userId, "Title", "Body");
+
+        await _deviceRepository.DidNotReceiveWithAnyArgs().GetByUserIdAsync(default, default);
+        await _fcmClient.DidNotReceiveWithAnyArgs().SendAsync(default!, default!, default!, default!, default);
+    }
+
+    [Fact]
+    public async Task SendToUserAsync_NoDevices_DoesNotSend()
+    {
+        _fcmClient.IsConfigured.Returns(true);
+        _deviceRepository.GetByUserIdAsync(_userId, Arg.Any<CancellationToken>())
+            .Returns(new List<UserDevice>());
+
+        await _service.SendToUserAsync(_userId, "Title", "Body");
+
+        await _fcmClient.DidNotReceiveWithAnyArgs().SendAsync(default!, default!, default!, default!, default);
+    }
+
+    [Fact]
+    public async Task SendToUserAsync_SendsToAllRegisteredDeviceTokens()
+    {
+        _fcmClient.IsConfigured.Returns(true);
+        _deviceRepository.GetByUserIdAsync(_userId, Arg.Any<CancellationToken>())
+            .Returns(new List<UserDevice> { Device(_userId, "token-a"), Device(_userId, "token-b") });
+        _fcmClient.SendAsync(
+                Arg.Any<IReadOnlyList<string>>(), Arg.Any<string>(), Arg.Any<string>(),
+                Arg.Any<IReadOnlyDictionary<string, string>>(), Arg.Any<CancellationToken>())
+            .Returns(new List<FcmSendResult>
+            {
+                new() { Token = "token-a", Success = true },
+                new() { Token = "token-b", Success = true }
+            });
+
+        await _service.SendToUserAsync(_userId, "Title", "Body",
+            new Dictionary<string, string> { ["route"] = "/dashboard" });
+
+        await _fcmClient.Received(1).SendAsync(
+            Arg.Is<IReadOnlyList<string>>(t => t.Count == 2 && t.Contains("token-a") && t.Contains("token-b")),
+            "Title",
+            "Body",
+            Arg.Is<IReadOnlyDictionary<string, string>>(d => d["route"] == "/dashboard"),
+            Arg.Any<CancellationToken>());
+        await _deviceRepository.DidNotReceiveWithAnyArgs().RemoveTokensAsync(default!, default);
+    }
+
+    [Fact]
+    public async Task SendToUserAsync_PrunesTokensReportedAsUnregistered()
+    {
+        _fcmClient.IsConfigured.Returns(true);
+        _deviceRepository.GetByUserIdAsync(_userId, Arg.Any<CancellationToken>())
+            .Returns(new List<UserDevice>
+            {
+                Device(_userId, "valid-token"),
+                Device(_userId, "stale-token"),
+                Device(_userId, "transient-failure-token")
+            });
+        _fcmClient.SendAsync(
+                Arg.Any<IReadOnlyList<string>>(), Arg.Any<string>(), Arg.Any<string>(),
+                Arg.Any<IReadOnlyDictionary<string, string>>(), Arg.Any<CancellationToken>())
+            .Returns(new List<FcmSendResult>
+            {
+                new() { Token = "valid-token", Success = true },
+                new() { Token = "stale-token", Success = false, IsTokenInvalid = true, Error = "Unregistered" },
+                new() { Token = "transient-failure-token", Success = false, IsTokenInvalid = false, Error = "Unavailable" }
+            });
+
+        await _service.SendToUserAsync(_userId, "Title", "Body");
+
+        // Only the unregistered token is pruned — transient failures keep their registration.
+        await _deviceRepository.Received(1).RemoveTokensAsync(
+            Arg.Is<IReadOnlyCollection<string>>(t => t.Count == 1 && t.Contains("stale-token")),
+            Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task SendToUserAsync_DeduplicatesTokensBeforeSending()
+    {
+        _fcmClient.IsConfigured.Returns(true);
+        _deviceRepository.GetByUserIdAsync(_userId, Arg.Any<CancellationToken>())
+            .Returns(new List<UserDevice> { Device(_userId, "token-a"), Device(_userId, "token-a") });
+        _fcmClient.SendAsync(
+                Arg.Any<IReadOnlyList<string>>(), Arg.Any<string>(), Arg.Any<string>(),
+                Arg.Any<IReadOnlyDictionary<string, string>>(), Arg.Any<CancellationToken>())
+            .Returns(new List<FcmSendResult> { new() { Token = "token-a", Success = true } });
+
+        await _service.SendToUserAsync(_userId, "Title", "Body");
+
+        await _fcmClient.Received(1).SendAsync(
+            Arg.Is<IReadOnlyList<string>>(t => t.Count == 1),
+            Arg.Any<string>(), Arg.Any<string>(),
+            Arg.Any<IReadOnlyDictionary<string, string>>(), Arg.Any<CancellationToken>());
+    }
+}

--- a/tests/MyMascada.Tests.Unit/Services/PushContentFormatterTests.cs
+++ b/tests/MyMascada.Tests.Unit/Services/PushContentFormatterTests.cs
@@ -1,0 +1,98 @@
+using MyMascada.Domain.Enums;
+using MyMascada.Infrastructure.Services.Push;
+
+namespace MyMascada.Tests.Unit.Services;
+
+public class PushContentFormatterTests
+{
+    [Fact]
+    public void FormatContent_CategorizationReminderTemplate_ExpandsCount()
+    {
+        var (title, body) = PushContentFormatter.FormatContent(
+            "CategorizationReminder", "CategorizationReminder.body",
+            """{"href":"/transactions/categorize","count":5}""");
+
+        title.Should().Be("Transactions to categorize");
+        body.Should().Be("You have 5 uncategorized transactions");
+    }
+
+    [Fact]
+    public void FormatContent_CategorizationReminderSingular_UsesSingularCopy()
+    {
+        var (_, body) = PushContentFormatter.FormatContent(
+            "CategorizationReminder", "CategorizationReminder.body",
+            """{"count":1}""");
+
+        body.Should().Be("You have 1 uncategorized transaction");
+    }
+
+    [Fact]
+    public void FormatContent_RuleSuggestionsTemplate_ExpandsCount()
+    {
+        var (title, body) = PushContentFormatter.FormatContent(
+            "RuleSuggestionsAvailable", "RuleSuggestionsAvailable.body",
+            """{"href":"/rules/suggestions","templateKey":"RuleSuggestionsAvailable","count":3}""");
+
+        title.Should().Be("New rule suggestions");
+        body.Should().Be("3 new categorization rule suggestions are available");
+    }
+
+    [Fact]
+    public void FormatContent_TransactionReminderTemplate_ExpandsMerchantAmountAndDate()
+    {
+        var (title, body) = PushContentFormatter.FormatContent(
+            "TransactionReminder", "TransactionReminder.body",
+            """{"href":"/transactions","templateKey":"TransactionReminder","merchantName":"Netflix","amountMinorUnits":1599,"dateIso":"2026-06-15"}""");
+
+        title.Should().Be("Upcoming transaction");
+        body.Should().Be("Netflix — 15.99 due on 2026-06-15");
+    }
+
+    [Fact]
+    public void FormatContent_NonTemplateNotification_PassesThroughUnchanged()
+    {
+        var (title, body) = PushContentFormatter.FormatContent(
+            "Budget exceeded", "You spent more than your Groceries budget.", null);
+
+        title.Should().Be("Budget exceeded");
+        body.Should().Be("You spent more than your Groceries budget.");
+    }
+
+    [Fact]
+    public void FormatContent_MalformedDataJson_FallsBackGracefully()
+    {
+        var (title, body) = PushContentFormatter.FormatContent(
+            "CategorizationReminder", "CategorizationReminder.body", "{not-json");
+
+        title.Should().Be("Transactions to categorize");
+        body.Should().Be("You have 0 uncategorized transactions");
+    }
+
+    [Fact]
+    public void BuildDataPayload_IncludesRouteNotificationIdAndType()
+    {
+        var notificationId = Guid.NewGuid();
+
+        var payload = PushContentFormatter.BuildDataPayload(NotificationType.BudgetExceeded, notificationId);
+
+        payload["route"].Should().Be("/dashboard/budgets");
+        payload["notificationId"].Should().Be(notificationId.ToString());
+        payload["notificationType"].Should().Be("BudgetExceeded");
+    }
+
+    [Theory]
+    [InlineData(NotificationType.TransactionReminder, "/transactions")]
+    [InlineData(NotificationType.CategorizationReminder, "/transactions")]
+    [InlineData(NotificationType.LargeTransaction, "/transactions")]
+    [InlineData(NotificationType.BudgetThreshold, "/dashboard/budgets")]
+    [InlineData(NotificationType.BudgetExceeded, "/dashboard/budgets")]
+    [InlineData(NotificationType.GoalMilestone, "/dashboard/goals")]
+    [InlineData(NotificationType.AccountSyncFailed, "/dashboard/bank-connections")]
+    [InlineData(NotificationType.RuleSuggestionsAvailable, "/dashboard/rules/suggestions")]
+    [InlineData(NotificationType.SystemMessage, "/dashboard")]
+    [InlineData(NotificationType.RunwayWarning, "/dashboard")]
+    public void MapMobileRoute_MapsNotificationTypesToMobileRoutes(NotificationType type, string expectedRoute)
+    {
+        PushContentFormatter.MapMobileRoute(type).Should().Be(expectedRoute);
+    }
+}


### PR DESCRIPTION
## Summary
- New `UserDevice` registry: `POST /api/v1/devices` (idempotent upsert, handles same-device user switch and concurrent-registration race via DbUpdateException recovery) and `DELETE /api/v1/devices` with body `{token}` (kept out of URL path so tokens never hit proxy logs)
- `IPushNotificationService` → `FirebasePushNotificationService` (FirebaseAdmin 3.5.0 behind testable `IFcmClient`); fail-soft when unconfigured; prunes only `Unregistered` tokens (INVALID_ARGUMENT deliberately not pruned — FCM returns it for malformed messages too)
- Wired into `NotificationService.CreateNotificationAsync`: every in-app notification now also pushes, honoring existing per-type channel preferences, quiet hours and rate limits; push failure never blocks in-app creation
- Data payload carries `route`/`notificationId`/`notificationType` matching the mobile tap handler
- `UserDataDeletionService` explicitly deletes UserDevices (plus DB cascade)
- 46 new unit tests (1149 total passing)

## Config required before push works in prod
`fly secrets set Firebase__ServiceAccountJson="$(cat service-account.json)" -a mymascada-api` — see `docs/push-notifications.md`

## Notes
- Adversarially reviewed (verdict: ship); review fixes included in `e4ba0b3`
- Mobile client counterpart (token sync on login/refresh, unregister on logout) lands in the mobile repo's `feat/release-readiness` branch
- Known gap (pre-existing): no scheduled job calls `NotifyTransactionReminderAsync` yet — bill-reminder scheduling comes with the recurring-transactions feature

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added mobile push notification support via device registration endpoints
  * Users can now register and unregister iOS/Android devices for push notifications
  * Push notifications automatically deliver to registered devices based on user preferences
  * Automatic cleanup of invalid device tokens

* **Documentation**
  * Added comprehensive push notification system documentation

* **Chores**
  * Added Firebase Cloud Messaging integration
  * Added database migration for device storage

<!-- end of auto-generated comment: release notes by coderabbit.ai -->