### PR TITLE
feat: transaction splits API (read + atomic replace)

### DIFF
--- a/src/Core/MyMascada.Application/Common/Interfaces/ITransactionRepository.cs
+++ b/src/Core/MyMascada.Application/Common/Interfaces/ITransactionRepository.cs
@@ -12,7 +12,9 @@ public interface ITransactionRepository
 
     /// <summary>
     /// Loads a transaction with its active (non-deleted) splits and their categories,
-    /// in addition to the account and category navigations. Used by the transaction
+    /// in addition to the account and category navigations. Soft-deleted splits are
+    /// excluded by the global query filter on TransactionSplit (see
+    /// ApplicationDbContext), which also applies to Include. Used by the transaction
     /// detail read path and the split write path.
     /// </summary>
     Task<Transaction?> GetByIdWithSplitsAsync(int id, Guid userId);

--- a/src/Core/MyMascada.Application/Common/Interfaces/ITransactionRepository.cs
+++ b/src/Core/MyMascada.Application/Common/Interfaces/ITransactionRepository.cs
@@ -9,6 +9,13 @@ public interface ITransactionRepository
 {
     Task<Transaction?> GetByIdAsync(int id, Guid userId);
     Task<Transaction?> GetByIdAsync(int id);
+
+    /// <summary>
+    /// Loads a transaction with its active (non-deleted) splits and their categories,
+    /// in addition to the account and category navigations. Used by the transaction
+    /// detail read path and the split write path.
+    /// </summary>
+    Task<Transaction?> GetByIdWithSplitsAsync(int id, Guid userId);
     Task<IEnumerable<Transaction>> GetByAccountIdAsync(int accountId, Guid userId);
     Task<bool> HasTransactionsAsync(int accountId, Guid userId);
     Task<IEnumerable<Transaction>> GetByCategoryIdAsync(int categoryId, Guid userId);

--- a/src/Core/MyMascada.Application/Common/Interfaces/IUnitOfWork.cs
+++ b/src/Core/MyMascada.Application/Common/Interfaces/IUnitOfWork.cs
@@ -1,3 +1,5 @@
+using System.Data;
+
 namespace MyMascada.Application.Common.Interfaces;
 
 /// <summary>
@@ -12,6 +14,15 @@ public interface IUnitOfWork
     /// be rolled back when the returned scope is disposed.
     /// </summary>
     Task<IUnitOfWorkTransaction> BeginTransactionAsync(CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// Begins a database transaction with the given isolation level. Use
+    /// <see cref="IsolationLevel.Serializable"/> for read-then-write sequences that must
+    /// be isolated from concurrent requests (one of two conflicting transactions is
+    /// aborted by the database with a serialization failure). The caller must Commit
+    /// or the transaction will be rolled back when the returned scope is disposed.
+    /// </summary>
+    Task<IUnitOfWorkTransaction> BeginTransactionAsync(IsolationLevel isolationLevel, CancellationToken cancellationToken = default);
 }
 
 /// <summary>

--- a/src/Core/MyMascada.Application/Features/Transactions/Commands/UpdateTransactionCommand.cs
+++ b/src/Core/MyMascada.Application/Features/Transactions/Commands/UpdateTransactionCommand.cs
@@ -1,3 +1,4 @@
+using System.Data;
 using MediatR;
 using MyMascada.Application.Common.Interfaces;
 using MyMascada.Application.Features.Categorization.Services;
@@ -40,19 +41,22 @@ public class UpdateTransactionCommandHandler : IRequestHandler<UpdateTransaction
     private readonly ITransferRepository _transferRepository;
     private readonly IAccountAccessService _accountAccessService;
     private readonly ICategorizationHistoryService _historyService;
+    private readonly IUnitOfWork _unitOfWork;
 
     public UpdateTransactionCommandHandler(
         ITransactionRepository transactionRepository,
         ICategoryRepository categoryRepository,
         ITransferRepository transferRepository,
         IAccountAccessService accountAccessService,
-        ICategorizationHistoryService historyService)
+        ICategorizationHistoryService historyService,
+        IUnitOfWork unitOfWork)
     {
         _transactionRepository = transactionRepository;
         _categoryRepository = categoryRepository;
         _transferRepository = transferRepository;
         _accountAccessService = accountAccessService;
         _historyService = historyService;
+        _unitOfWork = unitOfWork;
     }
 
     public async Task<TransactionDto> Handle(UpdateTransactionCommand request, CancellationToken cancellationToken)
@@ -117,6 +121,27 @@ public class UpdateTransactionCommandHandler : IRequestHandler<UpdateTransaction
         var amountChanged = Math.Abs(originalAmount - request.Amount) > 0.01m;
         var originalCategoryId = transaction.CategoryId;
         var originalDescription = transaction.Description;
+
+        // Amount edits must serialize against concurrent PUT /splits replacements:
+        // otherwise this handler clears only the splits it loaded, while a replace
+        // (validated against the old amount) can insert a fresh active set that
+        // commits after this save, leaving active splits that sum to the OLD amount.
+        // Serializable isolation (same mechanism as UpdateTransactionSplitsCommand)
+        // makes the database abort one of the two conflicting requests instead.
+        // Deliberately scoped to amount changes only; other field edits don't touch
+        // splits and don't need it. Disposing without Commit rolls back.
+        await using IUnitOfWorkTransaction? dbTransaction = originalAmount != request.Amount
+            ? await _unitOfWork.BeginTransactionAsync(IsolationLevel.Serializable, cancellationToken)
+            : null;
+
+        if (dbTransaction != null)
+        {
+            // Re-read the splits inside the open serializable transaction so the
+            // database registers the read (the initial load above happened outside
+            // it). The identity map keeps already-tracked instances, and splits
+            // committed since the first load are attached to transaction.Splits.
+            await _transactionRepository.GetByIdWithSplitsAsync(request.Id, request.UserId);
+        }
 
         // Update transaction properties
         transaction.Amount = request.Amount;
@@ -184,6 +209,11 @@ public class UpdateTransactionCommandHandler : IRequestHandler<UpdateTransaction
         }
 
         await _transactionRepository.SaveChangesAsync();
+
+        if (dbTransaction != null)
+        {
+            await dbTransaction.CommitAsync(cancellationToken);
+        }
 
         // Record categorization history (best-effort — transaction update already persisted above)
         var categoryChanged = originalCategoryId != request.CategoryId;

--- a/src/Core/MyMascada.Application/Features/Transactions/Commands/UpdateTransactionCommand.cs
+++ b/src/Core/MyMascada.Application/Features/Transactions/Commands/UpdateTransactionCommand.cs
@@ -61,8 +61,12 @@ public class UpdateTransactionCommandHandler : IRequestHandler<UpdateTransaction
 
     public async Task<TransactionDto> Handle(UpdateTransactionCommand request, CancellationToken cancellationToken)
     {
-        // Get existing transaction (with splits, so an amount change can clear them)
-        var transaction = await _transactionRepository.GetByIdWithSplitsAsync(request.Id, request.UserId);
+        // Get existing transaction WITHOUT splits. Loading splits here would leave
+        // them tracked on the context for every edit, and UpdateAsync marks the whole
+        // tracked graph Modified — a non-amount edit could then write stale split rows
+        // back (IsDeleted = false) over a concurrent split replacement. Splits are
+        // loaded only inside the serializable amount-change branch below.
+        var transaction = await _transactionRepository.GetByIdAsync(request.Id, request.UserId);
         if (transaction == null)
         {
             throw new ArgumentException($"Transaction with ID {request.Id} not found or does not belong to user");
@@ -136,10 +140,10 @@ public class UpdateTransactionCommandHandler : IRequestHandler<UpdateTransaction
 
         if (dbTransaction != null)
         {
-            // Re-read the splits inside the open serializable transaction so the
-            // database registers the read (the initial load above happened outside
-            // it). The identity map keeps already-tracked instances, and splits
-            // committed since the first load are attached to transaction.Splits.
+            // The ONLY place this handler loads splits: inside the open serializable
+            // transaction, so the database registers the read (the initial load above
+            // deliberately excludes splits — see comment there). The identity map
+            // attaches the loaded splits to the already-tracked transaction instance.
             await _transactionRepository.GetByIdWithSplitsAsync(request.Id, request.UserId);
         }
 

--- a/src/Core/MyMascada.Application/Features/Transactions/Commands/UpdateTransactionCommand.cs
+++ b/src/Core/MyMascada.Application/Features/Transactions/Commands/UpdateTransactionCommand.cs
@@ -9,6 +9,15 @@ using MyMascada.Domain.Common;
 
 namespace MyMascada.Application.Features.Transactions.Commands;
 
+/// <summary>
+/// Updates a transaction's editable fields.
+/// Note on splits: if the transaction has splits and the amount actually changes,
+/// all splits are cleared (soft-deleted) because they would no longer sum to the
+/// new amount — an invariant enforced by UpdateTransactionSplitsCommand. The web
+/// frontend has no splits UI, so rejecting amount edits on split transactions
+/// would strand web users; clients that care about splits must re-apply them via
+/// PUT /transactions/{id}/splits after changing the amount.
+/// </summary>
 public class UpdateTransactionCommand : IRequest<TransactionDto>, ITransactionBaseCommand
 {
     public Guid UserId { get; set; }
@@ -48,8 +57,8 @@ public class UpdateTransactionCommandHandler : IRequestHandler<UpdateTransaction
 
     public async Task<TransactionDto> Handle(UpdateTransactionCommand request, CancellationToken cancellationToken)
     {
-        // Get existing transaction
-        var transaction = await _transactionRepository.GetByIdAsync(request.Id, request.UserId);
+        // Get existing transaction (with splits, so an amount change can clear them)
+        var transaction = await _transactionRepository.GetByIdWithSplitsAsync(request.Id, request.UserId);
         if (transaction == null)
         {
             throw new ArgumentException($"Transaction with ID {request.Id} not found or does not belong to user");
@@ -124,7 +133,23 @@ public class UpdateTransactionCommandHandler : IRequestHandler<UpdateTransaction
         {
             transaction.CategoryId = request.CategoryId;
         }
-        
+
+        // Splits must sum to the transaction amount exactly (invariant enforced by
+        // UpdateTransactionSplitsCommand). If the amount actually changed, clear the
+        // splits (soft-delete, same pattern as the replace logic) rather than reject,
+        // since the web frontend has no splits UI to fix them. Exact comparison on
+        // purpose: even a sub-cent change breaks the exact-sum invariant.
+        if (originalAmount != request.Amount)
+        {
+            var now = DateTimeProvider.UtcNow;
+            foreach (var split in transaction.Splits.Where(s => !s.IsDeleted))
+            {
+                split.IsDeleted = true;
+                split.DeletedAt = now;
+                split.UpdatedAt = now;
+            }
+        }
+
         transaction.UpdatedAt = DateTimeProvider.UtcNow;
 
         await _transactionRepository.UpdateAsync(transaction);

--- a/src/Core/MyMascada.Application/Features/Transactions/Commands/UpdateTransactionCommand.cs
+++ b/src/Core/MyMascada.Application/Features/Transactions/Commands/UpdateTransactionCommand.cs
@@ -120,9 +120,15 @@ public class UpdateTransactionCommandHandler : IRequestHandler<UpdateTransaction
             }
         }
 
-        // Store originals before mutation
+        // Store originals before mutation. Exact comparison on purpose, shared by
+        // the split-clearing, serializable-transaction and transfer-sync branches:
+        // a mismatched tolerance (the transfer sync used > 0.01m historically) lets
+        // a sub-cent edit update this leg's amount while skipping the related
+        // transfer leg, leaving the pair inconsistent. Plain updates are not
+        // constrained to 2 decimal places by the validator, so sub-cent deltas can
+        // genuinely occur.
         var originalAmount = transaction.Amount;
-        var amountChanged = Math.Abs(originalAmount - request.Amount) > 0.01m;
+        var amountChanged = originalAmount != request.Amount;
         var originalCategoryId = transaction.CategoryId;
         var originalDescription = transaction.Description;
 
@@ -134,7 +140,7 @@ public class UpdateTransactionCommandHandler : IRequestHandler<UpdateTransaction
         // makes the database abort one of the two conflicting requests instead.
         // Deliberately scoped to amount changes only; other field edits don't touch
         // splits and don't need it. Disposing without Commit rolls back.
-        await using IUnitOfWorkTransaction? dbTransaction = originalAmount != request.Amount
+        await using IUnitOfWorkTransaction? dbTransaction = amountChanged
             ? await _unitOfWork.BeginTransactionAsync(IsolationLevel.Serializable, cancellationToken)
             : null;
 
@@ -166,9 +172,9 @@ public class UpdateTransactionCommandHandler : IRequestHandler<UpdateTransaction
         // Splits must sum to the transaction amount exactly (invariant enforced by
         // UpdateTransactionSplitsCommand). If the amount actually changed, clear the
         // splits (soft-delete, same pattern as the replace logic) rather than reject,
-        // since the web frontend has no splits UI to fix them. Exact comparison on
-        // purpose: even a sub-cent change breaks the exact-sum invariant.
-        if (originalAmount != request.Amount)
+        // since the web frontend has no splits UI to fix them. Even a sub-cent
+        // change breaks the exact-sum invariant.
+        if (amountChanged)
         {
             var now = DateTimeProvider.UtcNow;
             foreach (var split in transaction.Splits.Where(s => !s.IsDeleted))

--- a/src/Core/MyMascada.Application/Features/Transactions/Commands/UpdateTransactionSplitsCommand.cs
+++ b/src/Core/MyMascada.Application/Features/Transactions/Commands/UpdateTransactionSplitsCommand.cs
@@ -1,0 +1,133 @@
+using MediatR;
+using MyMascada.Application.Common.Interfaces;
+using MyMascada.Application.Features.Transactions.DTOs;
+using MyMascada.Application.Features.Transactions.Mappings;
+using MyMascada.Domain.Common;
+using MyMascada.Domain.Entities;
+
+namespace MyMascada.Application.Features.Transactions.Commands;
+
+/// <summary>
+/// Atomically replaces the splits of a transaction. A null or empty
+/// <see cref="Splits"/> list clears all splits (un-splits the transaction).
+/// Splitting does NOT change the parent transaction's CategoryId; analytics
+/// and budgets currently source category from the parent transaction only.
+/// </summary>
+public class UpdateTransactionSplitsCommand : IRequest<TransactionDto>
+{
+    public Guid UserId { get; set; }
+    public int TransactionId { get; set; }
+    public List<TransactionSplitInputDto>? Splits { get; set; }
+}
+
+public class UpdateTransactionSplitsCommandHandler : IRequestHandler<UpdateTransactionSplitsCommand, TransactionDto>
+{
+    private readonly ITransactionRepository _transactionRepository;
+    private readonly ICategoryRepository _categoryRepository;
+    private readonly IAccountAccessService _accountAccessService;
+
+    public UpdateTransactionSplitsCommandHandler(
+        ITransactionRepository transactionRepository,
+        ICategoryRepository categoryRepository,
+        IAccountAccessService accountAccessService)
+    {
+        _transactionRepository = transactionRepository;
+        _categoryRepository = categoryRepository;
+        _accountAccessService = accountAccessService;
+    }
+
+    public async Task<TransactionDto> Handle(UpdateTransactionSplitsCommand request, CancellationToken cancellationToken)
+    {
+        var transaction = await _transactionRepository.GetByIdWithSplitsAsync(request.TransactionId, request.UserId);
+        if (transaction == null)
+        {
+            throw new ArgumentException($"Transaction with ID {request.TransactionId} not found or does not belong to user");
+        }
+
+        // Verify the user has modify permission on the transaction's account (owner or Manager role)
+        if (!await _accountAccessService.CanModifyAccountAsync(request.UserId, transaction.AccountId))
+        {
+            throw new UnauthorizedAccessException("You do not have permission to update transactions on this account.");
+        }
+
+        // Transfer components cannot carry categories (see UpdateTransactionCommand),
+        // so they cannot be split either.
+        if (transaction.IsTransfer())
+        {
+            throw new ArgumentException("Transfer transactions cannot be split");
+        }
+
+        var newSplits = request.Splits ?? new List<TransactionSplitInputDto>();
+
+        if (newSplits.Count > 0)
+        {
+            ValidateSplits(transaction, newSplits);
+            await ValidateCategoriesAsync(request.UserId, newSplits);
+        }
+
+        var now = DateTimeProvider.UtcNow;
+
+        // Soft-delete all currently active splits (replace semantics).
+        foreach (var existing in transaction.Splits.Where(s => !s.IsDeleted))
+        {
+            existing.IsDeleted = true;
+            existing.DeletedAt = now;
+            existing.UpdatedAt = now;
+        }
+
+        foreach (var item in newSplits)
+        {
+            transaction.Splits.Add(new TransactionSplit
+            {
+                TransactionId = transaction.Id,
+                CategoryId = item.CategoryId,
+                Amount = item.Amount,
+                Description = item.Description,
+                CreatedAt = now,
+                UpdatedAt = now
+            });
+        }
+
+        transaction.UpdatedAt = now;
+
+        // Single SaveChanges inside UpdateAsync -> the replace is atomic.
+        await _transactionRepository.UpdateAsync(transaction);
+
+        // Re-load so newly added splits have their Category navigation populated
+        // for the response DTO (CategoryName/CategoryColor).
+        var updated = await _transactionRepository.GetByIdWithSplitsAsync(request.TransactionId, request.UserId);
+        return TransactionMapper.ToDto(updated ?? transaction);
+    }
+
+    private static void ValidateSplits(Transaction transaction, List<TransactionSplitInputDto> splits)
+    {
+        if (transaction.Amount == 0)
+        {
+            throw new ArgumentException("A zero-amount transaction cannot be split");
+        }
+
+        var transactionSign = Math.Sign(transaction.Amount);
+        if (splits.Any(s => Math.Sign(s.Amount) != transactionSign))
+        {
+            throw new ArgumentException("Each split amount must be non-zero and have the same sign as the transaction amount");
+        }
+
+        var sum = splits.Sum(s => s.Amount);
+        if (sum != transaction.Amount)
+        {
+            throw new ArgumentException($"Split amounts must sum to the transaction amount exactly. Expected {transaction.Amount} but got {sum}");
+        }
+    }
+
+    private async Task ValidateCategoriesAsync(Guid userId, List<TransactionSplitInputDto> splits)
+    {
+        foreach (var categoryId in splits.Select(s => s.CategoryId).Distinct())
+        {
+            var categoryExists = await _categoryRepository.ExistsAsync(categoryId, userId);
+            if (!categoryExists)
+            {
+                throw new ArgumentException($"Category with ID {categoryId} not found or does not belong to user");
+            }
+        }
+    }
+}

--- a/src/Core/MyMascada.Application/Features/Transactions/Commands/UpdateTransactionSplitsCommand.cs
+++ b/src/Core/MyMascada.Application/Features/Transactions/Commands/UpdateTransactionSplitsCommand.cs
@@ -1,3 +1,4 @@
+using System.Data;
 using MediatR;
 using MyMascada.Application.Common.Interfaces;
 using MyMascada.Application.Features.Transactions.DTOs;
@@ -28,19 +29,29 @@ public class UpdateTransactionSplitsCommandHandler : IRequestHandler<UpdateTrans
     private readonly ITransactionRepository _transactionRepository;
     private readonly ICategoryRepository _categoryRepository;
     private readonly IAccountAccessService _accountAccessService;
+    private readonly IUnitOfWork _unitOfWork;
 
     public UpdateTransactionSplitsCommandHandler(
         ITransactionRepository transactionRepository,
         ICategoryRepository categoryRepository,
-        IAccountAccessService accountAccessService)
+        IAccountAccessService accountAccessService,
+        IUnitOfWork unitOfWork)
     {
         _transactionRepository = transactionRepository;
         _categoryRepository = categoryRepository;
         _accountAccessService = accountAccessService;
+        _unitOfWork = unitOfWork;
     }
 
     public async Task<TransactionDto> Handle(UpdateTransactionSplitsCommand request, CancellationToken cancellationToken)
     {
+        // Serializable so two overlapping replace requests for the same transaction
+        // cannot both read the same active split set and each append their own rows
+        // (which would leave two active sets that no longer sum to the amount).
+        // The database aborts one of the conflicting transactions with a
+        // serialization failure instead. Disposing without Commit rolls back.
+        await using var dbTransaction = await _unitOfWork.BeginTransactionAsync(IsolationLevel.Serializable, cancellationToken);
+
         var transaction = await _transactionRepository.GetByIdWithSplitsAsync(request.TransactionId, request.UserId);
         if (transaction == null)
         {
@@ -93,13 +104,22 @@ public class UpdateTransactionSplitsCommandHandler : IRequestHandler<UpdateTrans
 
         transaction.UpdatedAt = now;
 
-        // Single SaveChanges inside UpdateAsync -> the replace is atomic.
         await _transactionRepository.UpdateAsync(transaction);
 
         // Re-load so newly added splits have their Category navigation populated
-        // for the response DTO (CategoryName/CategoryColor).
+        // for the response DTO (CategoryName/CategoryColor). Inside the open
+        // transaction this reads our own writes.
         var updated = await _transactionRepository.GetByIdWithSplitsAsync(request.TransactionId, request.UserId);
-        return TransactionMapper.ToDto(updated ?? transaction);
+        if (updated == null)
+        {
+            // Should be impossible inside the open transaction; fail loudly rather
+            // than return a DTO with unpopulated split category names/colors.
+            throw new InvalidOperationException($"Transaction {request.TransactionId} could not be reloaded after updating splits");
+        }
+
+        await dbTransaction.CommitAsync(cancellationToken);
+
+        return TransactionMapper.ToDto(updated);
     }
 
     private static void ValidateSplits(Transaction transaction, List<TransactionSplitInputDto> splits)

--- a/src/Core/MyMascada.Application/Features/Transactions/Commands/UpdateTransactionSplitsCommand.cs
+++ b/src/Core/MyMascada.Application/Features/Transactions/Commands/UpdateTransactionSplitsCommand.cs
@@ -12,6 +12,9 @@ namespace MyMascada.Application.Features.Transactions.Commands;
 /// <see cref="Splits"/> list clears all splits (un-splits the transaction).
 /// Splitting does NOT change the parent transaction's CategoryId; analytics
 /// and budgets currently source category from the parent transaction only.
+/// Note: editing the transaction's amount via UpdateTransactionCommand clears
+/// existing splits (they would no longer sum to the new amount), so clients
+/// must re-apply splits after an amount change.
 /// </summary>
 public class UpdateTransactionSplitsCommand : IRequest<TransactionDto>
 {

--- a/src/Core/MyMascada.Application/Features/Transactions/DTOs/TransactionDto.cs
+++ b/src/Core/MyMascada.Application/Features/Transactions/DTOs/TransactionDto.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Collections.Generic;
 using MyMascada.Domain.Enums;
 
 namespace MyMascada.Application.Features.Transactions.DTOs;
@@ -37,7 +38,11 @@ public class TransactionDto
     public Guid? TransferId { get; set; }
     public bool IsTransferSource { get; set; }
     public int? RelatedTransactionId { get; set; }
-    
+
+    // Splits information (additive; only populated on the single-transaction read
+    // path — null for list views and for transactions without splits)
+    public List<TransactionSplitDto>? Splits { get; set; }
+
     // Audit information
     public DateTime CreatedAt { get; set; }
     public DateTime UpdatedAt { get; set; }

--- a/src/Core/MyMascada.Application/Features/Transactions/DTOs/UpdateTransactionSplitsRequest.cs
+++ b/src/Core/MyMascada.Application/Features/Transactions/DTOs/UpdateTransactionSplitsRequest.cs
@@ -1,0 +1,24 @@
+using System.Collections.Generic;
+
+namespace MyMascada.Application.Features.Transactions.DTOs;
+
+/// <summary>
+/// Request body for PUT /api/v1/transactions/{id}/splits.
+/// Replaces the transaction's splits atomically; a null or empty list clears
+/// all splits (un-splits the transaction).
+/// </summary>
+public class UpdateTransactionSplitsRequest
+{
+    public List<TransactionSplitInputDto>? Splits { get; set; }
+}
+
+/// <summary>
+/// A single split item supplied by the client. Mirrors the writable subset of
+/// <see cref="TransactionSplitDto"/> (category, amount, optional description).
+/// </summary>
+public class TransactionSplitInputDto
+{
+    public int CategoryId { get; set; }
+    public decimal Amount { get; set; }
+    public string? Description { get; set; }
+}

--- a/src/Core/MyMascada.Application/Features/Transactions/Mappings/TransactionMapper.cs
+++ b/src/Core/MyMascada.Application/Features/Transactions/Mappings/TransactionMapper.cs
@@ -52,8 +52,14 @@ public static partial class TransactionMapper
         dto.CategoryColor = transaction.Category?.Color;
         dto.CategoryIcon = transaction.Category?.Icon;
         dto.RelatedAccountName = transaction.RelatedTransaction?.Account?.Name;
-        dto.Splits = transaction.Splits is { Count: > 0 } splits
-            ? splits.Select(ToSplitDto).ToList()
+        // Same defensive filtering as ToDto: the global query filter on
+        // TransactionSplit means EF never loads soft-deleted splits, but keep the
+        // two mappers consistent in case a caller materializes them another way.
+        var activeDetailSplits = transaction.Splits?
+            .Where(s => !s.IsDeleted)
+            .ToList();
+        dto.Splits = activeDetailSplits is { Count: > 0 }
+            ? activeDetailSplits.Select(ToSplitDto).ToList()
             : null;
         return dto;
     }

--- a/src/Core/MyMascada.Application/Features/Transactions/Mappings/TransactionMapper.cs
+++ b/src/Core/MyMascada.Application/Features/Transactions/Mappings/TransactionMapper.cs
@@ -14,12 +14,21 @@ public static partial class TransactionMapper
         dto.AccountName = transaction.Account?.Name ?? string.Empty;
         dto.CategoryName = transaction.Category?.Name;
         dto.CategoryColor = transaction.Category?.Color;
+        // Splits are only populated when the navigation was eagerly loaded
+        // (single-transaction read path); list queries leave it null.
+        var activeSplits = transaction.Splits?
+            .Where(s => !s.IsDeleted)
+            .ToList();
+        dto.Splits = activeSplits is { Count: > 0 }
+            ? activeSplits.Select(ToSplitDto).ToList()
+            : null;
         return dto;
     }
 
     [MapperIgnoreTarget(nameof(TransactionDto.AccountName))]
     [MapperIgnoreTarget(nameof(TransactionDto.CategoryName))]
     [MapperIgnoreTarget(nameof(TransactionDto.CategoryColor))]
+    [MapperIgnoreTarget(nameof(TransactionDto.Splits))]
     private static partial TransactionDto TransactionToDtoGenerated(Transaction transaction);
 
     // Transaction -> TransactionDetailDto (for single view)

--- a/src/Core/MyMascada.Application/Features/Transactions/Queries/GetTransactionQuery.cs
+++ b/src/Core/MyMascada.Application/Features/Transactions/Queries/GetTransactionQuery.cs
@@ -22,7 +22,7 @@ public class GetTransactionQueryHandler : IRequestHandler<GetTransactionQuery, T
 
     public async Task<TransactionDto?> Handle(GetTransactionQuery request, CancellationToken cancellationToken)
     {
-        var transaction = await _transactionRepository.GetByIdAsync(request.Id, request.UserId);
+        var transaction = await _transactionRepository.GetByIdWithSplitsAsync(request.Id, request.UserId);
         if (transaction == null)
         {
             return null;

--- a/src/Core/MyMascada.Application/Features/Transactions/Validators/UpdateTransactionSplitsCommandValidator.cs
+++ b/src/Core/MyMascada.Application/Features/Transactions/Validators/UpdateTransactionSplitsCommandValidator.cs
@@ -1,0 +1,34 @@
+using FluentValidation;
+using MyMascada.Application.Features.Transactions.Commands;
+
+namespace MyMascada.Application.Features.Transactions.Validators;
+
+public class UpdateTransactionSplitsCommandValidator : AbstractValidator<UpdateTransactionSplitsCommand>
+{
+    public UpdateTransactionSplitsCommandValidator()
+    {
+        RuleFor(x => x.TransactionId)
+            .GreaterThan(0)
+            .WithMessage("A valid transaction ID must be specified.");
+
+        RuleForEach(x => x.Splits)
+            .ChildRules(split =>
+            {
+                split.RuleFor(s => s.CategoryId)
+                    .GreaterThan(0)
+                    .WithMessage("Each split must specify a valid category ID.");
+
+                split.RuleFor(s => s.Amount)
+                    .NotEqual(0)
+                    .WithMessage("Split amounts must not be zero.")
+                    .Must(amount => amount == decimal.Round(amount, 2))
+                    .WithMessage("Split amounts cannot have more than 2 decimal places.");
+
+                split.RuleFor(s => s.Description)
+                    .MaximumLength(500)
+                    .WithMessage("Split description cannot exceed 500 characters.")
+                    .When(s => s.Description != null);
+            })
+            .When(x => x.Splits != null);
+    }
+}

--- a/src/Infrastructure/MyMascada.Infrastructure/Data/UnitOfWork.cs
+++ b/src/Infrastructure/MyMascada.Infrastructure/Data/UnitOfWork.cs
@@ -1,3 +1,5 @@
+using System.Data;
+using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Storage;
 using Microsoft.Extensions.Logging;
 using MyMascada.Application.Common.Interfaces;
@@ -23,6 +25,12 @@ public class UnitOfWork : IUnitOfWork
     public async Task<IUnitOfWorkTransaction> BeginTransactionAsync(CancellationToken cancellationToken = default)
     {
         var transaction = await _context.Database.BeginTransactionAsync(cancellationToken);
+        return new UnitOfWorkTransaction(transaction, _logger);
+    }
+
+    public async Task<IUnitOfWorkTransaction> BeginTransactionAsync(IsolationLevel isolationLevel, CancellationToken cancellationToken = default)
+    {
+        var transaction = await _context.Database.BeginTransactionAsync(isolationLevel, cancellationToken);
         return new UnitOfWorkTransaction(transaction, _logger);
     }
 

--- a/src/Infrastructure/MyMascada.Infrastructure/Repositories/TransactionRepository.cs
+++ b/src/Infrastructure/MyMascada.Infrastructure/Repositories/TransactionRepository.cs
@@ -36,6 +36,18 @@ public class TransactionRepository : ITransactionRepository
                                      accessibleIds.Contains(t.AccountId));
     }
 
+    public async Task<Transaction?> GetByIdWithSplitsAsync(int id, Guid userId)
+    {
+        var accessibleIds = await _accountAccess.GetAccessibleAccountIdsAsync(userId);
+        return await _context.Transactions
+            .Include(t => t.Account)
+            .Include(t => t.Category)
+            .Include(t => t.Splits)
+                .ThenInclude(s => s.Category)
+            .FirstOrDefaultAsync(t => t.Id == id &&
+                                     accessibleIds.Contains(t.AccountId));
+    }
+
     public async Task<IEnumerable<Transaction>> GetByAccountIdAsync(int accountId, Guid userId)
     {
         if (!await _accountAccess.CanAccessAccountAsync(userId, accountId))

--- a/src/WebAPI/MyMascada.WebAPI/Controllers/TransactionsController.cs
+++ b/src/WebAPI/MyMascada.WebAPI/Controllers/TransactionsController.cs
@@ -8,6 +8,7 @@ using MyMascada.Application.Features.Transactions.Commands;
 using MyMascada.Application.Features.Transactions.DTOs;
 using MyMascada.Application.Features.Transactions.Queries;
 using MyMascada.Domain.Enums;
+using MyMascada.WebAPI.Extensions;
 
 namespace MyMascada.WebAPI.Controllers;
 
@@ -188,6 +189,14 @@ public class TransactionsController : ControllerBase
         {
             return BadRequest(new { message = ex.Message });
         }
+        catch (Exception ex) when (ex.IsPostgresSerializationFailure())
+        {
+            // The amount-edit path runs in a Serializable transaction; losing a race
+            // with a concurrent split replacement aborts this request with a
+            // serialization failure. Retryable, so 409 rather than a raw 500.
+            _logger.LogWarning(ex, "Concurrent modification conflict updating transaction {TransactionId}", id);
+            return Conflict(new { message = "This transaction was modified concurrently - please retry" });
+        }
     }
 
     /// <summary>
@@ -220,6 +229,14 @@ public class TransactionsController : ControllerBase
         {
             _logger.LogWarning(ex, "Unauthorized transaction split update attempt for user {UserId}", _currentUserService.GetUserId());
             return StatusCode(StatusCodes.Status403Forbidden, new { message = "You do not have permission to update transactions on this account." });
+        }
+        catch (Exception ex) when (ex.IsPostgresSerializationFailure())
+        {
+            // The replace runs in a Serializable transaction; losing a race with a
+            // concurrent replace or amount edit aborts this request with a
+            // serialization failure. Retryable, so 409 rather than a raw 500.
+            _logger.LogWarning(ex, "Concurrent modification conflict updating splits for transaction {TransactionId}", id);
+            return Conflict(new { message = "This transaction was modified concurrently - please retry" });
         }
     }
 

--- a/src/WebAPI/MyMascada.WebAPI/Controllers/TransactionsController.cs
+++ b/src/WebAPI/MyMascada.WebAPI/Controllers/TransactionsController.cs
@@ -190,6 +190,36 @@ public class TransactionsController : ControllerBase
         }
     }
 
+    /// <summary>
+    /// Atomically replaces the splits of a transaction.
+    /// An empty or null splits list clears all splits (un-splits the transaction).
+    /// </summary>
+    [HttpPut("{id}/splits")]
+    public async Task<ActionResult<TransactionDto>> UpdateTransactionSplits(int id, [FromBody] UpdateTransactionSplitsRequest request)
+    {
+        var command = new UpdateTransactionSplitsCommand
+        {
+            UserId = _currentUserService.GetUserId(),
+            TransactionId = id,
+            Splits = request.Splits
+        };
+
+        try
+        {
+            var result = await _mediator.Send(command);
+            return Ok(result);
+        }
+        catch (ArgumentException ex)
+        {
+            return BadRequest(new { message = ex.Message });
+        }
+        catch (UnauthorizedAccessException ex)
+        {
+            _logger.LogWarning(ex, "Unauthorized transaction split update attempt for user {UserId}", _currentUserService.GetUserId());
+            return StatusCode(StatusCodes.Status403Forbidden, new { message = "You do not have permission to update transactions on this account." });
+        }
+    }
+
     [HttpDelete("{id}")]
     public async Task<IActionResult> DeleteTransaction(int id)
     {

--- a/src/WebAPI/MyMascada.WebAPI/Controllers/TransactionsController.cs
+++ b/src/WebAPI/MyMascada.WebAPI/Controllers/TransactionsController.cs
@@ -193,6 +193,9 @@ public class TransactionsController : ControllerBase
     /// <summary>
     /// Atomically replaces the splits of a transaction.
     /// An empty or null splits list clears all splits (un-splits the transaction).
+    /// Note: changing the transaction's amount via PUT /transactions/{id} clears
+    /// any existing splits (they would no longer sum to the new amount), so
+    /// clients must re-apply splits after an amount change.
     /// </summary>
     [HttpPut("{id}/splits")]
     public async Task<ActionResult<TransactionDto>> UpdateTransactionSplits(int id, [FromBody] UpdateTransactionSplitsRequest request)

--- a/src/WebAPI/MyMascada.WebAPI/Extensions/ExceptionExtensions.cs
+++ b/src/WebAPI/MyMascada.WebAPI/Extensions/ExceptionExtensions.cs
@@ -1,0 +1,32 @@
+using Npgsql;
+
+namespace MyMascada.WebAPI.Extensions;
+
+/// <summary>
+/// Helpers for classifying exceptions surfaced by the data layer.
+/// </summary>
+public static class ExceptionExtensions
+{
+    /// <summary>
+    /// True when the exception (or any inner exception) is a PostgreSQL serialization
+    /// failure (SQLSTATE 40001). These are raised when a Serializable transaction loses
+    /// a race with a concurrent write (e.g. two split replacements, or a split
+    /// replacement racing an amount edit) and are safe for the client to retry.
+    /// EF wraps them in <see cref="Microsoft.EntityFrameworkCore.DbUpdateException"/>
+    /// at SaveChanges time; at Commit time they can surface as a bare
+    /// <see cref="PostgresException"/> — hence the inner-exception walk.
+    /// </summary>
+    public static bool IsPostgresSerializationFailure(this Exception exception)
+    {
+        for (var current = exception; current != null; current = current.InnerException)
+        {
+            if (current is PostgresException postgres &&
+                postgres.SqlState == PostgresErrorCodes.SerializationFailure)
+            {
+                return true;
+            }
+        }
+
+        return false;
+    }
+}

--- a/src/WebAPI/MyMascada.WebAPI/Middleware/GlobalExceptionHandlingMiddleware.cs
+++ b/src/WebAPI/MyMascada.WebAPI/Middleware/GlobalExceptionHandlingMiddleware.cs
@@ -5,6 +5,7 @@ using Microsoft.Extensions.Logging;
 using MyMascada.Application.Common.Interfaces;
 using MyMascada.Domain.Common;
 using MyMascada.Infrastructure.Services.BankIntegration.Providers;
+using MyMascada.WebAPI.Extensions;
 
 namespace MyMascada.WebAPI.Middleware;
 
@@ -159,6 +160,14 @@ public class GlobalExceptionHandlingMiddleware
     {
         return exception switch
         {
+            // Serializable/optimistic concurrency conflicts (PostgreSQL SQLSTATE 40001):
+            // the request lost a race with a concurrent write and is safe to retry.
+            // Checked first because the failure may arrive wrapped in other exception
+            // types. Safety net for any path the controllers don't translate themselves.
+            var concurrencyEx when concurrencyEx.IsPostgresSerializationFailure() =>
+                (HttpStatusCode.Conflict, LogLevel.Warning,
+                "This record was modified by another request at the same time - please retry."),
+
             // Business rule violations (more specific exceptions first)
             ArgumentNullException _ => (HttpStatusCode.BadRequest, LogLevel.Warning,
                 "Required information is missing. Please provide all necessary data."),

--- a/tests/MyMascada.Tests.Unit/Commands/UpdateTransactionCommandHandlerTests.cs
+++ b/tests/MyMascada.Tests.Unit/Commands/UpdateTransactionCommandHandlerTests.cs
@@ -1,0 +1,119 @@
+using MyMascada.Application.Common.Interfaces;
+using MyMascada.Application.Features.Categorization.Services;
+using MyMascada.Application.Features.Transactions.Commands;
+using MyMascada.Domain.Entities;
+using MyMascada.Domain.Enums;
+
+namespace MyMascada.Tests.Unit.Commands;
+
+public class UpdateTransactionCommandHandlerTests
+{
+    private readonly ITransactionRepository _transactionRepository;
+    private readonly ICategoryRepository _categoryRepository;
+    private readonly ITransferRepository _transferRepository;
+    private readonly IAccountAccessService _accountAccessService;
+    private readonly ICategorizationHistoryService _historyService;
+    private readonly UpdateTransactionCommandHandler _handler;
+    private readonly Guid _userId = Guid.NewGuid();
+
+    public UpdateTransactionCommandHandlerTests()
+    {
+        _transactionRepository = Substitute.For<ITransactionRepository>();
+        _categoryRepository = Substitute.For<ICategoryRepository>();
+        _transferRepository = Substitute.For<ITransferRepository>();
+        _accountAccessService = Substitute.For<IAccountAccessService>();
+        _historyService = Substitute.For<ICategorizationHistoryService>();
+        _handler = new UpdateTransactionCommandHandler(
+            _transactionRepository,
+            _categoryRepository,
+            _transferRepository,
+            _accountAccessService,
+            _historyService);
+    }
+
+    private Transaction CreateSplitTransaction(decimal amount = -100m)
+    {
+        var transaction = new Transaction
+        {
+            Id = 1,
+            Amount = amount,
+            TransactionDate = DateTime.UtcNow,
+            Description = "Supermarket",
+            Status = TransactionStatus.Cleared,
+            AccountId = 10,
+            Account = new Account { Id = 10, Name = "Checking", UserId = _userId },
+            Splits = new List<TransactionSplit>
+            {
+                new() { Id = 1, TransactionId = 1, CategoryId = 5, Amount = -60m },
+                new() { Id = 2, TransactionId = 1, CategoryId = 6, Amount = -40m }
+            }
+        };
+
+        _transactionRepository.GetByIdWithSplitsAsync(transaction.Id, _userId).Returns(transaction);
+        _accountAccessService.CanModifyAccountAsync(_userId, transaction.AccountId).Returns(true);
+        return transaction;
+    }
+
+    private UpdateTransactionCommand CreateCommand(Transaction transaction, decimal amount)
+    {
+        return new UpdateTransactionCommand
+        {
+            UserId = _userId,
+            Id = transaction.Id,
+            Amount = amount,
+            TransactionDate = transaction.TransactionDate,
+            Description = transaction.Description,
+            Status = transaction.Status,
+            CategoryId = null
+        };
+    }
+
+    [Fact]
+    public async Task Handle_WhenAmountChangesOnSplitTransaction_ShouldClearSplits()
+    {
+        var transaction = CreateSplitTransaction(amount: -100m);
+        var command = CreateCommand(transaction, amount: -120m);
+
+        await _handler.Handle(command, CancellationToken.None);
+
+        // Splits would no longer sum to the new amount, so they must be cleared
+        // (soft-deleted, same pattern as the splits replace endpoint).
+        transaction.Splits.Should().AllSatisfy(s =>
+        {
+            s.IsDeleted.Should().BeTrue();
+            s.DeletedAt.Should().NotBeNull();
+        });
+        transaction.Amount.Should().Be(-120m);
+        await _transactionRepository.Received(1).UpdateAsync(transaction);
+    }
+
+    [Fact]
+    public async Task Handle_WhenAmountChangesBySubCentOnSplitTransaction_ShouldClearSplits()
+    {
+        // Even a sub-cent change breaks the exact-sum invariant.
+        var transaction = CreateSplitTransaction(amount: -100m);
+        var command = CreateCommand(transaction, amount: -100.001m);
+
+        await _handler.Handle(command, CancellationToken.None);
+
+        transaction.Splits.Should().AllSatisfy(s => s.IsDeleted.Should().BeTrue());
+    }
+
+    [Fact]
+    public async Task Handle_WhenAmountUnchangedOnSplitTransaction_ShouldPreserveSplits()
+    {
+        var transaction = CreateSplitTransaction(amount: -100m);
+        var command = CreateCommand(transaction, amount: -100m);
+        command.Notes = "Edited notes only";
+
+        await _handler.Handle(command, CancellationToken.None);
+
+        transaction.Splits.Should().AllSatisfy(s =>
+        {
+            s.IsDeleted.Should().BeFalse();
+            s.DeletedAt.Should().BeNull();
+        });
+        transaction.Notes.Should().Be("Edited notes only");
+        await _transactionRepository.Received(1).UpdateAsync(transaction);
+    }
+}

--- a/tests/MyMascada.Tests.Unit/Commands/UpdateTransactionCommandHandlerTests.cs
+++ b/tests/MyMascada.Tests.Unit/Commands/UpdateTransactionCommandHandlerTests.cs
@@ -39,7 +39,15 @@ public class UpdateTransactionCommandHandlerTests
             _unitOfWork);
     }
 
-    private Transaction CreateSplitTransaction(decimal amount = -100m)
+    /// <summary>
+    /// Models the real repository contract: the splits-free initial load
+    /// (GetByIdAsync) returns the transaction with an EMPTY Splits collection;
+    /// only GetByIdWithSplitsAsync attaches the split rows (mirroring EF's
+    /// identity-map fixup on the already-tracked instance). If the handler
+    /// regresses to loading splits on ordinary edits, the splits-untouched and
+    /// DidNotReceive assertions below actually fail.
+    /// </summary>
+    private (Transaction Transaction, List<TransactionSplit> Splits) CreateSplitTransaction(decimal amount = -100m)
     {
         var transaction = new Transaction
         {
@@ -50,20 +58,24 @@ public class UpdateTransactionCommandHandlerTests
             Status = TransactionStatus.Cleared,
             AccountId = 10,
             Account = new Account { Id = 10, Name = "Checking", UserId = _userId },
-            Splits = new List<TransactionSplit>
-            {
-                new() { Id = 1, TransactionId = 1, CategoryId = 5, Amount = -60m },
-                new() { Id = 2, TransactionId = 1, CategoryId = 6, Amount = -40m }
-            }
+            Splits = new List<TransactionSplit>()
         };
 
-        // Initial load excludes splits (stale tracked splits must not be written
-        // back by ordinary edits); the with-splits load only happens inside the
-        // serializable amount-change branch.
+        var loadedSplits = new List<TransactionSplit>
+        {
+            new() { Id = 1, TransactionId = 1, CategoryId = 5, Amount = -60m },
+            new() { Id = 2, TransactionId = 1, CategoryId = 6, Amount = -40m }
+        };
+
         _transactionRepository.GetByIdAsync(transaction.Id, _userId).Returns(transaction);
-        _transactionRepository.GetByIdWithSplitsAsync(transaction.Id, _userId).Returns(transaction);
+        _transactionRepository.GetByIdWithSplitsAsync(transaction.Id, _userId)
+            .Returns(_ =>
+            {
+                transaction.Splits = loadedSplits;
+                return transaction;
+            });
         _accountAccessService.CanModifyAccountAsync(_userId, transaction.AccountId).Returns(true);
-        return transaction;
+        return (transaction, loadedSplits);
     }
 
     private UpdateTransactionCommand CreateCommand(Transaction transaction, decimal amount)
@@ -83,14 +95,14 @@ public class UpdateTransactionCommandHandlerTests
     [Fact]
     public async Task Handle_WhenAmountChangesOnSplitTransaction_ShouldClearSplits()
     {
-        var transaction = CreateSplitTransaction(amount: -100m);
+        var (transaction, splits) = CreateSplitTransaction(amount: -100m);
         var command = CreateCommand(transaction, amount: -120m);
 
         await _handler.Handle(command, CancellationToken.None);
 
         // Splits would no longer sum to the new amount, so they must be cleared
         // (soft-deleted, same pattern as the splits replace endpoint).
-        transaction.Splits.Should().AllSatisfy(s =>
+        splits.Should().AllSatisfy(s =>
         {
             s.IsDeleted.Should().BeTrue();
             s.DeletedAt.Should().NotBeNull();
@@ -112,28 +124,32 @@ public class UpdateTransactionCommandHandlerTests
     public async Task Handle_WhenAmountChangesBySubCentOnSplitTransaction_ShouldClearSplits()
     {
         // Even a sub-cent change breaks the exact-sum invariant.
-        var transaction = CreateSplitTransaction(amount: -100m);
+        var (transaction, splits) = CreateSplitTransaction(amount: -100m);
         var command = CreateCommand(transaction, amount: -100.001m);
 
         await _handler.Handle(command, CancellationToken.None);
 
-        transaction.Splits.Should().AllSatisfy(s => s.IsDeleted.Should().BeTrue());
+        splits.Should().AllSatisfy(s => s.IsDeleted.Should().BeTrue());
     }
 
     [Fact]
     public async Task Handle_WhenAmountUnchangedOnSplitTransaction_ShouldPreserveSplits()
     {
-        var transaction = CreateSplitTransaction(amount: -100m);
+        var (transaction, splits) = CreateSplitTransaction(amount: -100m);
         var command = CreateCommand(transaction, amount: -100m);
         command.Notes = "Edited notes only";
 
         await _handler.Handle(command, CancellationToken.None);
 
-        transaction.Splits.Should().AllSatisfy(s =>
+        // The split rows were never loaded, let alone touched...
+        splits.Should().AllSatisfy(s =>
         {
             s.IsDeleted.Should().BeFalse();
             s.DeletedAt.Should().BeNull();
         });
+        // ...and the saved entity graph contains no split rows at all, so
+        // UpdateAsync cannot write stale split state back.
+        transaction.Splits.Should().BeEmpty();
         transaction.Notes.Should().Be("Edited notes only");
         await _transactionRepository.Received(1).UpdateAsync(transaction);
 
@@ -147,9 +163,59 @@ public class UpdateTransactionCommandHandlerTests
     }
 
     [Fact]
+    public async Task Handle_WhenTransferAmountChangesBySubCent_ShouldSyncRelatedLegAndTransfer()
+    {
+        // The transfer-sync branch must use the same exact amount-change predicate
+        // as the split-clearing/serializable branch. With the old > 0.01m tolerance,
+        // a sub-cent edit updated this leg but skipped the related leg and the
+        // transfer record, leaving the pair inconsistent.
+        var transferId = Guid.NewGuid();
+        var transaction = new Transaction
+        {
+            Id = 1,
+            Amount = -100m,
+            TransactionDate = DateTime.UtcNow,
+            Description = "Transfer out",
+            Status = TransactionStatus.Cleared,
+            AccountId = 10,
+            Account = new Account { Id = 10, Name = "Checking", UserId = _userId },
+            Type = TransactionType.TransferComponent,
+            TransferId = transferId,
+            RelatedTransactionId = 2,
+            IsTransferSource = true
+        };
+        var relatedTransaction = new Transaction
+        {
+            Id = 2,
+            Amount = 100m,
+            TransactionDate = transaction.TransactionDate,
+            Description = "Transfer in",
+            Status = TransactionStatus.Cleared,
+            AccountId = 11,
+            Account = new Account { Id = 11, Name = "Savings", UserId = _userId }
+        };
+        var transfer = new Transfer { TransferId = transferId, Amount = 100m };
+
+        _transactionRepository.GetByIdAsync(transaction.Id, _userId).Returns(transaction);
+        _transactionRepository.GetByIdWithSplitsAsync(transaction.Id, _userId).Returns(transaction);
+        _transactionRepository.GetByIdAsync(relatedTransaction.Id, _userId).Returns(relatedTransaction);
+        _transferRepository.GetByTransferIdAsync(transferId, _userId).Returns(transfer);
+        _accountAccessService.CanModifyAccountAsync(_userId, transaction.AccountId).Returns(true);
+
+        var command = CreateCommand(transaction, amount: -100.001m);
+
+        await _handler.Handle(command, CancellationToken.None);
+
+        transaction.Amount.Should().Be(-100.001m);
+        relatedTransaction.Amount.Should().Be(100.001m);
+        transfer.Amount.Should().Be(100.001m);
+        await _transferRepository.Received(1).UpdateAsync(transfer);
+    }
+
+    [Fact]
     public async Task Handle_WhenAmountChangesAndUpdateFails_ShouldNotCommitDbTransaction()
     {
-        var transaction = CreateSplitTransaction(amount: -100m);
+        var (transaction, _) = CreateSplitTransaction(amount: -100m);
         var command = CreateCommand(transaction, amount: -120m);
         _transactionRepository.UpdateAsync(transaction)
             .Returns<Task>(_ => throw new InvalidOperationException("db down"));

--- a/tests/MyMascada.Tests.Unit/Commands/UpdateTransactionCommandHandlerTests.cs
+++ b/tests/MyMascada.Tests.Unit/Commands/UpdateTransactionCommandHandlerTests.cs
@@ -1,3 +1,4 @@
+using System.Data;
 using MyMascada.Application.Common.Interfaces;
 using MyMascada.Application.Features.Categorization.Services;
 using MyMascada.Application.Features.Transactions.Commands;
@@ -13,6 +14,8 @@ public class UpdateTransactionCommandHandlerTests
     private readonly ITransferRepository _transferRepository;
     private readonly IAccountAccessService _accountAccessService;
     private readonly ICategorizationHistoryService _historyService;
+    private readonly IUnitOfWork _unitOfWork;
+    private readonly IUnitOfWorkTransaction _dbTransaction;
     private readonly UpdateTransactionCommandHandler _handler;
     private readonly Guid _userId = Guid.NewGuid();
 
@@ -23,12 +26,17 @@ public class UpdateTransactionCommandHandlerTests
         _transferRepository = Substitute.For<ITransferRepository>();
         _accountAccessService = Substitute.For<IAccountAccessService>();
         _historyService = Substitute.For<ICategorizationHistoryService>();
+        _unitOfWork = Substitute.For<IUnitOfWork>();
+        _dbTransaction = Substitute.For<IUnitOfWorkTransaction>();
+        _unitOfWork.BeginTransactionAsync(IsolationLevel.Serializable, Arg.Any<CancellationToken>())
+            .Returns(_dbTransaction);
         _handler = new UpdateTransactionCommandHandler(
             _transactionRepository,
             _categoryRepository,
             _transferRepository,
             _accountAccessService,
-            _historyService);
+            _historyService,
+            _unitOfWork);
     }
 
     private Transaction CreateSplitTransaction(decimal amount = -100m)
@@ -85,6 +93,13 @@ public class UpdateTransactionCommandHandlerTests
         });
         transaction.Amount.Should().Be(-120m);
         await _transactionRepository.Received(1).UpdateAsync(transaction);
+
+        // The clear runs inside a serializable DB transaction (committed) so it
+        // serializes against concurrent PUT /splits replacements, and the splits
+        // are re-read inside that transaction (initial load + in-transaction read).
+        await _unitOfWork.Received(1).BeginTransactionAsync(IsolationLevel.Serializable, Arg.Any<CancellationToken>());
+        await _dbTransaction.Received(1).CommitAsync(Arg.Any<CancellationToken>());
+        await _transactionRepository.Received(2).GetByIdWithSplitsAsync(transaction.Id, _userId);
     }
 
     [Fact]
@@ -115,5 +130,24 @@ public class UpdateTransactionCommandHandlerTests
         });
         transaction.Notes.Should().Be("Edited notes only");
         await _transactionRepository.Received(1).UpdateAsync(transaction);
+
+        // No amount change -> splits untouched -> no serializable transaction needed.
+        await _unitOfWork.DidNotReceiveWithAnyArgs()
+            .BeginTransactionAsync(Arg.Any<IsolationLevel>(), Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task Handle_WhenAmountChangesAndUpdateFails_ShouldNotCommitDbTransaction()
+    {
+        var transaction = CreateSplitTransaction(amount: -100m);
+        var command = CreateCommand(transaction, amount: -120m);
+        _transactionRepository.UpdateAsync(transaction)
+            .Returns<Task>(_ => throw new InvalidOperationException("db down"));
+
+        var act = async () => await _handler.Handle(command, CancellationToken.None);
+
+        await act.Should().ThrowAsync<InvalidOperationException>();
+        // Disposing without commit rolls back, so the half-applied clear is discarded.
+        await _dbTransaction.DidNotReceive().CommitAsync(Arg.Any<CancellationToken>());
     }
 }

--- a/tests/MyMascada.Tests.Unit/Commands/UpdateTransactionCommandHandlerTests.cs
+++ b/tests/MyMascada.Tests.Unit/Commands/UpdateTransactionCommandHandlerTests.cs
@@ -57,6 +57,10 @@ public class UpdateTransactionCommandHandlerTests
             }
         };
 
+        // Initial load excludes splits (stale tracked splits must not be written
+        // back by ordinary edits); the with-splits load only happens inside the
+        // serializable amount-change branch.
+        _transactionRepository.GetByIdAsync(transaction.Id, _userId).Returns(transaction);
         _transactionRepository.GetByIdWithSplitsAsync(transaction.Id, _userId).Returns(transaction);
         _accountAccessService.CanModifyAccountAsync(_userId, transaction.AccountId).Returns(true);
         return transaction;
@@ -95,11 +99,13 @@ public class UpdateTransactionCommandHandlerTests
         await _transactionRepository.Received(1).UpdateAsync(transaction);
 
         // The clear runs inside a serializable DB transaction (committed) so it
-        // serializes against concurrent PUT /splits replacements, and the splits
-        // are re-read inside that transaction (initial load + in-transaction read).
+        // serializes against concurrent PUT /splits replacements. The splits are
+        // loaded exactly once — inside that transaction; the initial load is the
+        // splits-free GetByIdAsync.
         await _unitOfWork.Received(1).BeginTransactionAsync(IsolationLevel.Serializable, Arg.Any<CancellationToken>());
         await _dbTransaction.Received(1).CommitAsync(Arg.Any<CancellationToken>());
-        await _transactionRepository.Received(2).GetByIdWithSplitsAsync(transaction.Id, _userId);
+        await _transactionRepository.Received(1).GetByIdAsync(transaction.Id, _userId);
+        await _transactionRepository.Received(1).GetByIdWithSplitsAsync(transaction.Id, _userId);
     }
 
     [Fact]
@@ -131,9 +137,13 @@ public class UpdateTransactionCommandHandlerTests
         transaction.Notes.Should().Be("Edited notes only");
         await _transactionRepository.Received(1).UpdateAsync(transaction);
 
-        // No amount change -> splits untouched -> no serializable transaction needed.
+        // No amount change -> splits untouched -> no serializable transaction needed,
+        // and crucially no splits loaded at all: stale tracked split rows would be
+        // marked Modified by UpdateAsync and could overwrite a concurrent replacement.
         await _unitOfWork.DidNotReceiveWithAnyArgs()
             .BeginTransactionAsync(Arg.Any<IsolationLevel>(), Arg.Any<CancellationToken>());
+        await _transactionRepository.DidNotReceiveWithAnyArgs()
+            .GetByIdWithSplitsAsync(Arg.Any<int>(), Arg.Any<Guid>());
     }
 
     [Fact]

--- a/tests/MyMascada.Tests.Unit/Commands/UpdateTransactionSplitsCommandHandlerTests.cs
+++ b/tests/MyMascada.Tests.Unit/Commands/UpdateTransactionSplitsCommandHandlerTests.cs
@@ -1,0 +1,318 @@
+using MyMascada.Application.Common.Interfaces;
+using MyMascada.Application.Features.Transactions.Commands;
+using MyMascada.Application.Features.Transactions.DTOs;
+using MyMascada.Domain.Entities;
+using MyMascada.Domain.Enums;
+
+namespace MyMascada.Tests.Unit.Commands;
+
+public class UpdateTransactionSplitsCommandHandlerTests
+{
+    private readonly ITransactionRepository _transactionRepository;
+    private readonly ICategoryRepository _categoryRepository;
+    private readonly IAccountAccessService _accountAccessService;
+    private readonly UpdateTransactionSplitsCommandHandler _handler;
+    private readonly Guid _userId = Guid.NewGuid();
+
+    public UpdateTransactionSplitsCommandHandlerTests()
+    {
+        _transactionRepository = Substitute.For<ITransactionRepository>();
+        _categoryRepository = Substitute.For<ICategoryRepository>();
+        _accountAccessService = Substitute.For<IAccountAccessService>();
+        _handler = new UpdateTransactionSplitsCommandHandler(
+            _transactionRepository, _categoryRepository, _accountAccessService);
+    }
+
+    private Transaction CreateTransaction(
+        int id = 1,
+        decimal amount = -100m,
+        Guid? transferId = null,
+        TransactionType type = TransactionType.Expense,
+        List<TransactionSplit>? splits = null)
+    {
+        return new Transaction
+        {
+            Id = id,
+            Amount = amount,
+            TransactionDate = DateTime.UtcNow,
+            Description = "Test transaction",
+            AccountId = 10,
+            Type = type,
+            TransferId = transferId,
+            Splits = splits ?? new List<TransactionSplit>(),
+            Account = new Account { Id = 10, Name = "Checking", UserId = _userId }
+        };
+    }
+
+    private void SetupHappyPath(Transaction transaction)
+    {
+        _transactionRepository.GetByIdWithSplitsAsync(transaction.Id, _userId).Returns(transaction);
+        _accountAccessService.CanModifyAccountAsync(_userId, transaction.AccountId).Returns(true);
+        _categoryRepository.ExistsAsync(Arg.Any<int>(), _userId).Returns(true);
+    }
+
+    private UpdateTransactionSplitsCommand CreateCommand(int transactionId, List<TransactionSplitInputDto>? splits)
+    {
+        return new UpdateTransactionSplitsCommand
+        {
+            UserId = _userId,
+            TransactionId = transactionId,
+            Splits = splits
+        };
+    }
+
+    [Fact]
+    public async Task Handle_WhenTransactionNotFound_ShouldThrowArgumentException()
+    {
+        _transactionRepository.GetByIdWithSplitsAsync(99, _userId).Returns((Transaction?)null);
+
+        var command = CreateCommand(99, new List<TransactionSplitInputDto>
+        {
+            new() { CategoryId = 1, Amount = -100m }
+        });
+
+        var act = async () => await _handler.Handle(command, CancellationToken.None);
+
+        await act.Should().ThrowAsync<ArgumentException>()
+            .WithMessage("*not found or does not belong to user*");
+        await _transactionRepository.DidNotReceive().UpdateAsync(Arg.Any<Transaction>());
+    }
+
+    [Fact]
+    public async Task Handle_WhenUserCannotModifyAccount_ShouldThrowUnauthorizedAccessException()
+    {
+        var transaction = CreateTransaction();
+        _transactionRepository.GetByIdWithSplitsAsync(transaction.Id, _userId).Returns(transaction);
+        _accountAccessService.CanModifyAccountAsync(_userId, transaction.AccountId).Returns(false);
+
+        var command = CreateCommand(transaction.Id, new List<TransactionSplitInputDto>
+        {
+            new() { CategoryId = 1, Amount = -100m }
+        });
+
+        var act = async () => await _handler.Handle(command, CancellationToken.None);
+
+        await act.Should().ThrowAsync<UnauthorizedAccessException>();
+        await _transactionRepository.DidNotReceive().UpdateAsync(Arg.Any<Transaction>());
+    }
+
+    [Fact]
+    public async Task Handle_WhenTransactionIsTransfer_ShouldThrowArgumentException()
+    {
+        var transaction = CreateTransaction(transferId: Guid.NewGuid(), type: TransactionType.TransferComponent);
+        SetupHappyPath(transaction);
+
+        var command = CreateCommand(transaction.Id, new List<TransactionSplitInputDto>
+        {
+            new() { CategoryId = 1, Amount = -100m }
+        });
+
+        var act = async () => await _handler.Handle(command, CancellationToken.None);
+
+        await act.Should().ThrowAsync<ArgumentException>()
+            .WithMessage("Transfer transactions cannot be split");
+        await _transactionRepository.DidNotReceive().UpdateAsync(Arg.Any<Transaction>());
+    }
+
+    [Fact]
+    public async Task Handle_WhenSumDoesNotMatchTransactionAmount_ShouldThrowArgumentException()
+    {
+        var transaction = CreateTransaction(amount: -100m);
+        SetupHappyPath(transaction);
+
+        var command = CreateCommand(transaction.Id, new List<TransactionSplitInputDto>
+        {
+            new() { CategoryId = 1, Amount = -60m },
+            new() { CategoryId = 2, Amount = -30m } // sums to -90, not -100
+        });
+
+        var act = async () => await _handler.Handle(command, CancellationToken.None);
+
+        await act.Should().ThrowAsync<ArgumentException>()
+            .WithMessage("*must sum to the transaction amount exactly*");
+        await _transactionRepository.DidNotReceive().UpdateAsync(Arg.Any<Transaction>());
+    }
+
+    [Fact]
+    public async Task Handle_WhenSplitHasOppositeSign_ShouldThrowArgumentException()
+    {
+        var transaction = CreateTransaction(amount: -100m);
+        SetupHappyPath(transaction);
+
+        var command = CreateCommand(transaction.Id, new List<TransactionSplitInputDto>
+        {
+            new() { CategoryId = 1, Amount = -150m },
+            new() { CategoryId = 2, Amount = 50m } // positive split on an expense
+        });
+
+        var act = async () => await _handler.Handle(command, CancellationToken.None);
+
+        await act.Should().ThrowAsync<ArgumentException>()
+            .WithMessage("*same sign as the transaction amount*");
+        await _transactionRepository.DidNotReceive().UpdateAsync(Arg.Any<Transaction>());
+    }
+
+    [Fact]
+    public async Task Handle_WhenSplitAmountIsZero_ShouldThrowArgumentException()
+    {
+        var transaction = CreateTransaction(amount: -100m);
+        SetupHappyPath(transaction);
+
+        var command = CreateCommand(transaction.Id, new List<TransactionSplitInputDto>
+        {
+            new() { CategoryId = 1, Amount = -100m },
+            new() { CategoryId = 2, Amount = 0m }
+        });
+
+        var act = async () => await _handler.Handle(command, CancellationToken.None);
+
+        await act.Should().ThrowAsync<ArgumentException>()
+            .WithMessage("*non-zero*");
+        await _transactionRepository.DidNotReceive().UpdateAsync(Arg.Any<Transaction>());
+    }
+
+    [Fact]
+    public async Task Handle_WhenTransactionAmountIsZero_ShouldThrowArgumentException()
+    {
+        var transaction = CreateTransaction(amount: 0m);
+        SetupHappyPath(transaction);
+
+        var command = CreateCommand(transaction.Id, new List<TransactionSplitInputDto>
+        {
+            new() { CategoryId = 1, Amount = -10m }
+        });
+
+        var act = async () => await _handler.Handle(command, CancellationToken.None);
+
+        await act.Should().ThrowAsync<ArgumentException>()
+            .WithMessage("*zero-amount transaction cannot be split*");
+        await _transactionRepository.DidNotReceive().UpdateAsync(Arg.Any<Transaction>());
+    }
+
+    [Fact]
+    public async Task Handle_WhenCategoryDoesNotBelongToUser_ShouldThrowArgumentException()
+    {
+        var transaction = CreateTransaction(amount: -100m);
+        _transactionRepository.GetByIdWithSplitsAsync(transaction.Id, _userId).Returns(transaction);
+        _accountAccessService.CanModifyAccountAsync(_userId, transaction.AccountId).Returns(true);
+        _categoryRepository.ExistsAsync(1, _userId).Returns(true);
+        _categoryRepository.ExistsAsync(2, _userId).Returns(false);
+
+        var command = CreateCommand(transaction.Id, new List<TransactionSplitInputDto>
+        {
+            new() { CategoryId = 1, Amount = -60m },
+            new() { CategoryId = 2, Amount = -40m }
+        });
+
+        var act = async () => await _handler.Handle(command, CancellationToken.None);
+
+        await act.Should().ThrowAsync<ArgumentException>()
+            .WithMessage("Category with ID 2 not found or does not belong to user");
+        await _transactionRepository.DidNotReceive().UpdateAsync(Arg.Any<Transaction>());
+    }
+
+    [Fact]
+    public async Task Handle_WithValidSplits_ShouldReplaceExistingSplitsAtomically()
+    {
+        var existingSplit = new TransactionSplit { Id = 5, TransactionId = 1, CategoryId = 9, Amount = -100m };
+        var transaction = CreateTransaction(amount: -100m, splits: new List<TransactionSplit> { existingSplit });
+        SetupHappyPath(transaction);
+
+        var command = CreateCommand(transaction.Id, new List<TransactionSplitInputDto>
+        {
+            new() { CategoryId = 1, Amount = -60m, Description = "Groceries part" },
+            new() { CategoryId = 2, Amount = -40m }
+        });
+
+        var result = await _handler.Handle(command, CancellationToken.None);
+
+        // Old split is soft-deleted, not removed
+        existingSplit.IsDeleted.Should().BeTrue();
+        existingSplit.DeletedAt.Should().NotBeNull();
+
+        // Two new active splits added
+        var activeSplits = transaction.Splits.Where(s => !s.IsDeleted).ToList();
+        activeSplits.Should().HaveCount(2);
+        activeSplits.Select(s => s.CategoryId).Should().BeEquivalentTo(new[] { 1, 2 });
+        activeSplits.Sum(s => s.Amount).Should().Be(-100m);
+        activeSplits.Single(s => s.CategoryId == 1).Description.Should().Be("Groceries part");
+
+        // Persisted exactly once (single SaveChanges -> atomic replace)
+        await _transactionRepository.Received(1).UpdateAsync(transaction);
+
+        // Response carries the new splits
+        result.Splits.Should().NotBeNull();
+        result.Splits.Should().HaveCount(2);
+    }
+
+    [Fact]
+    public async Task Handle_WithEmptyList_ShouldClearAllSplits()
+    {
+        var splitA = new TransactionSplit { Id = 5, TransactionId = 1, CategoryId = 1, Amount = -60m };
+        var splitB = new TransactionSplit { Id = 6, TransactionId = 1, CategoryId = 2, Amount = -40m };
+        var transaction = CreateTransaction(amount: -100m, splits: new List<TransactionSplit> { splitA, splitB });
+        SetupHappyPath(transaction);
+
+        var command = CreateCommand(transaction.Id, new List<TransactionSplitInputDto>());
+
+        var result = await _handler.Handle(command, CancellationToken.None);
+
+        splitA.IsDeleted.Should().BeTrue();
+        splitB.IsDeleted.Should().BeTrue();
+        transaction.Splits.Where(s => !s.IsDeleted).Should().BeEmpty();
+        await _transactionRepository.Received(1).UpdateAsync(transaction);
+        result.Splits.Should().BeNull();
+    }
+
+    [Fact]
+    public async Task Handle_WithNullList_ShouldClearAllSplits()
+    {
+        var existingSplit = new TransactionSplit { Id = 5, TransactionId = 1, CategoryId = 1, Amount = -100m };
+        var transaction = CreateTransaction(amount: -100m, splits: new List<TransactionSplit> { existingSplit });
+        SetupHappyPath(transaction);
+
+        var command = CreateCommand(transaction.Id, null);
+
+        var result = await _handler.Handle(command, CancellationToken.None);
+
+        existingSplit.IsDeleted.Should().BeTrue();
+        await _transactionRepository.Received(1).UpdateAsync(transaction);
+        result.Splits.Should().BeNull();
+    }
+
+    [Fact]
+    public async Task Handle_WithPositiveIncomeTransaction_ShouldAcceptPositiveSplits()
+    {
+        var transaction = CreateTransaction(amount: 250m, type: TransactionType.Income);
+        SetupHappyPath(transaction);
+
+        var command = CreateCommand(transaction.Id, new List<TransactionSplitInputDto>
+        {
+            new() { CategoryId = 1, Amount = 200m },
+            new() { CategoryId = 2, Amount = 50m }
+        });
+
+        var result = await _handler.Handle(command, CancellationToken.None);
+
+        result.Splits.Should().HaveCount(2);
+        transaction.Splits.Where(s => !s.IsDeleted).Sum(s => s.Amount).Should().Be(250m);
+    }
+
+    [Fact]
+    public async Task Handle_ShouldNotChangeParentTransactionCategory()
+    {
+        var transaction = CreateTransaction(amount: -100m);
+        transaction.CategoryId = 42;
+        SetupHappyPath(transaction);
+
+        var command = CreateCommand(transaction.Id, new List<TransactionSplitInputDto>
+        {
+            new() { CategoryId = 1, Amount = -60m },
+            new() { CategoryId = 2, Amount = -40m }
+        });
+
+        await _handler.Handle(command, CancellationToken.None);
+
+        transaction.CategoryId.Should().Be(42);
+    }
+}

--- a/tests/MyMascada.Tests.Unit/Commands/UpdateTransactionSplitsCommandHandlerTests.cs
+++ b/tests/MyMascada.Tests.Unit/Commands/UpdateTransactionSplitsCommandHandlerTests.cs
@@ -1,3 +1,4 @@
+using System.Data;
 using MyMascada.Application.Common.Interfaces;
 using MyMascada.Application.Features.Transactions.Commands;
 using MyMascada.Application.Features.Transactions.DTOs;
@@ -11,6 +12,8 @@ public class UpdateTransactionSplitsCommandHandlerTests
     private readonly ITransactionRepository _transactionRepository;
     private readonly ICategoryRepository _categoryRepository;
     private readonly IAccountAccessService _accountAccessService;
+    private readonly IUnitOfWork _unitOfWork;
+    private readonly IUnitOfWorkTransaction _dbTransaction;
     private readonly UpdateTransactionSplitsCommandHandler _handler;
     private readonly Guid _userId = Guid.NewGuid();
 
@@ -19,8 +22,12 @@ public class UpdateTransactionSplitsCommandHandlerTests
         _transactionRepository = Substitute.For<ITransactionRepository>();
         _categoryRepository = Substitute.For<ICategoryRepository>();
         _accountAccessService = Substitute.For<IAccountAccessService>();
+        _unitOfWork = Substitute.For<IUnitOfWork>();
+        _dbTransaction = Substitute.For<IUnitOfWorkTransaction>();
+        _unitOfWork.BeginTransactionAsync(IsolationLevel.Serializable, Arg.Any<CancellationToken>())
+            .Returns(_dbTransaction);
         _handler = new UpdateTransactionSplitsCommandHandler(
-            _transactionRepository, _categoryRepository, _accountAccessService);
+            _transactionRepository, _categoryRepository, _accountAccessService, _unitOfWork);
     }
 
     private Transaction CreateTransaction(
@@ -240,9 +247,53 @@ public class UpdateTransactionSplitsCommandHandlerTests
         // Persisted exactly once (single SaveChanges -> atomic replace)
         await _transactionRepository.Received(1).UpdateAsync(transaction);
 
+        // The replace runs inside a serializable DB transaction that is committed,
+        // so concurrent replaces for the same transaction are isolated.
+        await _unitOfWork.Received(1).BeginTransactionAsync(IsolationLevel.Serializable, Arg.Any<CancellationToken>());
+        await _dbTransaction.Received(1).CommitAsync(Arg.Any<CancellationToken>());
+
         // Response carries the new splits
         result.Splits.Should().NotBeNull();
         result.Splits.Should().HaveCount(2);
+    }
+
+    [Fact]
+    public async Task Handle_WhenValidationFails_ShouldNotCommitDbTransaction()
+    {
+        var transaction = CreateTransaction(amount: -100m);
+        SetupHappyPath(transaction);
+
+        var command = CreateCommand(transaction.Id, new List<TransactionSplitInputDto>
+        {
+            new() { CategoryId = 1, Amount = -50m } // does not sum to -100
+        });
+
+        var act = async () => await _handler.Handle(command, CancellationToken.None);
+
+        await act.Should().ThrowAsync<ArgumentException>();
+        await _dbTransaction.DidNotReceive().CommitAsync(Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task Handle_WhenReloadAfterUpdateReturnsNull_ShouldThrowAndNotCommit()
+    {
+        var transaction = CreateTransaction(amount: -100m);
+        _accountAccessService.CanModifyAccountAsync(_userId, transaction.AccountId).Returns(true);
+        _categoryRepository.ExistsAsync(Arg.Any<int>(), _userId).Returns(true);
+        // First load returns the transaction, reload after UpdateAsync returns null.
+        _transactionRepository.GetByIdWithSplitsAsync(transaction.Id, _userId)
+            .Returns(transaction, (Transaction?)null);
+
+        var command = CreateCommand(transaction.Id, new List<TransactionSplitInputDto>
+        {
+            new() { CategoryId = 1, Amount = -100m }
+        });
+
+        var act = async () => await _handler.Handle(command, CancellationToken.None);
+
+        await act.Should().ThrowAsync<InvalidOperationException>()
+            .WithMessage("*could not be reloaded after updating splits*");
+        await _dbTransaction.DidNotReceive().CommitAsync(Arg.Any<CancellationToken>());
     }
 
     [Fact]

--- a/tests/MyMascada.Tests.Unit/Commands/UpdateTransactionSplitsCommandValidatorTests.cs
+++ b/tests/MyMascada.Tests.Unit/Commands/UpdateTransactionSplitsCommandValidatorTests.cs
@@ -1,0 +1,107 @@
+using MyMascada.Application.Features.Transactions.Commands;
+using MyMascada.Application.Features.Transactions.DTOs;
+using MyMascada.Application.Features.Transactions.Validators;
+
+namespace MyMascada.Tests.Unit.Commands;
+
+public class UpdateTransactionSplitsCommandValidatorTests
+{
+    private readonly UpdateTransactionSplitsCommandValidator _validator = new();
+
+    private static UpdateTransactionSplitsCommand CreateCommand(List<TransactionSplitInputDto>? splits, int transactionId = 1)
+    {
+        return new UpdateTransactionSplitsCommand
+        {
+            UserId = Guid.NewGuid(),
+            TransactionId = transactionId,
+            Splits = splits
+        };
+    }
+
+    [Fact]
+    public void Validate_WithValidSplits_ShouldPass()
+    {
+        var command = CreateCommand(new List<TransactionSplitInputDto>
+        {
+            new() { CategoryId = 1, Amount = -60.50m, Description = "Part A" },
+            new() { CategoryId = 2, Amount = -39.50m }
+        });
+
+        _validator.Validate(command).IsValid.Should().BeTrue();
+    }
+
+    [Fact]
+    public void Validate_WithNullSplits_ShouldPass()
+    {
+        var command = CreateCommand(null);
+
+        _validator.Validate(command).IsValid.Should().BeTrue();
+    }
+
+    [Fact]
+    public void Validate_WithInvalidTransactionId_ShouldFail()
+    {
+        var command = CreateCommand(null, transactionId: 0);
+
+        var result = _validator.Validate(command);
+
+        result.IsValid.Should().BeFalse();
+        result.Errors.Should().Contain(e => e.ErrorMessage.Contains("transaction ID"));
+    }
+
+    [Fact]
+    public void Validate_WithZeroSplitAmount_ShouldFail()
+    {
+        var command = CreateCommand(new List<TransactionSplitInputDto>
+        {
+            new() { CategoryId = 1, Amount = 0m }
+        });
+
+        var result = _validator.Validate(command);
+
+        result.IsValid.Should().BeFalse();
+        result.Errors.Should().Contain(e => e.ErrorMessage.Contains("must not be zero"));
+    }
+
+    [Fact]
+    public void Validate_WithMoreThanTwoDecimalPlaces_ShouldFail()
+    {
+        var command = CreateCommand(new List<TransactionSplitInputDto>
+        {
+            new() { CategoryId = 1, Amount = -33.333m }
+        });
+
+        var result = _validator.Validate(command);
+
+        result.IsValid.Should().BeFalse();
+        result.Errors.Should().Contain(e => e.ErrorMessage.Contains("2 decimal places"));
+    }
+
+    [Fact]
+    public void Validate_WithInvalidCategoryId_ShouldFail()
+    {
+        var command = CreateCommand(new List<TransactionSplitInputDto>
+        {
+            new() { CategoryId = 0, Amount = -10m }
+        });
+
+        var result = _validator.Validate(command);
+
+        result.IsValid.Should().BeFalse();
+        result.Errors.Should().Contain(e => e.ErrorMessage.Contains("valid category ID"));
+    }
+
+    [Fact]
+    public void Validate_WithTooLongDescription_ShouldFail()
+    {
+        var command = CreateCommand(new List<TransactionSplitInputDto>
+        {
+            new() { CategoryId = 1, Amount = -10m, Description = new string('x', 501) }
+        });
+
+        var result = _validator.Validate(command);
+
+        result.IsValid.Should().BeFalse();
+        result.Errors.Should().Contain(e => e.ErrorMessage.Contains("500 characters"));
+    }
+}

--- a/tests/MyMascada.Tests.Unit/Controllers/TransactionsControllerTests.cs
+++ b/tests/MyMascada.Tests.Unit/Controllers/TransactionsControllerTests.cs
@@ -2,6 +2,8 @@ using MyMascada.Domain.Enums;
 using System.Security.Claims;
 using MediatR;
 using Microsoft.AspNetCore.Http;
+using Microsoft.EntityFrameworkCore;
+using Npgsql;
 using Microsoft.AspNetCore.Mvc;
 using MyMascada.Application.Common.Interfaces;
 using MyMascada.Application.Features.Transactions.Commands;
@@ -308,6 +310,86 @@ public class TransactionsControllerTests
             cmd.UserId == _userId &&
             cmd.Id == transactionId &&
             cmd.Amount == request.Amount));
+    }
+
+    [Fact]
+    public async Task UpdateTransaction_WhenSerializationFailure_ShouldReturnConflict()
+    {
+        // Arrange: the amount-edit path runs in a Serializable transaction; losing the
+        // race surfaces as a PostgresException (SQLSTATE 40001) wrapped by EF in a
+        // DbUpdateException at SaveChanges time.
+        var transactionId = 1;
+        var request = new UpdateTransactionRequest
+        {
+            Id = transactionId,
+            Amount = -75.00m,
+            TransactionDate = DateTime.Today,
+            Description = "Updated Transaction"
+        };
+
+        var serializationFailure = new DbUpdateException(
+            "An error occurred while saving the entity changes.",
+            new PostgresException("could not serialize access due to concurrent update", "ERROR", "ERROR", "40001"));
+        _mediator.Send(Arg.Any<UpdateTransactionCommand>())
+            .Returns(Task.FromException<TransactionDto>(serializationFailure));
+
+        // Act
+        var result = await _controller.UpdateTransaction(transactionId, request);
+
+        // Assert
+        var conflictResult = result.Result.Should().BeOfType<ConflictObjectResult>().Subject;
+        var message = conflictResult.Value!.GetType().GetProperty("message")?.GetValue(conflictResult.Value);
+        message.Should().Be("This transaction was modified concurrently - please retry");
+    }
+
+    [Fact]
+    public async Task UpdateTransactionSplits_WhenSerializationFailure_ShouldReturnConflict()
+    {
+        // Arrange: at Commit time the serialization failure can surface as a bare
+        // PostgresException (not wrapped in DbUpdateException).
+        var request = new UpdateTransactionSplitsRequest
+        {
+            Splits = new List<TransactionSplitInputDto>
+            {
+                new() { CategoryId = 1, Amount = -60m },
+                new() { CategoryId = 2, Amount = -40m }
+            }
+        };
+
+        _mediator.Send(Arg.Any<UpdateTransactionSplitsCommand>())
+            .Returns(Task.FromException<TransactionDto>(
+                new PostgresException("could not serialize access due to read/write dependencies among transactions", "ERROR", "ERROR", "40001")));
+
+        // Act
+        var result = await _controller.UpdateTransactionSplits(1, request);
+
+        // Assert
+        var conflictResult = result.Result.Should().BeOfType<ConflictObjectResult>().Subject;
+        var message = conflictResult.Value!.GetType().GetProperty("message")?.GetValue(conflictResult.Value);
+        message.Should().Be("This transaction was modified concurrently - please retry");
+    }
+
+    [Fact]
+    public async Task UpdateTransactionSplits_WhenNonSerializationDbFailure_ShouldNotReturnConflict()
+    {
+        // A non-40001 database failure must NOT be swallowed into a 409 — it should
+        // propagate to the global middleware (500).
+        var request = new UpdateTransactionSplitsRequest
+        {
+            Splits = new List<TransactionSplitInputDto> { new() { CategoryId = 1, Amount = -100m } }
+        };
+
+        _mediator.Send(Arg.Any<UpdateTransactionSplitsCommand>())
+            .Returns(Task.FromException<TransactionDto>(
+                new DbUpdateException(
+                    "An error occurred while saving the entity changes.",
+                    new PostgresException("duplicate key value violates unique constraint", "ERROR", "ERROR", "23505"))));
+
+        // Act
+        var act = async () => await _controller.UpdateTransactionSplits(1, request);
+
+        // Assert
+        await act.Should().ThrowAsync<DbUpdateException>();
     }
 
     [Fact]

--- a/tests/MyMascada.Tests.Unit/Extensions/ExceptionExtensionsTests.cs
+++ b/tests/MyMascada.Tests.Unit/Extensions/ExceptionExtensionsTests.cs
@@ -1,0 +1,51 @@
+using Microsoft.EntityFrameworkCore;
+using MyMascada.WebAPI.Extensions;
+using Npgsql;
+
+namespace MyMascada.Tests.Unit.Extensions;
+
+public class ExceptionExtensionsTests
+{
+    private static PostgresException SerializationFailure() =>
+        new("could not serialize access due to concurrent update", "ERROR", "ERROR", "40001");
+
+    [Fact]
+    public void IsPostgresSerializationFailure_WithBarePostgresException40001_ShouldBeTrue()
+    {
+        SerializationFailure().IsPostgresSerializationFailure().Should().BeTrue();
+    }
+
+    [Fact]
+    public void IsPostgresSerializationFailure_WhenWrappedInDbUpdateException_ShouldBeTrue()
+    {
+        var wrapped = new DbUpdateException("save failed", SerializationFailure());
+
+        wrapped.IsPostgresSerializationFailure().Should().BeTrue();
+    }
+
+    [Fact]
+    public void IsPostgresSerializationFailure_WhenNestedTwoLevelsDeep_ShouldBeTrue()
+    {
+        var nested = new InvalidOperationException(
+            "outer",
+            new DbUpdateException("save failed", SerializationFailure()));
+
+        nested.IsPostgresSerializationFailure().Should().BeTrue();
+    }
+
+    [Fact]
+    public void IsPostgresSerializationFailure_WithOtherSqlState_ShouldBeFalse()
+    {
+        var uniqueViolation = new DbUpdateException(
+            "save failed",
+            new PostgresException("duplicate key value violates unique constraint", "ERROR", "ERROR", "23505"));
+
+        uniqueViolation.IsPostgresSerializationFailure().Should().BeFalse();
+    }
+
+    [Fact]
+    public void IsPostgresSerializationFailure_WithUnrelatedException_ShouldBeFalse()
+    {
+        new InvalidOperationException("nope").IsPostgresSerializationFailure().Should().BeFalse();
+    }
+}

--- a/tests/MyMascada.Tests.Unit/Features/Transactions/TransactionMapperTests.cs
+++ b/tests/MyMascada.Tests.Unit/Features/Transactions/TransactionMapperTests.cs
@@ -1,0 +1,68 @@
+using MyMascada.Application.Features.Transactions.Mappings;
+using MyMascada.Domain.Entities;
+using MyMascada.Domain.Enums;
+
+namespace MyMascada.Tests.Unit.Features.Transactions;
+
+public class TransactionMapperTests
+{
+    private static Transaction CreateTransaction(List<TransactionSplit>? splits = null)
+    {
+        return new Transaction
+        {
+            Id = 1,
+            Amount = -100m,
+            TransactionDate = DateTime.UtcNow,
+            Description = "Test transaction",
+            AccountId = 10,
+            Type = TransactionType.Expense,
+            Splits = splits ?? new List<TransactionSplit>(),
+            Account = new Account { Id = 10, Name = "Checking", UserId = Guid.NewGuid() }
+        };
+    }
+
+    [Fact]
+    public void ToDetailDto_ShouldFilterSoftDeletedSplits()
+    {
+        var transaction = CreateTransaction(new List<TransactionSplit>
+        {
+            new() { Id = 1, TransactionId = 1, CategoryId = 1, Amount = -60m },
+            new() { Id = 2, TransactionId = 1, CategoryId = 2, Amount = -40m, IsDeleted = true }
+        });
+
+        var dto = TransactionMapper.ToDetailDto(transaction);
+
+        dto.Splits.Should().NotBeNull();
+        dto.Splits.Should().HaveCount(1);
+        dto.Splits![0].CategoryId.Should().Be(1);
+    }
+
+    [Fact]
+    public void ToDetailDto_WhenAllSplitsSoftDeleted_ShouldReturnNullSplits()
+    {
+        var transaction = CreateTransaction(new List<TransactionSplit>
+        {
+            new() { Id = 1, TransactionId = 1, CategoryId = 1, Amount = -100m, IsDeleted = true }
+        });
+
+        var dto = TransactionMapper.ToDetailDto(transaction);
+
+        dto.Splits.Should().BeNull();
+    }
+
+    [Fact]
+    public void ToDto_ShouldFilterSoftDeletedSplits()
+    {
+        var transaction = CreateTransaction(new List<TransactionSplit>
+        {
+            new() { Id = 1, TransactionId = 1, CategoryId = 1, Amount = -100m },
+            new() { Id = 2, TransactionId = 1, CategoryId = 2, Amount = -40m, IsDeleted = true }
+        });
+
+        var dto = TransactionMapper.ToDto(transaction);
+
+        dto.Splits.Should().NotBeNull();
+        dto.Splits.Should().HaveCount(1);
+        dto.Splits![0].CategoryId.Should().Be(1);
+    }
+}

--- a/tests/MyMascada.Tests.Unit/Middleware/GlobalExceptionHandlingMiddlewareTests.cs
+++ b/tests/MyMascada.Tests.Unit/Middleware/GlobalExceptionHandlingMiddlewareTests.cs
@@ -1,0 +1,68 @@
+using System.Text;
+using Microsoft.AspNetCore.Hosting;
+using Microsoft.AspNetCore.Http;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Logging;
+using MyMascada.WebAPI.Middleware;
+using Npgsql;
+
+namespace MyMascada.Tests.Unit.Middleware;
+
+public class GlobalExceptionHandlingMiddlewareTests
+{
+    private readonly ILogger<GlobalExceptionHandlingMiddleware> _logger =
+        Substitute.For<ILogger<GlobalExceptionHandlingMiddleware>>();
+    private readonly IWebHostEnvironment _environment = Substitute.For<IWebHostEnvironment>();
+
+    public GlobalExceptionHandlingMiddlewareTests()
+    {
+        _environment.EnvironmentName.Returns("Production");
+    }
+
+    private static async Task<(HttpContext context, string body)> InvokeWithException(
+        GlobalExceptionHandlingMiddleware middleware)
+    {
+        var context = new DefaultHttpContext();
+        context.Response.Body = new MemoryStream();
+
+        await middleware.InvokeAsync(context);
+
+        context.Response.Body.Seek(0, SeekOrigin.Begin);
+        using var reader = new StreamReader(context.Response.Body, Encoding.UTF8);
+        var body = await reader.ReadToEndAsync();
+        return (context, body);
+    }
+
+    [Fact]
+    public async Task InvokeAsync_WhenSerializationFailure_ShouldReturn409WithRetryMessage()
+    {
+        // The safety net for serializable-transaction conflicts that controllers
+        // don't translate themselves (e.g. future paths): 409, not a raw 500.
+        var middleware = new GlobalExceptionHandlingMiddleware(
+            _ => throw new DbUpdateException(
+                "save failed",
+                new PostgresException("could not serialize access due to concurrent update", "ERROR", "ERROR", "40001")),
+            _logger,
+            _environment);
+
+        var (context, body) = await InvokeWithException(middleware);
+
+        context.Response.StatusCode.Should().Be(StatusCodes.Status409Conflict);
+        body.Should().Contain("please retry");
+    }
+
+    [Fact]
+    public async Task InvokeAsync_WhenUnclassifiedException_ShouldReturn500()
+    {
+        var middleware = new GlobalExceptionHandlingMiddleware(
+            _ => throw new DbUpdateException(
+                "save failed",
+                new PostgresException("duplicate key value violates unique constraint", "ERROR", "ERROR", "23505")),
+            _logger,
+            _environment);
+
+        var (context, _) = await InvokeWithException(middleware);
+
+        context.Response.StatusCode.Should().Be(StatusCodes.Status500InternalServerError);
+    }
+}

--- a/tests/MyMascada.Tests.Unit/Queries/GetTransactionQueryHandlerTests.cs
+++ b/tests/MyMascada.Tests.Unit/Queries/GetTransactionQueryHandlerTests.cs
@@ -1,0 +1,106 @@
+using MyMascada.Application.Common.Interfaces;
+using MyMascada.Application.Features.Transactions.Queries;
+using MyMascada.Domain.Entities;
+
+namespace MyMascada.Tests.Unit.Queries;
+
+public class GetTransactionQueryHandlerTests
+{
+    private readonly ITransactionRepository _transactionRepository;
+    private readonly GetTransactionQueryHandler _handler;
+    private readonly Guid _userId = Guid.NewGuid();
+
+    public GetTransactionQueryHandlerTests()
+    {
+        _transactionRepository = Substitute.For<ITransactionRepository>();
+        _handler = new GetTransactionQueryHandler(_transactionRepository);
+    }
+
+    [Fact]
+    public async Task Handle_WhenTransactionNotFound_ShouldReturnNull()
+    {
+        _transactionRepository.GetByIdWithSplitsAsync(99, _userId).Returns((Transaction?)null);
+
+        var result = await _handler.Handle(
+            new GetTransactionQuery { UserId = _userId, Id = 99 }, CancellationToken.None);
+
+        result.Should().BeNull();
+    }
+
+    [Fact]
+    public async Task Handle_WhenTransactionHasSplits_ShouldIncludeActiveSplitsInDto()
+    {
+        var transaction = new Transaction
+        {
+            Id = 1,
+            Amount = -100m,
+            Description = "Supermarket",
+            AccountId = 10,
+            Account = new Account { Id = 10, Name = "Checking", UserId = _userId },
+            Splits = new List<TransactionSplit>
+            {
+                new()
+                {
+                    Id = 1,
+                    TransactionId = 1,
+                    CategoryId = 5,
+                    Amount = -60m,
+                    Description = "Food",
+                    Category = new Category { Id = 5, Name = "Groceries", Color = "#00FF00" }
+                },
+                new()
+                {
+                    Id = 2,
+                    TransactionId = 1,
+                    CategoryId = 6,
+                    Amount = -40m,
+                    Category = new Category { Id = 6, Name = "Household" }
+                },
+                new()
+                {
+                    Id = 3,
+                    TransactionId = 1,
+                    CategoryId = 7,
+                    Amount = -999m,
+                    IsDeleted = true // soft-deleted splits must not surface
+                }
+            }
+        };
+        _transactionRepository.GetByIdWithSplitsAsync(1, _userId).Returns(transaction);
+
+        var result = await _handler.Handle(
+            new GetTransactionQuery { UserId = _userId, Id = 1 }, CancellationToken.None);
+
+        result.Should().NotBeNull();
+        result!.Splits.Should().NotBeNull();
+        result.Splits.Should().HaveCount(2);
+
+        var first = result.Splits!.Single(s => s.CategoryId == 5);
+        first.Amount.Should().Be(-60m);
+        first.Description.Should().Be("Food");
+        first.CategoryName.Should().Be("Groceries");
+        first.CategoryColor.Should().Be("#00FF00");
+
+        result.Splits!.Single(s => s.CategoryId == 6).Amount.Should().Be(-40m);
+    }
+
+    [Fact]
+    public async Task Handle_WhenTransactionHasNoSplits_ShouldReturnNullSplits()
+    {
+        var transaction = new Transaction
+        {
+            Id = 2,
+            Amount = -50m,
+            Description = "Coffee",
+            AccountId = 10,
+            Account = new Account { Id = 10, Name = "Checking", UserId = _userId }
+        };
+        _transactionRepository.GetByIdWithSplitsAsync(2, _userId).Returns(transaction);
+
+        var result = await _handler.Handle(
+            new GetTransactionQuery { UserId = _userId, Id = 2 }, CancellationToken.None);
+
+        result.Should().NotBeNull();
+        result!.Splits.Should().BeNull();
+    }
+}


### PR DESCRIPTION
## Summary
- `PUT /api/v1/transactions/{id}/splits` — atomically replaces a transaction's splits (`{splits: [{categoryId, amount, description?}]}`); empty list un-splits. Validation: exact sum match, same sign, ≤2dp, non-zero rows, category + transaction ownership, account MODIFY permission, transfers rejected
- `GET /api/v1/transactions/{id}` gains an additive nullable `splits` field (kept `TransactionDto` rather than switching to `ToDetailDto`, which would have broken existing clients: enum-as-int vs string, `type` rename, `tags` shape)
- Editing a split transaction's amount now clears its splits in the same SaveChanges (web has no splits UI, so rejecting would strand web users) — documented on the command and endpoint
- No migration needed: `TransactionSplits` table existed since InitialCreate, was never wired
- 26 new unit tests (1129 total passing)

## Explicitly out of scope (follow-up)
Analytics/budgets still aggregate on `transaction.CategoryId` only — splits don't feed spending-by-category or budget math yet. `Transaction.GetEffectiveAmount()`/`GetCategorizedAmounts()` helpers already exist for that follow-up.

## Notes
- Adversarially reviewed (ship-with-fixes); the amount-edit invariant fix is in `4eda112`
- Mobile splits UI is already on the mobile repo's `feat/release-readiness` branch
- Independent of the push/recurring branches; EF model snapshot may conflict trivially with whichever merges last

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Add full transaction split support: view, validate, and atomically replace splits via PUT /transactions/{id}/splits.
  * Splits included in transaction responses when present; null when none.

* **Behavior Changes / Bug Fixes**
  * Updating a transaction amount now clears prior splits to preserve sums.
  * Concurrency conflicts during updates return 409 Conflict with a retry message.
* **Validation**
  * New validation enforces split invariants (non‑zero, two decimals, matching sum, description length).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->