### PR TITLE
feat: recurring transactions (scheduled bills) with auto-create or push reminders

### DIFF
--- a/src/Core/MyMascada.Application/BackgroundJobs/IRecurringTransactionJobService.cs
+++ b/src/Core/MyMascada.Application/BackgroundJobs/IRecurringTransactionJobService.cs
@@ -1,0 +1,17 @@
+namespace MyMascada.Application.BackgroundJobs;
+
+/// <summary>
+/// Service for the daily user-created recurring transaction job.
+/// Auto-creates due transactions or sends reminder notifications,
+/// then advances each schedule's next due date.
+/// </summary>
+public interface IRecurringTransactionJobService
+{
+    /// <summary>
+    /// Processes all due recurring transactions across all users.
+    /// This is the main entry point called by Hangfire daily.
+    /// Safe to run multiple times per day (idempotent per scheduled date).
+    /// </summary>
+    /// <param name="performContext">Hangfire context for progress tracking (optional)</param>
+    Task ProcessAllDueAsync(object? performContext = null);
+}

--- a/src/Core/MyMascada.Application/Common/Interfaces/IRecurringTransactionRepository.cs
+++ b/src/Core/MyMascada.Application/Common/Interfaces/IRecurringTransactionRepository.cs
@@ -60,9 +60,33 @@ public interface IRecurringTransactionRepository
         CancellationToken cancellationToken = default);
 
     /// <summary>
+    /// Gets the occurrence for the given schedule and date, or null when none exists
+    /// </summary>
+    Task<RecurringTransactionOccurrence?> GetOccurrenceAsync(
+        int recurringTransactionId,
+        DateTime scheduledDate,
+        CancellationToken cancellationToken = default);
+
+    /// <summary>
     /// Creates a new occurrence record
     /// </summary>
     Task<RecurringTransactionOccurrence> CreateOccurrenceAsync(
+        RecurringTransactionOccurrence occurrence,
+        CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// Attempts to insert an occurrence row, returning null when the unique
+    /// (RecurringTransactionId, ScheduledDate) index rejects it because another
+    /// run already claimed that scheduled date.
+    /// </summary>
+    Task<RecurringTransactionOccurrence?> TryCreateOccurrenceAsync(
+        RecurringTransactionOccurrence occurrence,
+        CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// Updates an existing occurrence record
+    /// </summary>
+    Task<RecurringTransactionOccurrence> UpdateOccurrenceAsync(
         RecurringTransactionOccurrence occurrence,
         CancellationToken cancellationToken = default);
 
@@ -74,4 +98,17 @@ public interface IRecurringTransactionRepository
         Guid userId,
         int count = 10,
         CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// Checks whether the account still exists and is not soft-deleted.
+    /// Used by the daily job to deactivate schedules pointing at removed accounts.
+    /// </summary>
+    Task<bool> AccountExistsAsync(int accountId, CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// Detaches all tracked entities from the underlying unit of work. Called after
+    /// a failed save so one schedule's poisoned change tracker cannot fail every
+    /// subsequent schedule processed in the same scope.
+    /// </summary>
+    void ResetChangeTracking();
 }

--- a/src/Core/MyMascada.Application/Common/Interfaces/IRecurringTransactionRepository.cs
+++ b/src/Core/MyMascada.Application/Common/Interfaces/IRecurringTransactionRepository.cs
@@ -1,0 +1,77 @@
+using MyMascada.Domain.Entities;
+
+namespace MyMascada.Application.Common.Interfaces;
+
+/// <summary>
+/// Repository for user-created recurring transactions (scheduled bills) and their occurrences
+/// </summary>
+public interface IRecurringTransactionRepository
+{
+    /// <summary>
+    /// Gets a recurring transaction by ID for a specific user (includes Account/Category)
+    /// </summary>
+    Task<RecurringTransaction?> GetByIdAsync(int id, Guid userId, CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// Gets all recurring transactions for a user
+    /// </summary>
+    Task<IEnumerable<RecurringTransaction>> GetByUserIdAsync(
+        Guid userId,
+        bool includeInactive = false,
+        CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// Gets active recurring transactions across all users that are due on or before the given date.
+    /// Used by the daily background job.
+    /// </summary>
+    Task<IEnumerable<RecurringTransaction>> GetDueAsync(
+        DateTime asOfDate,
+        CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// Gets active recurring transactions for a user (for upcoming schedule materialization)
+    /// </summary>
+    Task<IEnumerable<RecurringTransaction>> GetActiveByUserIdAsync(
+        Guid userId,
+        CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// Creates a new recurring transaction
+    /// </summary>
+    Task<RecurringTransaction> CreateAsync(RecurringTransaction recurringTransaction, CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// Updates an existing recurring transaction
+    /// </summary>
+    Task<RecurringTransaction> UpdateAsync(RecurringTransaction recurringTransaction, CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// Soft deletes a recurring transaction for a user. Returns true when found and deleted.
+    /// </summary>
+    Task<bool> DeleteAsync(int id, Guid userId, CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// Checks whether an occurrence already exists for the given schedule and date
+    /// (idempotency guard for the daily job)
+    /// </summary>
+    Task<bool> HasOccurrenceAsync(
+        int recurringTransactionId,
+        DateTime scheduledDate,
+        CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// Creates a new occurrence record
+    /// </summary>
+    Task<RecurringTransactionOccurrence> CreateOccurrenceAsync(
+        RecurringTransactionOccurrence occurrence,
+        CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// Gets the most recent occurrences for a recurring transaction
+    /// </summary>
+    Task<IEnumerable<RecurringTransactionOccurrence>> GetRecentOccurrencesAsync(
+        int recurringTransactionId,
+        Guid userId,
+        int count = 10,
+        CancellationToken cancellationToken = default);
+}

--- a/src/Core/MyMascada.Application/Features/RecurringTransactions/Commands/CreateRecurringTransactionCommand.cs
+++ b/src/Core/MyMascada.Application/Features/RecurringTransactions/Commands/CreateRecurringTransactionCommand.cs
@@ -29,15 +29,18 @@ public class CreateRecurringTransactionCommandHandler
     private readonly IRecurringTransactionRepository _recurringTransactionRepository;
     private readonly IAccountRepository _accountRepository;
     private readonly ICategoryRepository _categoryRepository;
+    private readonly IAccountAccessService _accountAccessService;
 
     public CreateRecurringTransactionCommandHandler(
         IRecurringTransactionRepository recurringTransactionRepository,
         IAccountRepository accountRepository,
-        ICategoryRepository categoryRepository)
+        ICategoryRepository categoryRepository,
+        IAccountAccessService accountAccessService)
     {
         _recurringTransactionRepository = recurringTransactionRepository;
         _accountRepository = accountRepository;
         _categoryRepository = categoryRepository;
+        _accountAccessService = accountAccessService;
     }
 
     public async Task<RecurringTransactionDto> Handle(
@@ -49,6 +52,17 @@ public class CreateRecurringTransactionCommandHandler
         if (account == null)
         {
             throw new ArgumentException($"Account with ID {request.AccountId} not found or does not belong to user");
+        }
+
+        // Auto-create schedules materialize real transactions through the standard
+        // pipeline, which requires modify access (owner or Manager share). Reject
+        // viewer-only accounts up front instead of letting the nightly job fail on
+        // every run. Reminder-only schedules are fine with view access.
+        if (request.AutoCreate
+            && !await _accountAccessService.CanModifyAccountAsync(request.UserId, request.AccountId))
+        {
+            throw new UnauthorizedAccessException(
+                "You do not have permission to auto-create transactions on this account.");
         }
 
         // Validate category if provided

--- a/src/Core/MyMascada.Application/Features/RecurringTransactions/Commands/CreateRecurringTransactionCommand.cs
+++ b/src/Core/MyMascada.Application/Features/RecurringTransactions/Commands/CreateRecurringTransactionCommand.cs
@@ -1,0 +1,94 @@
+using MediatR;
+using MyMascada.Application.Common.Interfaces;
+using MyMascada.Application.Features.RecurringTransactions.DTOs;
+using MyMascada.Application.Features.RecurringTransactions.Mappings;
+using MyMascada.Domain.Common;
+using MyMascada.Domain.Entities;
+using MyMascada.Domain.Enums;
+
+namespace MyMascada.Application.Features.RecurringTransactions.Commands;
+
+public class CreateRecurringTransactionCommand : IRequest<RecurringTransactionDto>, IRecurringTransactionBaseCommand
+{
+    public Guid UserId { get; set; }
+    public int AccountId { get; set; }
+    public int? CategoryId { get; set; }
+    public string Description { get; set; } = string.Empty;
+    public decimal Amount { get; set; }
+    public RecurrenceFrequency Frequency { get; set; }
+    public int? CustomIntervalDays { get; set; }
+    public DateTime StartDate { get; set; }
+    public DateTime? EndDate { get; set; }
+    public bool AutoCreate { get; set; }
+    public string? Notes { get; set; }
+}
+
+public class CreateRecurringTransactionCommandHandler
+    : IRequestHandler<CreateRecurringTransactionCommand, RecurringTransactionDto>
+{
+    private readonly IRecurringTransactionRepository _recurringTransactionRepository;
+    private readonly IAccountRepository _accountRepository;
+    private readonly ICategoryRepository _categoryRepository;
+
+    public CreateRecurringTransactionCommandHandler(
+        IRecurringTransactionRepository recurringTransactionRepository,
+        IAccountRepository accountRepository,
+        ICategoryRepository categoryRepository)
+    {
+        _recurringTransactionRepository = recurringTransactionRepository;
+        _accountRepository = accountRepository;
+        _categoryRepository = categoryRepository;
+    }
+
+    public async Task<RecurringTransactionDto> Handle(
+        CreateRecurringTransactionCommand request,
+        CancellationToken cancellationToken)
+    {
+        // Validate account exists and belongs to user
+        var account = await _accountRepository.GetByIdAsync(request.AccountId, request.UserId);
+        if (account == null)
+        {
+            throw new ArgumentException($"Account with ID {request.AccountId} not found or does not belong to user");
+        }
+
+        // Validate category if provided
+        if (request.CategoryId.HasValue)
+        {
+            var categoryExists = await _categoryRepository.ExistsAsync(request.CategoryId.Value, request.UserId);
+            if (!categoryExists)
+            {
+                throw new ArgumentException($"Category with ID {request.CategoryId} not found or does not belong to user");
+            }
+        }
+
+        var recurringTransaction = new RecurringTransaction
+        {
+            UserId = request.UserId,
+            AccountId = request.AccountId,
+            CategoryId = request.CategoryId,
+            Description = request.Description.Trim(),
+            Amount = request.Amount,
+            Frequency = request.Frequency,
+            CustomIntervalDays = request.Frequency == RecurrenceFrequency.Custom ? request.CustomIntervalDays : null,
+            StartDate = DateTimeProvider.ToUtc(request.StartDate.Date),
+            EndDate = request.EndDate.HasValue ? DateTimeProvider.ToUtc(request.EndDate.Value.Date) : null,
+            NextDueDate = DateTimeProvider.ToUtc(request.StartDate.Date),
+            AutoCreate = request.AutoCreate,
+            IsActive = true,
+            Notes = request.Notes,
+            CreatedAt = DateTimeProvider.UtcNow,
+            UpdatedAt = DateTimeProvider.UtcNow
+        };
+
+        // Fast-forward schedules that start in the past so the job does not
+        // retroactively fire occurrences from before the schedule was created.
+        var today = DateTimeProvider.UtcNow.Date;
+        if (recurringTransaction.NextDueDate.Date < today)
+        {
+            recurringTransaction.AdvanceNextDueDate(today.AddDays(-1));
+        }
+
+        var created = await _recurringTransactionRepository.CreateAsync(recurringTransaction, cancellationToken);
+        return RecurringTransactionMapper.ToDto(created);
+    }
+}

--- a/src/Core/MyMascada.Application/Features/RecurringTransactions/Commands/DeleteRecurringTransactionCommand.cs
+++ b/src/Core/MyMascada.Application/Features/RecurringTransactions/Commands/DeleteRecurringTransactionCommand.cs
@@ -1,0 +1,25 @@
+using MediatR;
+using MyMascada.Application.Common.Interfaces;
+
+namespace MyMascada.Application.Features.RecurringTransactions.Commands;
+
+public class DeleteRecurringTransactionCommand : IRequest<bool>
+{
+    public int Id { get; set; }
+    public Guid UserId { get; set; }
+}
+
+public class DeleteRecurringTransactionCommandHandler : IRequestHandler<DeleteRecurringTransactionCommand, bool>
+{
+    private readonly IRecurringTransactionRepository _recurringTransactionRepository;
+
+    public DeleteRecurringTransactionCommandHandler(IRecurringTransactionRepository recurringTransactionRepository)
+    {
+        _recurringTransactionRepository = recurringTransactionRepository;
+    }
+
+    public async Task<bool> Handle(DeleteRecurringTransactionCommand request, CancellationToken cancellationToken)
+    {
+        return await _recurringTransactionRepository.DeleteAsync(request.Id, request.UserId, cancellationToken);
+    }
+}

--- a/src/Core/MyMascada.Application/Features/RecurringTransactions/Commands/IRecurringTransactionBaseCommand.cs
+++ b/src/Core/MyMascada.Application/Features/RecurringTransactions/Commands/IRecurringTransactionBaseCommand.cs
@@ -1,0 +1,22 @@
+using MyMascada.Domain.Enums;
+
+namespace MyMascada.Application.Features.RecurringTransactions.Commands;
+
+/// <summary>
+/// Shared shape for create/update recurring transaction commands so
+/// validation rules can be defined once.
+/// </summary>
+public interface IRecurringTransactionBaseCommand
+{
+    Guid UserId { get; }
+    int AccountId { get; }
+    int? CategoryId { get; }
+    string Description { get; }
+    decimal Amount { get; }
+    RecurrenceFrequency Frequency { get; }
+    int? CustomIntervalDays { get; }
+    DateTime StartDate { get; }
+    DateTime? EndDate { get; }
+    bool AutoCreate { get; }
+    string? Notes { get; }
+}

--- a/src/Core/MyMascada.Application/Features/RecurringTransactions/Commands/SetRecurringTransactionActiveCommand.cs
+++ b/src/Core/MyMascada.Application/Features/RecurringTransactions/Commands/SetRecurringTransactionActiveCommand.cs
@@ -1,0 +1,53 @@
+using MediatR;
+using MyMascada.Application.Common.Interfaces;
+using MyMascada.Application.Features.RecurringTransactions.DTOs;
+using MyMascada.Application.Features.RecurringTransactions.Mappings;
+using MyMascada.Domain.Common;
+
+namespace MyMascada.Application.Features.RecurringTransactions.Commands;
+
+/// <summary>
+/// Pauses (IsActive = false) or resumes (IsActive = true) a recurring transaction.
+/// Resuming fast-forwards NextDueDate so occurrences missed while paused are not fired.
+/// </summary>
+public class SetRecurringTransactionActiveCommand : IRequest<RecurringTransactionDto>
+{
+    public int Id { get; set; }
+    public Guid UserId { get; set; }
+    public bool IsActive { get; set; }
+}
+
+public class SetRecurringTransactionActiveCommandHandler
+    : IRequestHandler<SetRecurringTransactionActiveCommand, RecurringTransactionDto>
+{
+    private readonly IRecurringTransactionRepository _recurringTransactionRepository;
+
+    public SetRecurringTransactionActiveCommandHandler(IRecurringTransactionRepository recurringTransactionRepository)
+    {
+        _recurringTransactionRepository = recurringTransactionRepository;
+    }
+
+    public async Task<RecurringTransactionDto> Handle(
+        SetRecurringTransactionActiveCommand request,
+        CancellationToken cancellationToken)
+    {
+        var recurringTransaction = await _recurringTransactionRepository.GetByIdAsync(
+            request.Id, request.UserId, cancellationToken);
+        if (recurringTransaction == null)
+        {
+            throw new ArgumentException($"Recurring transaction with ID {request.Id} not found");
+        }
+
+        if (request.IsActive)
+        {
+            recurringTransaction.Resume(DateTimeProvider.UtcNow.Date);
+        }
+        else
+        {
+            recurringTransaction.Pause();
+        }
+
+        var updated = await _recurringTransactionRepository.UpdateAsync(recurringTransaction, cancellationToken);
+        return RecurringTransactionMapper.ToDto(updated);
+    }
+}

--- a/src/Core/MyMascada.Application/Features/RecurringTransactions/Commands/SetRecurringTransactionActiveCommand.cs
+++ b/src/Core/MyMascada.Application/Features/RecurringTransactions/Commands/SetRecurringTransactionActiveCommand.cs
@@ -35,7 +35,7 @@ public class SetRecurringTransactionActiveCommandHandler
             request.Id, request.UserId, cancellationToken);
         if (recurringTransaction == null)
         {
-            throw new ArgumentException($"Recurring transaction with ID {request.Id} not found");
+            throw new KeyNotFoundException($"Recurring transaction with ID {request.Id} not found");
         }
 
         if (request.IsActive)

--- a/src/Core/MyMascada.Application/Features/RecurringTransactions/Commands/UpdateRecurringTransactionCommand.cs
+++ b/src/Core/MyMascada.Application/Features/RecurringTransactions/Commands/UpdateRecurringTransactionCommand.cs
@@ -29,15 +29,18 @@ public class UpdateRecurringTransactionCommandHandler
     private readonly IRecurringTransactionRepository _recurringTransactionRepository;
     private readonly IAccountRepository _accountRepository;
     private readonly ICategoryRepository _categoryRepository;
+    private readonly IAccountAccessService _accountAccessService;
 
     public UpdateRecurringTransactionCommandHandler(
         IRecurringTransactionRepository recurringTransactionRepository,
         IAccountRepository accountRepository,
-        ICategoryRepository categoryRepository)
+        ICategoryRepository categoryRepository,
+        IAccountAccessService accountAccessService)
     {
         _recurringTransactionRepository = recurringTransactionRepository;
         _accountRepository = accountRepository;
         _categoryRepository = categoryRepository;
+        _accountAccessService = accountAccessService;
     }
 
     public async Task<RecurringTransactionDto> Handle(
@@ -56,6 +59,19 @@ public class UpdateRecurringTransactionCommandHandler
         if (account == null)
         {
             throw new ArgumentException($"Account with ID {request.AccountId} not found or does not belong to user");
+        }
+
+        // Auto-create schedules materialize real transactions through the standard
+        // pipeline, which requires modify access (owner or Manager share). Reject
+        // viewer-only accounts up front — covers both moving a schedule to a
+        // viewer-only account and toggling AutoCreate on — instead of letting the
+        // nightly job fail on every run. Reminder-only schedules are fine with
+        // view access.
+        if (request.AutoCreate
+            && !await _accountAccessService.CanModifyAccountAsync(request.UserId, request.AccountId))
+        {
+            throw new UnauthorizedAccessException(
+                "You do not have permission to auto-create transactions on this account.");
         }
 
         // Validate category if provided

--- a/src/Core/MyMascada.Application/Features/RecurringTransactions/Commands/UpdateRecurringTransactionCommand.cs
+++ b/src/Core/MyMascada.Application/Features/RecurringTransactions/Commands/UpdateRecurringTransactionCommand.cs
@@ -1,0 +1,112 @@
+using MediatR;
+using MyMascada.Application.Common.Interfaces;
+using MyMascada.Application.Features.RecurringTransactions.DTOs;
+using MyMascada.Application.Features.RecurringTransactions.Mappings;
+using MyMascada.Domain.Common;
+using MyMascada.Domain.Enums;
+
+namespace MyMascada.Application.Features.RecurringTransactions.Commands;
+
+public class UpdateRecurringTransactionCommand : IRequest<RecurringTransactionDto>, IRecurringTransactionBaseCommand
+{
+    public int Id { get; set; }
+    public Guid UserId { get; set; }
+    public int AccountId { get; set; }
+    public int? CategoryId { get; set; }
+    public string Description { get; set; } = string.Empty;
+    public decimal Amount { get; set; }
+    public RecurrenceFrequency Frequency { get; set; }
+    public int? CustomIntervalDays { get; set; }
+    public DateTime StartDate { get; set; }
+    public DateTime? EndDate { get; set; }
+    public bool AutoCreate { get; set; }
+    public string? Notes { get; set; }
+}
+
+public class UpdateRecurringTransactionCommandHandler
+    : IRequestHandler<UpdateRecurringTransactionCommand, RecurringTransactionDto>
+{
+    private readonly IRecurringTransactionRepository _recurringTransactionRepository;
+    private readonly IAccountRepository _accountRepository;
+    private readonly ICategoryRepository _categoryRepository;
+
+    public UpdateRecurringTransactionCommandHandler(
+        IRecurringTransactionRepository recurringTransactionRepository,
+        IAccountRepository accountRepository,
+        ICategoryRepository categoryRepository)
+    {
+        _recurringTransactionRepository = recurringTransactionRepository;
+        _accountRepository = accountRepository;
+        _categoryRepository = categoryRepository;
+    }
+
+    public async Task<RecurringTransactionDto> Handle(
+        UpdateRecurringTransactionCommand request,
+        CancellationToken cancellationToken)
+    {
+        var recurringTransaction = await _recurringTransactionRepository.GetByIdAsync(
+            request.Id, request.UserId, cancellationToken);
+        if (recurringTransaction == null)
+        {
+            throw new ArgumentException($"Recurring transaction with ID {request.Id} not found");
+        }
+
+        // Validate account exists and belongs to user
+        var account = await _accountRepository.GetByIdAsync(request.AccountId, request.UserId);
+        if (account == null)
+        {
+            throw new ArgumentException($"Account with ID {request.AccountId} not found or does not belong to user");
+        }
+
+        // Validate category if provided
+        if (request.CategoryId.HasValue)
+        {
+            var categoryExists = await _categoryRepository.ExistsAsync(request.CategoryId.Value, request.UserId);
+            if (!categoryExists)
+            {
+                throw new ArgumentException($"Category with ID {request.CategoryId} not found or does not belong to user");
+            }
+        }
+
+        var newStartDate = DateTimeProvider.ToUtc(request.StartDate.Date);
+        var scheduleChanged = recurringTransaction.StartDate.Date != newStartDate.Date
+                              || recurringTransaction.Frequency != request.Frequency
+                              || recurringTransaction.CustomIntervalDays != request.CustomIntervalDays;
+
+        recurringTransaction.AccountId = request.AccountId;
+        recurringTransaction.CategoryId = request.CategoryId;
+        recurringTransaction.Description = request.Description.Trim();
+        recurringTransaction.Amount = request.Amount;
+        recurringTransaction.Frequency = request.Frequency;
+        recurringTransaction.CustomIntervalDays =
+            request.Frequency == RecurrenceFrequency.Custom ? request.CustomIntervalDays : null;
+        recurringTransaction.StartDate = newStartDate;
+        recurringTransaction.EndDate = request.EndDate.HasValue
+            ? DateTimeProvider.ToUtc(request.EndDate.Value.Date)
+            : null;
+        recurringTransaction.AutoCreate = request.AutoCreate;
+        recurringTransaction.Notes = request.Notes;
+
+        if (scheduleChanged)
+        {
+            // Recompute the next due date from the new schedule, fast-forwarding
+            // past dates so the job does not retroactively fire old occurrences.
+            recurringTransaction.NextDueDate = newStartDate;
+            var today = DateTimeProvider.UtcNow.Date;
+            if (recurringTransaction.NextDueDate.Date < today)
+            {
+                recurringTransaction.AdvanceNextDueDate(today.AddDays(-1));
+            }
+        }
+
+        // A shrunk EndDate may invalidate the current NextDueDate
+        if (recurringTransaction.EndDate.HasValue
+            && recurringTransaction.NextDueDate.Date > recurringTransaction.EndDate.Value.Date)
+        {
+            recurringTransaction.IsActive = false;
+        }
+
+        var updated = await _recurringTransactionRepository.UpdateAsync(recurringTransaction, cancellationToken);
+        return RecurringTransactionMapper.ToDto(updated);
+    }
+}

--- a/src/Core/MyMascada.Application/Features/RecurringTransactions/Commands/UpdateRecurringTransactionCommand.cs
+++ b/src/Core/MyMascada.Application/Features/RecurringTransactions/Commands/UpdateRecurringTransactionCommand.cs
@@ -48,7 +48,7 @@ public class UpdateRecurringTransactionCommandHandler
             request.Id, request.UserId, cancellationToken);
         if (recurringTransaction == null)
         {
-            throw new ArgumentException($"Recurring transaction with ID {request.Id} not found");
+            throw new KeyNotFoundException($"Recurring transaction with ID {request.Id} not found");
         }
 
         // Validate account exists and belongs to user

--- a/src/Core/MyMascada.Application/Features/RecurringTransactions/DTOs/CreateRecurringTransactionRequest.cs
+++ b/src/Core/MyMascada.Application/Features/RecurringTransactions/DTOs/CreateRecurringTransactionRequest.cs
@@ -5,34 +5,73 @@ namespace MyMascada.Application.Features.RecurringTransactions.DTOs;
 /// <summary>
 /// Request DTO for creating a recurring transaction.
 /// Full validation is performed by the command validator.
+///
+/// API notes:
+/// - StartDate/EndDate are treated as date-only values (the time component is
+///   discarded server-side). Clients should send date-only strings like
+///   "2026-07-31" — sending timezone-offset ISO strings can shift the value
+///   across midnight and change the anchor day used for monthly clamping.
+/// - Amount is a positive value. Recurring transactions are expense-only:
+///   auto-created transactions are stored with a negative amount. Recurring
+///   income would require a future direction flag.
 /// </summary>
 public class CreateRecurringTransactionRequest
 {
     public int AccountId { get; set; }
     public int? CategoryId { get; set; }
     public string Description { get; set; } = string.Empty;
+
+    /// <summary>
+    /// Positive bill amount (expense-only; stored negative when auto-created)
+    /// </summary>
     public decimal Amount { get; set; }
+
     public RecurrenceFrequency Frequency { get; set; }
     public int? CustomIntervalDays { get; set; }
+
+    /// <summary>
+    /// Date-only. Anchors the day-of-month for Monthly/Yearly clamping.
+    /// </summary>
     public DateTime StartDate { get; set; }
+
+    /// <summary>
+    /// Date-only. Last date on which an occurrence may fall.
+    /// </summary>
     public DateTime? EndDate { get; set; }
+
     public bool AutoCreate { get; set; }
     public string? Notes { get; set; }
 }
 
 /// <summary>
-/// Request DTO for updating a recurring transaction
+/// Request DTO for updating a recurring transaction.
+/// Same API notes as <see cref="CreateRecurringTransactionRequest"/>:
+/// dates are date-only, amount is positive (expense-only).
 /// </summary>
 public class UpdateRecurringTransactionRequest
 {
     public int AccountId { get; set; }
     public int? CategoryId { get; set; }
     public string Description { get; set; } = string.Empty;
+
+    /// <summary>
+    /// Positive bill amount (expense-only; stored negative when auto-created)
+    /// </summary>
     public decimal Amount { get; set; }
+
     public RecurrenceFrequency Frequency { get; set; }
     public int? CustomIntervalDays { get; set; }
+
+    /// <summary>
+    /// Date-only. Anchors the day-of-month for Monthly/Yearly clamping.
+    /// </summary>
     public DateTime StartDate { get; set; }
+
+    /// <summary>
+    /// Date-only. Last date on which an occurrence may fall.
+    /// </summary>
     public DateTime? EndDate { get; set; }
+
     public bool AutoCreate { get; set; }
     public string? Notes { get; set; }
 }

--- a/src/Core/MyMascada.Application/Features/RecurringTransactions/DTOs/CreateRecurringTransactionRequest.cs
+++ b/src/Core/MyMascada.Application/Features/RecurringTransactions/DTOs/CreateRecurringTransactionRequest.cs
@@ -1,0 +1,38 @@
+using MyMascada.Domain.Enums;
+
+namespace MyMascada.Application.Features.RecurringTransactions.DTOs;
+
+/// <summary>
+/// Request DTO for creating a recurring transaction.
+/// Full validation is performed by the command validator.
+/// </summary>
+public class CreateRecurringTransactionRequest
+{
+    public int AccountId { get; set; }
+    public int? CategoryId { get; set; }
+    public string Description { get; set; } = string.Empty;
+    public decimal Amount { get; set; }
+    public RecurrenceFrequency Frequency { get; set; }
+    public int? CustomIntervalDays { get; set; }
+    public DateTime StartDate { get; set; }
+    public DateTime? EndDate { get; set; }
+    public bool AutoCreate { get; set; }
+    public string? Notes { get; set; }
+}
+
+/// <summary>
+/// Request DTO for updating a recurring transaction
+/// </summary>
+public class UpdateRecurringTransactionRequest
+{
+    public int AccountId { get; set; }
+    public int? CategoryId { get; set; }
+    public string Description { get; set; } = string.Empty;
+    public decimal Amount { get; set; }
+    public RecurrenceFrequency Frequency { get; set; }
+    public int? CustomIntervalDays { get; set; }
+    public DateTime StartDate { get; set; }
+    public DateTime? EndDate { get; set; }
+    public bool AutoCreate { get; set; }
+    public string? Notes { get; set; }
+}

--- a/src/Core/MyMascada.Application/Features/RecurringTransactions/DTOs/RecurringTransactionDto.cs
+++ b/src/Core/MyMascada.Application/Features/RecurringTransactions/DTOs/RecurringTransactionDto.cs
@@ -1,0 +1,63 @@
+using MyMascada.Domain.Enums;
+
+namespace MyMascada.Application.Features.RecurringTransactions.DTOs;
+
+/// <summary>
+/// Summary DTO for a user-created recurring transaction (scheduled bill)
+/// </summary>
+public class RecurringTransactionDto
+{
+    public int Id { get; set; }
+    public int AccountId { get; set; }
+    public string AccountName { get; set; } = string.Empty;
+    public int? CategoryId { get; set; }
+    public string? CategoryName { get; set; }
+    public string Description { get; set; } = string.Empty;
+    public decimal Amount { get; set; }
+    public RecurrenceFrequency Frequency { get; set; }
+    public int? CustomIntervalDays { get; set; }
+    public DateTime StartDate { get; set; }
+    public DateTime? EndDate { get; set; }
+    public DateTime NextDueDate { get; set; }
+    public bool AutoCreate { get; set; }
+    public bool IsActive { get; set; }
+    public string? Notes { get; set; }
+    public DateTime CreatedAt { get; set; }
+    public DateTime UpdatedAt { get; set; }
+}
+
+/// <summary>
+/// Detail DTO including recent occurrences
+/// </summary>
+public class RecurringTransactionDetailDto : RecurringTransactionDto
+{
+    public List<RecurringTransactionOccurrenceDto> RecentOccurrences { get; set; } = new();
+}
+
+/// <summary>
+/// DTO for a processed occurrence of a recurring transaction
+/// </summary>
+public class RecurringTransactionOccurrenceDto
+{
+    public int Id { get; set; }
+    public DateTime ScheduledDate { get; set; }
+    public RecurringTransactionOccurrenceStatus Status { get; set; }
+    public int? TransactionId { get; set; }
+    public DateTime CreatedAt { get; set; }
+}
+
+/// <summary>
+/// A materialized upcoming occurrence of a recurring transaction
+/// </summary>
+public class UpcomingRecurringTransactionDto
+{
+    public int RecurringTransactionId { get; set; }
+    public string Description { get; set; } = string.Empty;
+    public decimal Amount { get; set; }
+    public int AccountId { get; set; }
+    public string AccountName { get; set; } = string.Empty;
+    public int? CategoryId { get; set; }
+    public string? CategoryName { get; set; }
+    public DateTime DueDate { get; set; }
+    public bool AutoCreate { get; set; }
+}

--- a/src/Core/MyMascada.Application/Features/RecurringTransactions/DTOs/RecurringTransactionDto.cs
+++ b/src/Core/MyMascada.Application/Features/RecurringTransactions/DTOs/RecurringTransactionDto.cs
@@ -3,7 +3,10 @@ using MyMascada.Domain.Enums;
 namespace MyMascada.Application.Features.RecurringTransactions.DTOs;
 
 /// <summary>
-/// Summary DTO for a user-created recurring transaction (scheduled bill)
+/// Summary DTO for a user-created recurring transaction (scheduled bill).
+/// Dates (StartDate/EndDate/NextDueDate) are date-only values serialized at
+/// UTC midnight; Amount is always positive (expense-only — auto-created
+/// transactions are stored negative).
 /// </summary>
 public class RecurringTransactionDto
 {

--- a/src/Core/MyMascada.Application/Features/RecurringTransactions/Mappings/RecurringTransactionMapper.cs
+++ b/src/Core/MyMascada.Application/Features/RecurringTransactions/Mappings/RecurringTransactionMapper.cs
@@ -1,0 +1,60 @@
+using MyMascada.Application.Features.RecurringTransactions.DTOs;
+using MyMascada.Domain.Entities;
+
+namespace MyMascada.Application.Features.RecurringTransactions.Mappings;
+
+/// <summary>
+/// Manual mapping between RecurringTransaction entities and DTOs
+/// </summary>
+public static class RecurringTransactionMapper
+{
+    public static RecurringTransactionDto ToDto(RecurringTransaction entity)
+    {
+        var dto = new RecurringTransactionDto();
+        MapSummary(entity, dto);
+        return dto;
+    }
+
+    public static RecurringTransactionDetailDto ToDetailDto(
+        RecurringTransaction entity,
+        IEnumerable<RecurringTransactionOccurrence> recentOccurrences)
+    {
+        var dto = new RecurringTransactionDetailDto();
+        MapSummary(entity, dto);
+        dto.RecentOccurrences = recentOccurrences.Select(ToOccurrenceDto).ToList();
+        return dto;
+    }
+
+    public static RecurringTransactionOccurrenceDto ToOccurrenceDto(RecurringTransactionOccurrence occurrence)
+    {
+        return new RecurringTransactionOccurrenceDto
+        {
+            Id = occurrence.Id,
+            ScheduledDate = occurrence.ScheduledDate,
+            Status = occurrence.Status,
+            TransactionId = occurrence.TransactionId,
+            CreatedAt = occurrence.CreatedAt
+        };
+    }
+
+    private static void MapSummary(RecurringTransaction entity, RecurringTransactionDto dto)
+    {
+        dto.Id = entity.Id;
+        dto.AccountId = entity.AccountId;
+        dto.AccountName = entity.Account?.Name ?? string.Empty;
+        dto.CategoryId = entity.CategoryId;
+        dto.CategoryName = entity.Category?.Name;
+        dto.Description = entity.Description;
+        dto.Amount = entity.Amount;
+        dto.Frequency = entity.Frequency;
+        dto.CustomIntervalDays = entity.CustomIntervalDays;
+        dto.StartDate = entity.StartDate;
+        dto.EndDate = entity.EndDate;
+        dto.NextDueDate = entity.NextDueDate;
+        dto.AutoCreate = entity.AutoCreate;
+        dto.IsActive = entity.IsActive;
+        dto.Notes = entity.Notes;
+        dto.CreatedAt = entity.CreatedAt;
+        dto.UpdatedAt = entity.UpdatedAt;
+    }
+}

--- a/src/Core/MyMascada.Application/Features/RecurringTransactions/Queries/GetRecurringTransactionQuery.cs
+++ b/src/Core/MyMascada.Application/Features/RecurringTransactions/Queries/GetRecurringTransactionQuery.cs
@@ -1,0 +1,40 @@
+using MediatR;
+using MyMascada.Application.Common.Interfaces;
+using MyMascada.Application.Features.RecurringTransactions.DTOs;
+using MyMascada.Application.Features.RecurringTransactions.Mappings;
+
+namespace MyMascada.Application.Features.RecurringTransactions.Queries;
+
+public class GetRecurringTransactionQuery : IRequest<RecurringTransactionDetailDto?>
+{
+    public int Id { get; set; }
+    public Guid UserId { get; set; }
+}
+
+public class GetRecurringTransactionQueryHandler
+    : IRequestHandler<GetRecurringTransactionQuery, RecurringTransactionDetailDto?>
+{
+    private readonly IRecurringTransactionRepository _recurringTransactionRepository;
+
+    public GetRecurringTransactionQueryHandler(IRecurringTransactionRepository recurringTransactionRepository)
+    {
+        _recurringTransactionRepository = recurringTransactionRepository;
+    }
+
+    public async Task<RecurringTransactionDetailDto?> Handle(
+        GetRecurringTransactionQuery request,
+        CancellationToken cancellationToken)
+    {
+        var recurringTransaction = await _recurringTransactionRepository.GetByIdAsync(
+            request.Id, request.UserId, cancellationToken);
+        if (recurringTransaction == null)
+        {
+            return null;
+        }
+
+        var occurrences = await _recurringTransactionRepository.GetRecentOccurrencesAsync(
+            request.Id, request.UserId, count: 10, cancellationToken);
+
+        return RecurringTransactionMapper.ToDetailDto(recurringTransaction, occurrences);
+    }
+}

--- a/src/Core/MyMascada.Application/Features/RecurringTransactions/Queries/GetRecurringTransactionsQuery.cs
+++ b/src/Core/MyMascada.Application/Features/RecurringTransactions/Queries/GetRecurringTransactionsQuery.cs
@@ -1,0 +1,33 @@
+using MediatR;
+using MyMascada.Application.Common.Interfaces;
+using MyMascada.Application.Features.RecurringTransactions.DTOs;
+using MyMascada.Application.Features.RecurringTransactions.Mappings;
+
+namespace MyMascada.Application.Features.RecurringTransactions.Queries;
+
+public class GetRecurringTransactionsQuery : IRequest<List<RecurringTransactionDto>>
+{
+    public Guid UserId { get; set; }
+    public bool IncludeInactive { get; set; }
+}
+
+public class GetRecurringTransactionsQueryHandler
+    : IRequestHandler<GetRecurringTransactionsQuery, List<RecurringTransactionDto>>
+{
+    private readonly IRecurringTransactionRepository _recurringTransactionRepository;
+
+    public GetRecurringTransactionsQueryHandler(IRecurringTransactionRepository recurringTransactionRepository)
+    {
+        _recurringTransactionRepository = recurringTransactionRepository;
+    }
+
+    public async Task<List<RecurringTransactionDto>> Handle(
+        GetRecurringTransactionsQuery request,
+        CancellationToken cancellationToken)
+    {
+        var recurringTransactions = await _recurringTransactionRepository.GetByUserIdAsync(
+            request.UserId, request.IncludeInactive, cancellationToken);
+
+        return recurringTransactions.Select(RecurringTransactionMapper.ToDto).ToList();
+    }
+}

--- a/src/Core/MyMascada.Application/Features/RecurringTransactions/Queries/GetUpcomingRecurringTransactionsQuery.cs
+++ b/src/Core/MyMascada.Application/Features/RecurringTransactions/Queries/GetUpcomingRecurringTransactionsQuery.cs
@@ -1,0 +1,66 @@
+using MediatR;
+using MyMascada.Application.Common.Interfaces;
+using MyMascada.Application.Features.RecurringTransactions.DTOs;
+using MyMascada.Domain.Common;
+
+namespace MyMascada.Application.Features.RecurringTransactions.Queries;
+
+/// <summary>
+/// Materializes the upcoming schedule for the user's active recurring transactions
+/// (user-created bills — distinct from heuristic upcoming-bills detection).
+/// </summary>
+public class GetUpcomingRecurringTransactionsQuery : IRequest<List<UpcomingRecurringTransactionDto>>
+{
+    public Guid UserId { get; set; }
+    public int DaysAhead { get; set; } = 30;
+}
+
+public class GetUpcomingRecurringTransactionsQueryHandler
+    : IRequestHandler<GetUpcomingRecurringTransactionsQuery, List<UpcomingRecurringTransactionDto>>
+{
+    private readonly IRecurringTransactionRepository _recurringTransactionRepository;
+
+    public GetUpcomingRecurringTransactionsQueryHandler(
+        IRecurringTransactionRepository recurringTransactionRepository)
+    {
+        _recurringTransactionRepository = recurringTransactionRepository;
+    }
+
+    public async Task<List<UpcomingRecurringTransactionDto>> Handle(
+        GetUpcomingRecurringTransactionsQuery request,
+        CancellationToken cancellationToken)
+    {
+        var daysAhead = Math.Clamp(request.DaysAhead, 1, 366);
+        var fromDate = DateTimeProvider.UtcNow.Date;
+        var toDate = fromDate.AddDays(daysAhead);
+
+        var activeRecurringTransactions = await _recurringTransactionRepository.GetActiveByUserIdAsync(
+            request.UserId, cancellationToken);
+
+        var upcoming = new List<UpcomingRecurringTransactionDto>();
+
+        foreach (var recurringTransaction in activeRecurringTransactions)
+        {
+            foreach (var dueDate in recurringTransaction.GetScheduledDates(fromDate, toDate))
+            {
+                upcoming.Add(new UpcomingRecurringTransactionDto
+                {
+                    RecurringTransactionId = recurringTransaction.Id,
+                    Description = recurringTransaction.Description,
+                    Amount = recurringTransaction.Amount,
+                    AccountId = recurringTransaction.AccountId,
+                    AccountName = recurringTransaction.Account?.Name ?? string.Empty,
+                    CategoryId = recurringTransaction.CategoryId,
+                    CategoryName = recurringTransaction.Category?.Name,
+                    DueDate = dueDate,
+                    AutoCreate = recurringTransaction.AutoCreate
+                });
+            }
+        }
+
+        return upcoming
+            .OrderBy(u => u.DueDate)
+            .ThenBy(u => u.Description)
+            .ToList();
+    }
+}

--- a/src/Core/MyMascada.Application/Features/RecurringTransactions/Services/RecurringTransactionProcessingService.cs
+++ b/src/Core/MyMascada.Application/Features/RecurringTransactions/Services/RecurringTransactionProcessingService.cs
@@ -37,17 +37,23 @@ public class RecurringTransactionProcessingService : IRecurringTransactionProces
     private readonly IRecurringTransactionRepository _recurringTransactionRepository;
     private readonly IMediator _mediator;
     private readonly INotificationTriggerService _notificationTriggerService;
+    private readonly IAccountAccessService _accountAccessService;
+    private readonly IUnitOfWork _unitOfWork;
     private readonly ILogger<RecurringTransactionProcessingService> _logger;
 
     public RecurringTransactionProcessingService(
         IRecurringTransactionRepository recurringTransactionRepository,
         IMediator mediator,
         INotificationTriggerService notificationTriggerService,
+        IAccountAccessService accountAccessService,
+        IUnitOfWork unitOfWork,
         ILogger<RecurringTransactionProcessingService> logger)
     {
         _recurringTransactionRepository = recurringTransactionRepository;
         _mediator = mediator;
         _notificationTriggerService = notificationTriggerService;
+        _accountAccessService = accountAccessService;
+        _unitOfWork = unitOfWork;
         _logger = logger;
     }
 
@@ -104,6 +110,27 @@ public class RecurringTransactionProcessingService : IRecurringTransactionProces
             _logger.LogWarning(
                 "Account {AccountId} for recurring transaction {RecurringTransactionId} no longer exists; deactivating schedule",
                 schedule.AccountId, schedule.Id);
+
+            schedule.Pause();
+            await _recurringTransactionRepository.UpdateAsync(schedule, cancellationToken);
+            result.SchedulesDeactivated++;
+            return;
+        }
+
+        // A revoked or downgraded share leaves the account in place but the owner
+        // without the access the schedule needs: auto-create requires modify access
+        // (CreateTransactionCommand enforces it and would fail every night), and a
+        // reminder-only schedule must not keep notifying about an account the user
+        // can no longer view. Pause instead of failing/ghost-reminding forever.
+        var hasRequiredAccess = schedule.AutoCreate
+            ? await _accountAccessService.CanModifyAccountAsync(schedule.UserId, schedule.AccountId)
+            : await _accountAccessService.CanAccessAccountAsync(schedule.UserId, schedule.AccountId);
+
+        if (!hasRequiredAccess)
+        {
+            _logger.LogWarning(
+                "User {UserId} no longer has {RequiredAccess} access to account {AccountId} for recurring transaction {RecurringTransactionId}; pausing schedule",
+                schedule.UserId, schedule.AutoCreate ? "modify" : "view", schedule.AccountId, schedule.Id);
 
             schedule.Pause();
             await _recurringTransactionRepository.UpdateAsync(schedule, cancellationToken);
@@ -190,6 +217,16 @@ public class RecurringTransactionProcessingService : IRecurringTransactionProces
     {
         if (schedule.AutoCreate)
         {
+            // The real transaction insert and the occurrence's Pending → Created
+            // flip must commit atomically. Every repository in this job scope
+            // shares the same scoped DbContext, so the handler's internal
+            // SaveChanges enlists in this ambient transaction. A crash or failed
+            // occurrence update after CreateTransactionCommand therefore rolls
+            // the money record back too, instead of leaving a committed
+            // transaction behind a Pending claim for the next run's recovery
+            // path to duplicate.
+            await using var transaction = await _unitOfWork.BeginTransactionAsync(cancellationToken);
+
             // Reuse the standard transaction creation pipeline (validation,
             // categorization, account access). Expenses are stored negative.
             var transactionDto = await _mediator.Send(new CreateTransactionCommand
@@ -210,10 +247,16 @@ public class RecurringTransactionProcessingService : IRecurringTransactionProces
 
             occurrence.TransactionId = transactionDto.Id;
             occurrence.Status = RecurringTransactionOccurrenceStatus.Created;
+            await _recurringTransactionRepository.UpdateOccurrenceAsync(occurrence, cancellationToken);
+
+            await transaction.CommitAsync(cancellationToken);
             result.TransactionsCreated++;
         }
         else
         {
+            // Reminders are not money records: a rare duplicate notification is
+            // benign and the push delivery cannot be rolled back anyway, so no
+            // ambient transaction is needed here.
             await _notificationTriggerService.NotifyTransactionReminderAsync(
                 schedule.UserId,
                 schedule.Description,
@@ -223,8 +266,8 @@ public class RecurringTransactionProcessingService : IRecurringTransactionProces
 
             occurrence.Status = RecurringTransactionOccurrenceStatus.Notified;
             result.RemindersSent++;
-        }
 
-        await _recurringTransactionRepository.UpdateOccurrenceAsync(occurrence, cancellationToken);
+            await _recurringTransactionRepository.UpdateOccurrenceAsync(occurrence, cancellationToken);
+        }
     }
 }

--- a/src/Core/MyMascada.Application/Features/RecurringTransactions/Services/RecurringTransactionProcessingService.cs
+++ b/src/Core/MyMascada.Application/Features/RecurringTransactions/Services/RecurringTransactionProcessingService.cs
@@ -1,0 +1,164 @@
+using MediatR;
+using Microsoft.Extensions.Logging;
+using MyMascada.Application.Common.Interfaces;
+using MyMascada.Application.Features.Transactions.Commands;
+using MyMascada.Domain.Entities;
+using MyMascada.Domain.Enums;
+
+namespace MyMascada.Application.Features.RecurringTransactions.Services;
+
+/// <summary>
+/// Result summary of a recurring transaction processing run
+/// </summary>
+public class RecurringTransactionProcessingResult
+{
+    public int SchedulesProcessed { get; set; }
+    public int TransactionsCreated { get; set; }
+    public int RemindersSent { get; set; }
+    public int OccurrencesSkipped { get; set; }
+    public int SchedulesDeactivated { get; set; }
+    public int SchedulesFailed { get; set; }
+}
+
+/// <summary>
+/// Core logic for the daily recurring transaction job. For every active schedule
+/// that is due, either auto-creates the real transaction or sends a reminder,
+/// then advances the schedule. Idempotent per (schedule, scheduled date).
+/// </summary>
+public interface IRecurringTransactionProcessingService
+{
+    Task<RecurringTransactionProcessingResult> ProcessDueAsync(
+        DateTime asOfDate,
+        CancellationToken cancellationToken = default);
+}
+
+public class RecurringTransactionProcessingService : IRecurringTransactionProcessingService
+{
+    private readonly IRecurringTransactionRepository _recurringTransactionRepository;
+    private readonly IMediator _mediator;
+    private readonly INotificationTriggerService _notificationTriggerService;
+    private readonly ILogger<RecurringTransactionProcessingService> _logger;
+
+    public RecurringTransactionProcessingService(
+        IRecurringTransactionRepository recurringTransactionRepository,
+        IMediator mediator,
+        INotificationTriggerService notificationTriggerService,
+        ILogger<RecurringTransactionProcessingService> logger)
+    {
+        _recurringTransactionRepository = recurringTransactionRepository;
+        _mediator = mediator;
+        _notificationTriggerService = notificationTriggerService;
+        _logger = logger;
+    }
+
+    public async Task<RecurringTransactionProcessingResult> ProcessDueAsync(
+        DateTime asOfDate,
+        CancellationToken cancellationToken = default)
+    {
+        var today = asOfDate.Date;
+        var result = new RecurringTransactionProcessingResult();
+
+        var dueSchedules = (await _recurringTransactionRepository.GetDueAsync(today, cancellationToken)).ToList();
+
+        _logger.LogInformation(
+            "Processing {Count} due recurring transactions as of {Date}",
+            dueSchedules.Count, today);
+
+        foreach (var schedule in dueSchedules)
+        {
+            try
+            {
+                await ProcessScheduleAsync(schedule, today, result, cancellationToken);
+                result.SchedulesProcessed++;
+            }
+            catch (OperationCanceledException)
+            {
+                throw;
+            }
+            catch (Exception ex)
+            {
+                result.SchedulesFailed++;
+                _logger.LogError(ex,
+                    "Failed to process recurring transaction {RecurringTransactionId} for user {UserId}",
+                    schedule.Id, schedule.UserId);
+            }
+        }
+
+        return result;
+    }
+
+    private async Task ProcessScheduleAsync(
+        RecurringTransaction schedule,
+        DateTime today,
+        RecurringTransactionProcessingResult result,
+        CancellationToken cancellationToken)
+    {
+        foreach (var dueDate in schedule.GetDueDates(today))
+        {
+            // Idempotency guard: never fire the same scheduled date twice
+            if (await _recurringTransactionRepository.HasOccurrenceAsync(schedule.Id, dueDate, cancellationToken))
+            {
+                result.OccurrencesSkipped++;
+                continue;
+            }
+
+            int? transactionId = null;
+            RecurringTransactionOccurrenceStatus status;
+
+            if (schedule.AutoCreate)
+            {
+                // Reuse the standard transaction creation pipeline (validation,
+                // categorization, account access). Expenses are stored negative.
+                var transactionDto = await _mediator.Send(new CreateTransactionCommand
+                {
+                    UserId = schedule.UserId,
+                    AccountId = schedule.AccountId,
+                    CategoryId = schedule.CategoryId,
+                    Amount = -Math.Abs(schedule.Amount),
+                    TransactionDate = dueDate,
+                    Description = schedule.Description,
+                    Status = TransactionStatus.Pending,
+                    Notes = schedule.Notes,
+                    Tags = "recurring",
+                    // Occurrence uniqueness is our idempotency mechanism; the duplicate
+                    // checker would otherwise collapse identical catch-up occurrences.
+                    AllowDuplicates = true
+                }, cancellationToken);
+
+                transactionId = transactionDto.Id;
+                status = RecurringTransactionOccurrenceStatus.Created;
+                result.TransactionsCreated++;
+            }
+            else
+            {
+                await _notificationTriggerService.NotifyTransactionReminderAsync(
+                    schedule.UserId,
+                    schedule.Description,
+                    schedule.Amount,
+                    dueDate,
+                    cancellationToken);
+
+                status = RecurringTransactionOccurrenceStatus.Notified;
+                result.RemindersSent++;
+            }
+
+            await _recurringTransactionRepository.CreateOccurrenceAsync(new RecurringTransactionOccurrence
+            {
+                RecurringTransactionId = schedule.Id,
+                ScheduledDate = dueDate,
+                Status = status,
+                TransactionId = transactionId
+            }, cancellationToken);
+        }
+
+        var wasActive = schedule.IsActive;
+        schedule.AdvanceNextDueDate(today);
+
+        if (wasActive && !schedule.IsActive)
+        {
+            result.SchedulesDeactivated++;
+        }
+
+        await _recurringTransactionRepository.UpdateAsync(schedule, cancellationToken);
+    }
+}

--- a/src/Core/MyMascada.Application/Features/RecurringTransactions/Services/RecurringTransactionProcessingService.cs
+++ b/src/Core/MyMascada.Application/Features/RecurringTransactions/Services/RecurringTransactionProcessingService.cs
@@ -111,7 +111,9 @@ public class RecurringTransactionProcessingService : IRecurringTransactionProces
             return;
         }
 
-        foreach (var dueDate in schedule.GetDueDates(today))
+        var dueDates = schedule.GetDueDates(today);
+
+        foreach (var dueDate in dueDates)
         {
             var existing = await _recurringTransactionRepository.GetOccurrenceAsync(
                 schedule.Id, dueDate, cancellationToken);
@@ -157,7 +159,19 @@ public class RecurringTransactionProcessingService : IRecurringTransactionProces
         }
 
         var wasActive = schedule.IsActive;
-        schedule.AdvanceNextDueDate(today);
+
+        if (dueDates.Count > 0)
+        {
+            // Advance from the last materialized date instead of snapping past
+            // today: when GetDueDates hits its catch-up cap the remaining dates
+            // are still due, and the next nightly run continues from where this
+            // one stopped instead of silently losing them.
+            schedule.AdvanceNextDueDateAfter(dueDates[^1]);
+        }
+        else
+        {
+            schedule.AdvanceNextDueDate(today);
+        }
 
         if (wasActive && !schedule.IsActive)
         {

--- a/src/Core/MyMascada.Application/Features/RecurringTransactions/Services/RecurringTransactionProcessingService.cs
+++ b/src/Core/MyMascada.Application/Features/RecurringTransactions/Services/RecurringTransactionProcessingService.cs
@@ -81,6 +81,10 @@ public class RecurringTransactionProcessingService : IRecurringTransactionProces
                 _logger.LogError(ex,
                     "Failed to process recurring transaction {RecurringTransactionId} for user {UserId}",
                     schedule.Id, schedule.UserId);
+
+                // A failed save leaves poisoned entries in the shared scoped change
+                // tracker; detach everything so subsequent schedules can still save.
+                _recurringTransactionRepository.ResetChangeTracking();
             }
         }
 
@@ -93,62 +97,63 @@ public class RecurringTransactionProcessingService : IRecurringTransactionProces
         RecurringTransactionProcessingResult result,
         CancellationToken cancellationToken)
     {
+        // Schedules pointing at a deleted account can never succeed — deactivate
+        // them instead of failing (or ghost-reminding) every night.
+        if (!await _recurringTransactionRepository.AccountExistsAsync(schedule.AccountId, cancellationToken))
+        {
+            _logger.LogWarning(
+                "Account {AccountId} for recurring transaction {RecurringTransactionId} no longer exists; deactivating schedule",
+                schedule.AccountId, schedule.Id);
+
+            schedule.Pause();
+            await _recurringTransactionRepository.UpdateAsync(schedule, cancellationToken);
+            result.SchedulesDeactivated++;
+            return;
+        }
+
         foreach (var dueDate in schedule.GetDueDates(today))
         {
-            // Idempotency guard: never fire the same scheduled date twice
-            if (await _recurringTransactionRepository.HasOccurrenceAsync(schedule.Id, dueDate, cancellationToken))
+            var existing = await _recurringTransactionRepository.GetOccurrenceAsync(
+                schedule.Id, dueDate, cancellationToken);
+
+            if (existing != null)
             {
+                if (existing.Status == RecurringTransactionOccurrenceStatus.Pending)
+                {
+                    // A previous run claimed this date but crashed before completing it.
+                    // Concurrent job executions are serialized (DisableConcurrentExecution),
+                    // so a Pending row seen here is stale — finish it now.
+                    await CompleteOccurrenceAsync(schedule, existing, dueDate, result, cancellationToken);
+                }
+                else
+                {
+                    // Already fired on an earlier run — never fire the same date twice.
+                    result.OccurrencesSkipped++;
+                }
+
+                continue;
+            }
+
+            // Claim the scheduled date BEFORE creating the transaction / sending the
+            // reminder. The unique (RecurringTransactionId, ScheduledDate) index makes
+            // the claim atomic: a crash after this point leaves a Pending row that the
+            // next run completes, instead of replaying the bill into a duplicate.
+            var claim = await _recurringTransactionRepository.TryCreateOccurrenceAsync(
+                new RecurringTransactionOccurrence
+                {
+                    RecurringTransactionId = schedule.Id,
+                    ScheduledDate = dueDate,
+                    Status = RecurringTransactionOccurrenceStatus.Pending
+                }, cancellationToken);
+
+            if (claim == null)
+            {
+                // Lost the insert race to another run that claimed this date.
                 result.OccurrencesSkipped++;
                 continue;
             }
 
-            int? transactionId = null;
-            RecurringTransactionOccurrenceStatus status;
-
-            if (schedule.AutoCreate)
-            {
-                // Reuse the standard transaction creation pipeline (validation,
-                // categorization, account access). Expenses are stored negative.
-                var transactionDto = await _mediator.Send(new CreateTransactionCommand
-                {
-                    UserId = schedule.UserId,
-                    AccountId = schedule.AccountId,
-                    CategoryId = schedule.CategoryId,
-                    Amount = -Math.Abs(schedule.Amount),
-                    TransactionDate = dueDate,
-                    Description = schedule.Description,
-                    Status = TransactionStatus.Pending,
-                    Notes = schedule.Notes,
-                    Tags = "recurring",
-                    // Occurrence uniqueness is our idempotency mechanism; the duplicate
-                    // checker would otherwise collapse identical catch-up occurrences.
-                    AllowDuplicates = true
-                }, cancellationToken);
-
-                transactionId = transactionDto.Id;
-                status = RecurringTransactionOccurrenceStatus.Created;
-                result.TransactionsCreated++;
-            }
-            else
-            {
-                await _notificationTriggerService.NotifyTransactionReminderAsync(
-                    schedule.UserId,
-                    schedule.Description,
-                    schedule.Amount,
-                    dueDate,
-                    cancellationToken);
-
-                status = RecurringTransactionOccurrenceStatus.Notified;
-                result.RemindersSent++;
-            }
-
-            await _recurringTransactionRepository.CreateOccurrenceAsync(new RecurringTransactionOccurrence
-            {
-                RecurringTransactionId = schedule.Id,
-                ScheduledDate = dueDate,
-                Status = status,
-                TransactionId = transactionId
-            }, cancellationToken);
+            await CompleteOccurrenceAsync(schedule, claim, dueDate, result, cancellationToken);
         }
 
         var wasActive = schedule.IsActive;
@@ -160,5 +165,52 @@ public class RecurringTransactionProcessingService : IRecurringTransactionProces
         }
 
         await _recurringTransactionRepository.UpdateAsync(schedule, cancellationToken);
+    }
+
+    private async Task CompleteOccurrenceAsync(
+        RecurringTransaction schedule,
+        RecurringTransactionOccurrence occurrence,
+        DateTime dueDate,
+        RecurringTransactionProcessingResult result,
+        CancellationToken cancellationToken)
+    {
+        if (schedule.AutoCreate)
+        {
+            // Reuse the standard transaction creation pipeline (validation,
+            // categorization, account access). Expenses are stored negative.
+            var transactionDto = await _mediator.Send(new CreateTransactionCommand
+            {
+                UserId = schedule.UserId,
+                AccountId = schedule.AccountId,
+                CategoryId = schedule.CategoryId,
+                Amount = -Math.Abs(schedule.Amount),
+                TransactionDate = dueDate,
+                Description = schedule.Description,
+                Status = TransactionStatus.Pending,
+                Notes = schedule.Notes,
+                Tags = "recurring",
+                // The claimed occurrence row is our idempotency mechanism; the duplicate
+                // checker would otherwise collapse identical catch-up occurrences.
+                AllowDuplicates = true
+            }, cancellationToken);
+
+            occurrence.TransactionId = transactionDto.Id;
+            occurrence.Status = RecurringTransactionOccurrenceStatus.Created;
+            result.TransactionsCreated++;
+        }
+        else
+        {
+            await _notificationTriggerService.NotifyTransactionReminderAsync(
+                schedule.UserId,
+                schedule.Description,
+                schedule.Amount,
+                dueDate,
+                cancellationToken);
+
+            occurrence.Status = RecurringTransactionOccurrenceStatus.Notified;
+            result.RemindersSent++;
+        }
+
+        await _recurringTransactionRepository.UpdateOccurrenceAsync(occurrence, cancellationToken);
     }
 }

--- a/src/Core/MyMascada.Application/Features/RecurringTransactions/Validators/RecurringTransactionCommandValidatorBase.cs
+++ b/src/Core/MyMascada.Application/Features/RecurringTransactions/Validators/RecurringTransactionCommandValidatorBase.cs
@@ -1,0 +1,72 @@
+using FluentValidation;
+using MyMascada.Application.Features.RecurringTransactions.Commands;
+using MyMascada.Domain.Enums;
+
+namespace MyMascada.Application.Features.RecurringTransactions.Validators;
+
+/// <summary>
+/// Base validator containing shared validation rules for recurring transaction commands.
+/// </summary>
+public abstract class RecurringTransactionCommandValidatorBase<TCommand> : AbstractValidator<TCommand>
+    where TCommand : IRecurringTransactionBaseCommand
+{
+    protected RecurringTransactionCommandValidatorBase()
+    {
+        RuleFor(x => x.AccountId)
+            .GreaterThan(0)
+            .WithMessage("A valid account must be specified.");
+
+        RuleFor(x => x.Description)
+            .NotEmpty()
+            .WithMessage("Description is required.")
+            .MaximumLength(200)
+            .WithMessage("Description cannot exceed 200 characters.");
+
+        RuleFor(x => x.Amount)
+            .GreaterThan(0)
+            .WithMessage("Amount must be greater than zero.")
+            .LessThanOrEqualTo(1_000_000m)
+            .WithMessage("Amount must not exceed 1,000,000.");
+
+        RuleFor(x => x.Frequency)
+            .IsInEnum()
+            .WithMessage("A valid frequency must be specified.");
+
+        RuleFor(x => x.CustomIntervalDays)
+            .NotNull()
+            .WithMessage("Custom interval days is required when frequency is Custom.")
+            .InclusiveBetween(1, 366)
+            .WithMessage("Custom interval days must be between 1 and 366.")
+            .When(x => x.Frequency == RecurrenceFrequency.Custom);
+
+        RuleFor(x => x.StartDate)
+            .NotEmpty()
+            .WithMessage("Start date is required.");
+
+        RuleFor(x => x.EndDate)
+            .GreaterThanOrEqualTo(x => x.StartDate)
+            .WithMessage("End date must be on or after the start date.")
+            .When(x => x.EndDate.HasValue);
+
+        RuleFor(x => x.Notes)
+            .MaximumLength(500)
+            .WithMessage("Notes cannot exceed 500 characters.")
+            .When(x => x.Notes != null);
+    }
+}
+
+public class CreateRecurringTransactionCommandValidator
+    : RecurringTransactionCommandValidatorBase<CreateRecurringTransactionCommand>
+{
+}
+
+public class UpdateRecurringTransactionCommandValidator
+    : RecurringTransactionCommandValidatorBase<UpdateRecurringTransactionCommand>
+{
+    public UpdateRecurringTransactionCommandValidator()
+    {
+        RuleFor(x => x.Id)
+            .GreaterThan(0)
+            .WithMessage("A valid recurring transaction ID must be specified.");
+    }
+}

--- a/src/Core/MyMascada.Domain/Entities/RecurringTransaction.cs
+++ b/src/Core/MyMascada.Domain/Entities/RecurringTransaction.cs
@@ -1,0 +1,268 @@
+using System.ComponentModel.DataAnnotations;
+using MyMascada.Domain.Common;
+using MyMascada.Domain.Enums;
+
+namespace MyMascada.Domain.Entities;
+
+/// <summary>
+/// Represents a user-created recurring transaction (scheduled bill).
+/// Unlike <see cref="RecurringPattern"/> (heuristic detection from bank data),
+/// this entity is explicitly created and managed by the user.
+/// </summary>
+public class RecurringTransaction : BaseEntity
+{
+    /// <summary>
+    /// Maximum number of schedule advancements processed in a single catch-up loop.
+    /// Guards against runaway loops (366 covers a full year of daily occurrences).
+    /// </summary>
+    public const int MaxCatchUpIterations = 366;
+
+    /// <summary>
+    /// User ID who owns this recurring transaction
+    /// </summary>
+    [Required]
+    public Guid UserId { get; set; }
+
+    /// <summary>
+    /// Account the transaction is scheduled against
+    /// </summary>
+    [Required]
+    public int AccountId { get; set; }
+
+    /// <summary>
+    /// Optional category applied to auto-created transactions
+    /// </summary>
+    public int? CategoryId { get; set; }
+
+    /// <summary>
+    /// Description used for reminders and auto-created transactions
+    /// </summary>
+    [Required]
+    [MaxLength(200)]
+    public string Description { get; set; } = string.Empty;
+
+    /// <summary>
+    /// Amount of the scheduled bill (always stored as a positive value).
+    /// Auto-created transactions are negated (expenses are negative).
+    /// </summary>
+    public decimal Amount { get; set; }
+
+    /// <summary>
+    /// How often the transaction repeats
+    /// </summary>
+    [Required]
+    public RecurrenceFrequency Frequency { get; set; }
+
+    /// <summary>
+    /// Interval in days when Frequency is Custom (1..366)
+    /// </summary>
+    public int? CustomIntervalDays { get; set; }
+
+    /// <summary>
+    /// First scheduled date. Also anchors the day-of-month/day-of-year
+    /// for Monthly/Yearly clamping (e.g. due on the 31st → Feb 28 → Mar 31).
+    /// </summary>
+    [Required]
+    public DateTime StartDate { get; set; }
+
+    /// <summary>
+    /// Optional last date on which an occurrence may fall
+    /// </summary>
+    public DateTime? EndDate { get; set; }
+
+    /// <summary>
+    /// Next date this recurring transaction is due
+    /// </summary>
+    [Required]
+    public DateTime NextDueDate { get; set; }
+
+    /// <summary>
+    /// When true the job creates the real transaction automatically;
+    /// when false (default) the user only receives a reminder notification.
+    /// </summary>
+    public bool AutoCreate { get; set; }
+
+    /// <summary>
+    /// Whether the schedule is active (false = paused or finished)
+    /// </summary>
+    public bool IsActive { get; set; } = true;
+
+    /// <summary>
+    /// Optional user notes
+    /// </summary>
+    [MaxLength(500)]
+    public string? Notes { get; set; }
+
+    // Navigation properties
+
+    /// <summary>
+    /// Account the transaction is scheduled against
+    /// </summary>
+    public Account Account { get; set; } = null!;
+
+    /// <summary>
+    /// Category applied to auto-created transactions (if any)
+    /// </summary>
+    public Category? Category { get; set; }
+
+    /// <summary>
+    /// Historical occurrences of this recurring transaction
+    /// </summary>
+    public ICollection<RecurringTransactionOccurrence> Occurrences { get; set; } = new List<RecurringTransactionOccurrence>();
+
+    // Business logic methods
+
+    /// <summary>
+    /// Calculates the occurrence date that follows <paramref name="currentDueDate"/>.
+    /// Monthly/Yearly use calendar math with end-of-month clamping anchored on
+    /// StartDate's day (e.g. anchor 31st: Jan 31 → Feb 28 → Mar 31).
+    /// </summary>
+    public DateTime CalculateNextDueDate(DateTime currentDueDate)
+    {
+        return Frequency switch
+        {
+            RecurrenceFrequency.Weekly => currentDueDate.AddDays(7),
+            RecurrenceFrequency.Fortnightly => currentDueDate.AddDays(14),
+            RecurrenceFrequency.Monthly => AddMonthsClamped(currentDueDate, 1, StartDate.Day),
+            RecurrenceFrequency.Yearly => AddYearsClamped(currentDueDate, 1, StartDate.Day),
+            RecurrenceFrequency.Custom => currentDueDate.AddDays(GetCustomIntervalDays()),
+            _ => throw new InvalidOperationException($"Unsupported recurrence frequency: {Frequency}")
+        };
+    }
+
+    /// <summary>
+    /// Advances NextDueDate until it is strictly after <paramref name="today"/>.
+    /// Deactivates the schedule when the next due date falls past EndDate.
+    /// </summary>
+    public void AdvanceNextDueDate(DateTime today)
+    {
+        var iterations = 0;
+        while (NextDueDate.Date <= today.Date && iterations < MaxCatchUpIterations)
+        {
+            NextDueDate = CalculateNextDueDate(NextDueDate);
+            iterations++;
+        }
+
+        if (EndDate.HasValue && NextDueDate.Date > EndDate.Value.Date)
+        {
+            IsActive = false;
+        }
+
+        UpdatedAt = DateTime.UtcNow;
+    }
+
+    /// <summary>
+    /// Returns the scheduled dates that are due on or before <paramref name="today"/>
+    /// (and on or before EndDate, when set), starting from NextDueDate.
+    /// </summary>
+    public IReadOnlyList<DateTime> GetDueDates(DateTime today)
+    {
+        var dates = new List<DateTime>();
+        var current = NextDueDate.Date;
+        var iterations = 0;
+
+        while (current <= today.Date && iterations < MaxCatchUpIterations)
+        {
+            if (EndDate.HasValue && current > EndDate.Value.Date)
+            {
+                break;
+            }
+
+            dates.Add(current);
+            current = CalculateNextDueDate(current).Date;
+            iterations++;
+        }
+
+        return dates;
+    }
+
+    /// <summary>
+    /// Returns the scheduled dates falling within [fromDate, toDate], capped at EndDate.
+    /// Used to materialize the upcoming schedule for display.
+    /// </summary>
+    public IReadOnlyList<DateTime> GetScheduledDates(DateTime fromDate, DateTime toDate)
+    {
+        var dates = new List<DateTime>();
+        var current = NextDueDate.Date;
+        var iterations = 0;
+
+        while (current <= toDate.Date && iterations < MaxCatchUpIterations)
+        {
+            if (EndDate.HasValue && current > EndDate.Value.Date)
+            {
+                break;
+            }
+
+            if (current >= fromDate.Date)
+            {
+                dates.Add(current);
+            }
+
+            current = CalculateNextDueDate(current).Date;
+            iterations++;
+        }
+
+        return dates;
+    }
+
+    /// <summary>
+    /// Pauses the schedule (user action)
+    /// </summary>
+    public void Pause()
+    {
+        IsActive = false;
+        UpdatedAt = DateTime.UtcNow;
+    }
+
+    /// <summary>
+    /// Resumes the schedule, fast-forwarding NextDueDate past today so
+    /// occurrences missed while paused are not retroactively fired.
+    /// </summary>
+    public void Resume(DateTime today)
+    {
+        IsActive = true;
+
+        if (NextDueDate.Date <= today.Date)
+        {
+            AdvanceNextDueDate(today);
+            // AdvanceNextDueDate may deactivate when past EndDate — keep that result.
+        }
+        else
+        {
+            UpdatedAt = DateTime.UtcNow;
+        }
+    }
+
+    private int GetCustomIntervalDays()
+    {
+        if (!CustomIntervalDays.HasValue || CustomIntervalDays.Value < 1)
+        {
+            throw new InvalidOperationException(
+                "CustomIntervalDays must be set to a positive value when Frequency is Custom.");
+        }
+
+        return CustomIntervalDays.Value;
+    }
+
+    /// <summary>
+    /// Adds calendar months preserving the anchor day-of-month, clamped to the
+    /// target month's length (anchor 31 → Feb 28/29, Apr 30, May 31, ...).
+    /// </summary>
+    internal static DateTime AddMonthsClamped(DateTime date, int months, int anchorDay)
+    {
+        var target = date.AddMonths(months);
+        var day = Math.Min(anchorDay, DateTime.DaysInMonth(target.Year, target.Month));
+        return new DateTime(target.Year, target.Month, day, 0, 0, 0, date.Kind);
+    }
+
+    /// <summary>
+    /// Adds calendar years preserving the anchor day-of-month, clamped for
+    /// non-leap years (Feb 29 → Feb 28, back to Feb 29 on the next leap year).
+    /// </summary>
+    internal static DateTime AddYearsClamped(DateTime date, int years, int anchorDay)
+    {
+        var targetYear = date.Year + years;
+        var day = Math.Min(anchorDay, DateTime.DaysInMonth(targetYear, date.Month));
+        return new DateTime(targetYear, date.Month, day, 0, 0, 0, date.Kind);
+    }
+}

--- a/src/Core/MyMascada.Domain/Entities/RecurringTransaction.cs
+++ b/src/Core/MyMascada.Domain/Entities/RecurringTransaction.cs
@@ -12,8 +12,9 @@ namespace MyMascada.Domain.Entities;
 public class RecurringTransaction : BaseEntity
 {
     /// <summary>
-    /// Maximum number of schedule advancements processed in a single catch-up loop.
-    /// Guards against runaway loops (366 covers a full year of daily occurrences).
+    /// Maximum number of dates materialized by GetDueDates/GetScheduledDates.
+    /// Caps how many occurrences can be fired/displayed in one pass
+    /// (366 covers a full year of daily occurrences).
     /// </summary>
     public const int MaxCatchUpIterations = 366;
 
@@ -131,16 +132,28 @@ public class RecurringTransaction : BaseEntity
     }
 
     /// <summary>
-    /// Advances NextDueDate until it is strictly after <paramref name="today"/>.
-    /// Deactivates the schedule when the next due date falls past EndDate.
+    /// Advances NextDueDate until it is strictly after <paramref name="today"/>,
+    /// no matter how far behind the schedule is (arbitrarily old StartDate,
+    /// long pauses, etc.). Deactivates the schedule when the next due date
+    /// falls past EndDate.
     /// </summary>
     public void AdvanceNextDueDate(DateTime today)
     {
-        var iterations = 0;
-        while (NextDueDate.Date <= today.Date && iterations < MaxCatchUpIterations)
+        if (NextDueDate.Date <= today.Date)
         {
-            NextDueDate = CalculateNextDueDate(NextDueDate);
-            iterations++;
+            NextDueDate = Frequency switch
+            {
+                // Fixed-interval frequencies snap forward arithmetically so a
+                // schedule years behind cannot land short of today.
+                RecurrenceFrequency.Weekly => FastForwardByDays(NextDueDate, today, 7),
+                RecurrenceFrequency.Fortnightly => FastForwardByDays(NextDueDate, today, 14),
+                RecurrenceFrequency.Custom => FastForwardByDays(NextDueDate, today, GetCustomIntervalDays()),
+
+                // Calendar frequencies advance step-by-step to preserve the
+                // anchor-day clamping. Each step moves at least 28 days, so the
+                // loop terminates without an iteration cap.
+                _ => FastForwardCalendar(NextDueDate, today)
+            };
         }
 
         if (EndDate.HasValue && NextDueDate.Date > EndDate.Value.Date)
@@ -149,6 +162,32 @@ public class RecurringTransaction : BaseEntity
         }
 
         UpdatedAt = DateTime.UtcNow;
+    }
+
+    /// <summary>
+    /// Snaps a fixed-interval schedule to the first occurrence strictly after
+    /// <paramref name="today"/>, preserving the original anchor (date + N * interval).
+    /// </summary>
+    private static DateTime FastForwardByDays(DateTime from, DateTime today, int intervalDays)
+    {
+        var daysBehind = (today.Date - from.Date).Days; // >= 0 — caller checked
+        var periods = (daysBehind / intervalDays) + 1;
+        return from.AddDays((double)periods * intervalDays);
+    }
+
+    /// <summary>
+    /// Advances a Monthly/Yearly schedule one calendar step at a time until it
+    /// is strictly after <paramref name="today"/>.
+    /// </summary>
+    private DateTime FastForwardCalendar(DateTime from, DateTime today)
+    {
+        var current = from;
+        while (current.Date <= today.Date)
+        {
+            current = CalculateNextDueDate(current);
+        }
+
+        return current;
     }
 
     /// <summary>

--- a/src/Core/MyMascada.Domain/Entities/RecurringTransaction.cs
+++ b/src/Core/MyMascada.Domain/Entities/RecurringTransaction.cs
@@ -141,19 +141,7 @@ public class RecurringTransaction : BaseEntity
     {
         if (NextDueDate.Date <= today.Date)
         {
-            NextDueDate = Frequency switch
-            {
-                // Fixed-interval frequencies snap forward arithmetically so a
-                // schedule years behind cannot land short of today.
-                RecurrenceFrequency.Weekly => FastForwardByDays(NextDueDate, today, 7),
-                RecurrenceFrequency.Fortnightly => FastForwardByDays(NextDueDate, today, 14),
-                RecurrenceFrequency.Custom => FastForwardByDays(NextDueDate, today, GetCustomIntervalDays()),
-
-                // Calendar frequencies advance step-by-step to preserve the
-                // anchor-day clamping. Each step moves at least 28 days, so the
-                // loop terminates without an iteration cap.
-                _ => FastForwardCalendar(NextDueDate, today)
-            };
+            NextDueDate = FastForward(NextDueDate, today);
         }
 
         if (EndDate.HasValue && NextDueDate.Date > EndDate.Value.Date)
@@ -162,6 +150,46 @@ public class RecurringTransaction : BaseEntity
         }
 
         UpdatedAt = DateTime.UtcNow;
+    }
+
+    /// <summary>
+    /// Advances NextDueDate to the occurrence that follows
+    /// <paramref name="lastFiredDate"/> (the last due date a processing run
+    /// materialized). Unlike <see cref="AdvanceNextDueDate"/> the result may
+    /// still be in the past: when a run hits <see cref="MaxCatchUpIterations"/>
+    /// the remaining due dates stay due, so the next run continues catching up
+    /// instead of silently skipping them. Deactivates the schedule when the
+    /// next due date falls past EndDate.
+    /// </summary>
+    public void AdvanceNextDueDateAfter(DateTime lastFiredDate)
+    {
+        NextDueDate = CalculateNextDueDate(lastFiredDate.Date);
+
+        if (EndDate.HasValue && NextDueDate.Date > EndDate.Value.Date)
+        {
+            IsActive = false;
+        }
+
+        UpdatedAt = DateTime.UtcNow;
+    }
+
+    /// <summary>
+    /// Returns the first occurrence strictly after <paramref name="today"/>,
+    /// starting from <paramref name="from"/>. Fixed-interval frequencies snap
+    /// forward arithmetically so a schedule years behind cannot land short of
+    /// today; calendar frequencies advance step-by-step to preserve the
+    /// anchor-day clamping (each step moves at least 28 days, so the loop
+    /// terminates without an iteration cap).
+    /// </summary>
+    private DateTime FastForward(DateTime from, DateTime today)
+    {
+        return Frequency switch
+        {
+            RecurrenceFrequency.Weekly => FastForwardByDays(from, today, 7),
+            RecurrenceFrequency.Fortnightly => FastForwardByDays(from, today, 14),
+            RecurrenceFrequency.Custom => FastForwardByDays(from, today, GetCustomIntervalDays()),
+            _ => FastForwardCalendar(from, today)
+        };
     }
 
     /// <summary>
@@ -224,6 +252,15 @@ public class RecurringTransaction : BaseEntity
         var dates = new List<DateTime>();
         var current = NextDueDate.Date;
         var iterations = 0;
+
+        // A stale NextDueDate (long pause, job downtime) could otherwise burn
+        // the whole iteration budget before reaching the window and return an
+        // empty list. Jump straight to the first occurrence on/after fromDate,
+        // preserving the schedule anchor.
+        if (current < fromDate.Date)
+        {
+            current = FastForward(current, fromDate.Date.AddDays(-1)).Date;
+        }
 
         while (current <= toDate.Date && iterations < MaxCatchUpIterations)
         {

--- a/src/Core/MyMascada.Domain/Entities/RecurringTransactionOccurrence.cs
+++ b/src/Core/MyMascada.Domain/Entities/RecurringTransactionOccurrence.cs
@@ -1,0 +1,48 @@
+using System.ComponentModel.DataAnnotations;
+using MyMascada.Domain.Common;
+using MyMascada.Domain.Enums;
+
+namespace MyMascada.Domain.Entities;
+
+/// <summary>
+/// Records a single processed occurrence of a user-created recurring transaction.
+/// One row exists per (recurring transaction, scheduled date) — this uniqueness
+/// is what makes the daily job idempotent.
+/// </summary>
+public class RecurringTransactionOccurrence : BaseEntity
+{
+    /// <summary>
+    /// Foreign key to the parent recurring transaction
+    /// </summary>
+    [Required]
+    public int RecurringTransactionId { get; set; }
+
+    /// <summary>
+    /// The date this occurrence was scheduled for
+    /// </summary>
+    [Required]
+    public DateTime ScheduledDate { get; set; }
+
+    /// <summary>
+    /// How the occurrence was handled (Notified, Created, Skipped)
+    /// </summary>
+    [Required]
+    public RecurringTransactionOccurrenceStatus Status { get; set; }
+
+    /// <summary>
+    /// The auto-created transaction (only set when Status is Created)
+    /// </summary>
+    public int? TransactionId { get; set; }
+
+    // Navigation properties
+
+    /// <summary>
+    /// Parent recurring transaction
+    /// </summary>
+    public RecurringTransaction RecurringTransaction { get; set; } = null!;
+
+    /// <summary>
+    /// Auto-created transaction (if any)
+    /// </summary>
+    public Transaction? Transaction { get; set; }
+}

--- a/src/Core/MyMascada.Domain/Enums/RecurringTransactionEnums.cs
+++ b/src/Core/MyMascada.Domain/Enums/RecurringTransactionEnums.cs
@@ -49,5 +49,14 @@ public enum RecurringTransactionOccurrenceStatus
     /// <summary>
     /// The occurrence was skipped (e.g., schedule was inactive or past its end date)
     /// </summary>
-    Skipped = 3
+    Skipped = 3,
+
+    /// <summary>
+    /// The occurrence row has been claimed by the daily job but not yet completed.
+    /// The job inserts the claim BEFORE creating the transaction / sending the
+    /// reminder (the unique (RecurringTransactionId, ScheduledDate) index rejects
+    /// concurrent claimers), so a crash mid-occurrence leaves a Pending row that
+    /// the next run completes instead of firing the bill twice.
+    /// </summary>
+    Pending = 4
 }

--- a/src/Core/MyMascada.Domain/Enums/RecurringTransactionEnums.cs
+++ b/src/Core/MyMascada.Domain/Enums/RecurringTransactionEnums.cs
@@ -1,0 +1,53 @@
+namespace MyMascada.Domain.Enums;
+
+/// <summary>
+/// Frequency at which a user-created recurring transaction repeats
+/// </summary>
+public enum RecurrenceFrequency
+{
+    /// <summary>
+    /// Repeats every 7 days
+    /// </summary>
+    Weekly = 1,
+
+    /// <summary>
+    /// Repeats every 14 days
+    /// </summary>
+    Fortnightly = 2,
+
+    /// <summary>
+    /// Repeats every calendar month (with end-of-month clamping)
+    /// </summary>
+    Monthly = 3,
+
+    /// <summary>
+    /// Repeats every calendar year (with leap-day clamping)
+    /// </summary>
+    Yearly = 4,
+
+    /// <summary>
+    /// Repeats every CustomIntervalDays days
+    /// </summary>
+    Custom = 5
+}
+
+/// <summary>
+/// Outcome of a single scheduled occurrence of a recurring transaction
+/// </summary>
+public enum RecurringTransactionOccurrenceStatus
+{
+    /// <summary>
+    /// A reminder notification was sent to the user (remind-only mode)
+    /// </summary>
+    Notified = 1,
+
+    /// <summary>
+    /// A real transaction was automatically created (auto-create mode)
+    /// </summary>
+    Created = 2,
+
+    /// <summary>
+    /// The occurrence was skipped (e.g., schedule was inactive or past its end date)
+    /// </summary>
+    Skipped = 3
+}

--- a/src/Infrastructure/MyMascada.Infrastructure/BackgroundJobs/RecurringTransactionJobService.cs
+++ b/src/Infrastructure/MyMascada.Infrastructure/BackgroundJobs/RecurringTransactionJobService.cs
@@ -1,0 +1,78 @@
+using Hangfire;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
+using MyMascada.Application.BackgroundJobs;
+using MyMascada.Application.Features.RecurringTransactions.Services;
+using MyMascada.Domain.Common;
+
+namespace MyMascada.Infrastructure.BackgroundJobs;
+
+/// <summary>
+/// Hangfire-based implementation of the user-created recurring transaction job.
+/// Runs daily to auto-create due transactions or send reminder notifications.
+/// Idempotent: occurrence uniqueness per (schedule, scheduled date) makes it
+/// safe to run multiple times in a day.
+/// </summary>
+public class RecurringTransactionJobService : IRecurringTransactionJobService
+{
+    private readonly IServiceScopeFactory _serviceScopeFactory;
+    private readonly ILogger<RecurringTransactionJobService> _logger;
+
+    public RecurringTransactionJobService(
+        IServiceScopeFactory serviceScopeFactory,
+        ILogger<RecurringTransactionJobService> logger)
+    {
+        _serviceScopeFactory = serviceScopeFactory;
+        _logger = logger;
+    }
+
+    /// <summary>
+    /// Processes all due recurring transactions across all users.
+    /// Scheduled to run daily at 2:30 AM.
+    /// </summary>
+    [AutomaticRetry(Attempts = 3, DelaysInSeconds = new[] { 60, 300, 900 })]
+    public async Task ProcessAllDueAsync(object? performContext = null)
+    {
+        var startTime = DateTime.UtcNow;
+
+        _logger.LogInformation("🔄 Starting daily recurring transaction job at {StartTime}", startTime);
+
+        try
+        {
+            using var scope = _serviceScopeFactory.CreateScope();
+            var processingService = scope.ServiceProvider
+                .GetRequiredService<IRecurringTransactionProcessingService>();
+
+            var result = await processingService.ProcessDueAsync(DateTimeProvider.UtcNow.Date);
+
+            var totalDuration = DateTime.UtcNow - startTime;
+
+            _logger.LogInformation("✅ Daily recurring transaction job completed at {EndTime}. " +
+                "📊 Stats: {SchedulesProcessed} schedules processed, {TransactionsCreated} transactions created, " +
+                "{RemindersSent} reminders sent, {OccurrencesSkipped} occurrences skipped (already processed), " +
+                "{SchedulesDeactivated} schedules deactivated, {SchedulesFailed} schedules failed. " +
+                "⏱️ Duration: {Duration}s",
+                DateTime.UtcNow,
+                result.SchedulesProcessed,
+                result.TransactionsCreated,
+                result.RemindersSent,
+                result.OccurrencesSkipped,
+                result.SchedulesDeactivated,
+                result.SchedulesFailed,
+                totalDuration.TotalSeconds);
+
+            if (result.SchedulesFailed > 0)
+            {
+                _logger.LogWarning("⚠️ {FailedCount} recurring transaction schedules failed to process",
+                    result.SchedulesFailed);
+            }
+        }
+        catch (Exception ex)
+        {
+            var totalDuration = DateTime.UtcNow - startTime;
+            _logger.LogError(ex, "💥 Critical error during daily recurring transaction job after {Duration}s",
+                totalDuration.TotalSeconds);
+            throw; // Re-throw to trigger Hangfire retry mechanism
+        }
+    }
+}

--- a/src/Infrastructure/MyMascada.Infrastructure/BackgroundJobs/RecurringTransactionJobService.cs
+++ b/src/Infrastructure/MyMascada.Infrastructure/BackgroundJobs/RecurringTransactionJobService.cs
@@ -29,8 +29,12 @@ public class RecurringTransactionJobService : IRecurringTransactionJobService
     /// <summary>
     /// Processes all due recurring transactions across all users.
     /// Scheduled to run daily at 2:30 AM.
+    /// Serialized via DisableConcurrentExecution so overlapping runs (retry +
+    /// manual trigger) cannot race each other; combined with the Pending-claim
+    /// occurrence rows this guarantees each scheduled date fires at most once.
     /// </summary>
     [AutomaticRetry(Attempts = 3, DelaysInSeconds = new[] { 60, 300, 900 })]
+    [DisableConcurrentExecution(timeoutInSeconds: 30 * 60)]
     public async Task ProcessAllDueAsync(object? performContext = null)
     {
         var startTime = DateTime.UtcNow;

--- a/src/Infrastructure/MyMascada.Infrastructure/Data/ApplicationDbContext.cs
+++ b/src/Infrastructure/MyMascada.Infrastructure/Data/ApplicationDbContext.cs
@@ -39,6 +39,8 @@ public class ApplicationDbContext : DbContext
     public DbSet<BudgetCategory> BudgetCategories => Set<BudgetCategory>();
     public DbSet<RecurringPattern> RecurringPatterns => Set<RecurringPattern>();
     public DbSet<RecurringOccurrence> RecurringOccurrences => Set<RecurringOccurrence>();
+    public DbSet<RecurringTransaction> RecurringTransactions => Set<RecurringTransaction>();
+    public DbSet<RecurringTransactionOccurrence> RecurringTransactionOccurrences => Set<RecurringTransactionOccurrence>();
     public DbSet<WaitlistEntry> WaitlistEntries => Set<WaitlistEntry>();
     public DbSet<InvitationCode> InvitationCodes => Set<InvitationCode>();
     public DbSet<AccountShare> AccountShares => Set<AccountShare>();
@@ -689,6 +691,74 @@ public class ApplicationDbContext : DbContext
             entity.HasIndex(e => new { e.PatternId, e.Outcome });
 
             // Foreign key to Transaction
+            entity.HasOne(e => e.Transaction)
+                .WithMany()
+                .HasForeignKey(e => e.TransactionId)
+                .OnDelete(DeleteBehavior.SetNull); // Allow transaction deletion
+
+            entity.HasQueryFilter(e => !e.IsDeleted);
+        });
+
+        // RecurringTransaction configuration (user-created scheduled bills)
+        modelBuilder.Entity<RecurringTransaction>(entity =>
+        {
+            entity.HasKey(e => e.Id);
+            entity.Property(e => e.UserId).IsRequired();
+            entity.Property(e => e.AccountId).IsRequired();
+            entity.Property(e => e.Description).IsRequired().HasMaxLength(200);
+            entity.Property(e => e.Amount).HasPrecision(18, 2);
+            entity.Property(e => e.Frequency).IsRequired();
+            entity.Property(e => e.StartDate).IsRequired();
+            entity.Property(e => e.NextDueDate).IsRequired();
+            entity.Property(e => e.AutoCreate).HasDefaultValue(false);
+            entity.Property(e => e.IsActive).HasDefaultValue(true);
+            entity.Property(e => e.Notes).HasMaxLength(500);
+
+            // Indexes for efficient querying
+            entity.HasIndex(e => e.UserId);
+            entity.HasIndex(e => new { e.UserId, e.IsActive });
+            entity.HasIndex(e => new { e.IsActive, e.NextDueDate }); // daily job scan
+
+            // Foreign key to User
+            entity.HasOne<User>()
+                .WithMany()
+                .HasForeignKey(e => e.UserId)
+                .OnDelete(DeleteBehavior.Cascade);
+
+            // Foreign key to Account
+            entity.HasOne(e => e.Account)
+                .WithMany()
+                .HasForeignKey(e => e.AccountId)
+                .OnDelete(DeleteBehavior.Cascade);
+
+            // Foreign key to Category (optional)
+            entity.HasOne(e => e.Category)
+                .WithMany()
+                .HasForeignKey(e => e.CategoryId)
+                .OnDelete(DeleteBehavior.SetNull); // Allow category deletion
+
+            // One-to-many relationship with occurrences
+            entity.HasMany(e => e.Occurrences)
+                .WithOne(o => o.RecurringTransaction)
+                .HasForeignKey(o => o.RecurringTransactionId)
+                .OnDelete(DeleteBehavior.Cascade);
+
+            entity.HasQueryFilter(e => !e.IsDeleted);
+        });
+
+        // RecurringTransactionOccurrence configuration
+        modelBuilder.Entity<RecurringTransactionOccurrence>(entity =>
+        {
+            entity.HasKey(e => e.Id);
+            entity.Property(e => e.RecurringTransactionId).IsRequired();
+            entity.Property(e => e.ScheduledDate).IsRequired();
+            entity.Property(e => e.Status).IsRequired();
+
+            // Idempotency: one occurrence per recurring transaction per scheduled date
+            entity.HasIndex(e => new { e.RecurringTransactionId, e.ScheduledDate }).IsUnique();
+            entity.HasIndex(e => e.TransactionId);
+
+            // Foreign key to Transaction (optional, only for auto-created occurrences)
             entity.HasOne(e => e.Transaction)
                 .WithMany()
                 .HasForeignKey(e => e.TransactionId)

--- a/src/Infrastructure/MyMascada.Infrastructure/Repositories/RecurringTransactionRepository.cs
+++ b/src/Infrastructure/MyMascada.Infrastructure/Repositories/RecurringTransactionRepository.cs
@@ -159,6 +159,21 @@ public class RecurringTransactionRepository : IRecurringTransactionRepository
     }
 
     /// <summary>
+    /// Gets the occurrence for the given schedule and date, or null when none exists
+    /// </summary>
+    public async Task<RecurringTransactionOccurrence?> GetOccurrenceAsync(
+        int recurringTransactionId,
+        DateTime scheduledDate,
+        CancellationToken cancellationToken = default)
+    {
+        var date = scheduledDate.Date;
+        return await _context.RecurringTransactionOccurrences
+            .FirstOrDefaultAsync(o => o.RecurringTransactionId == recurringTransactionId
+                                      && o.ScheduledDate == date
+                                      && !o.IsDeleted, cancellationToken);
+    }
+
+    /// <summary>
     /// Creates a new occurrence record
     /// </summary>
     public async Task<RecurringTransactionOccurrence> CreateOccurrenceAsync(
@@ -169,6 +184,42 @@ public class RecurringTransactionRepository : IRecurringTransactionRepository
         var entry = await _context.RecurringTransactionOccurrences.AddAsync(occurrence, cancellationToken);
         await _context.SaveChangesAsync(cancellationToken);
         return entry.Entity;
+    }
+
+    /// <summary>
+    /// Attempts to insert an occurrence row, returning null when the unique
+    /// (RecurringTransactionId, ScheduledDate) index rejects it
+    /// </summary>
+    public async Task<RecurringTransactionOccurrence?> TryCreateOccurrenceAsync(
+        RecurringTransactionOccurrence occurrence,
+        CancellationToken cancellationToken = default)
+    {
+        try
+        {
+            return await CreateOccurrenceAsync(occurrence, cancellationToken);
+        }
+        catch (DbUpdateException)
+        {
+            // Single-row insert into a table whose only constraint besides the PK is
+            // the unique (RecurringTransactionId, ScheduledDate) index — another run
+            // claimed this scheduled date first. Detach the failed entity so the
+            // change tracker stays usable for subsequent schedules.
+            _context.Entry(occurrence).State = EntityState.Detached;
+            return null;
+        }
+    }
+
+    /// <summary>
+    /// Updates an existing occurrence record
+    /// </summary>
+    public async Task<RecurringTransactionOccurrence> UpdateOccurrenceAsync(
+        RecurringTransactionOccurrence occurrence,
+        CancellationToken cancellationToken = default)
+    {
+        occurrence.UpdatedAt = DateTime.UtcNow;
+        _context.RecurringTransactionOccurrences.Update(occurrence);
+        await _context.SaveChangesAsync(cancellationToken);
+        return occurrence;
     }
 
     /// <summary>
@@ -187,5 +238,23 @@ public class RecurringTransactionRepository : IRecurringTransactionRepository
             .OrderByDescending(o => o.ScheduledDate)
             .Take(count)
             .ToListAsync(cancellationToken);
+    }
+
+    /// <summary>
+    /// Checks whether the account still exists and is not soft-deleted
+    /// (the Accounts query filter hides soft-deleted rows)
+    /// </summary>
+    public async Task<bool> AccountExistsAsync(int accountId, CancellationToken cancellationToken = default)
+    {
+        return await _context.Accounts.AnyAsync(a => a.Id == accountId, cancellationToken);
+    }
+
+    /// <summary>
+    /// Detaches all tracked entities so a failed save for one schedule cannot
+    /// poison the shared change tracker for subsequent schedules
+    /// </summary>
+    public void ResetChangeTracking()
+    {
+        _context.ChangeTracker.Clear();
     }
 }

--- a/src/Infrastructure/MyMascada.Infrastructure/Repositories/RecurringTransactionRepository.cs
+++ b/src/Infrastructure/MyMascada.Infrastructure/Repositories/RecurringTransactionRepository.cs
@@ -1,0 +1,191 @@
+using Microsoft.EntityFrameworkCore;
+using MyMascada.Application.Common.Interfaces;
+using MyMascada.Domain.Entities;
+using MyMascada.Infrastructure.Data;
+
+namespace MyMascada.Infrastructure.Repositories;
+
+/// <summary>
+/// Repository for user-created recurring transactions and their occurrences
+/// </summary>
+public class RecurringTransactionRepository : IRecurringTransactionRepository
+{
+    private readonly ApplicationDbContext _context;
+
+    public RecurringTransactionRepository(ApplicationDbContext context)
+    {
+        _context = context;
+    }
+
+    /// <summary>
+    /// Gets a recurring transaction by ID for a specific user
+    /// </summary>
+    public async Task<RecurringTransaction?> GetByIdAsync(int id, Guid userId, CancellationToken cancellationToken = default)
+    {
+        return await _context.RecurringTransactions
+            .Include(r => r.Account)
+            .Include(r => r.Category)
+            .FirstOrDefaultAsync(r => r.Id == id && r.UserId == userId && !r.IsDeleted, cancellationToken);
+    }
+
+    /// <summary>
+    /// Gets all recurring transactions for a user
+    /// </summary>
+    public async Task<IEnumerable<RecurringTransaction>> GetByUserIdAsync(
+        Guid userId,
+        bool includeInactive = false,
+        CancellationToken cancellationToken = default)
+    {
+        var query = _context.RecurringTransactions
+            .Include(r => r.Account)
+            .Include(r => r.Category)
+            .Where(r => r.UserId == userId && !r.IsDeleted);
+
+        if (!includeInactive)
+        {
+            query = query.Where(r => r.IsActive);
+        }
+
+        return await query
+            .OrderByDescending(r => r.IsActive)
+            .ThenBy(r => r.NextDueDate)
+            .ThenBy(r => r.Description)
+            .ToListAsync(cancellationToken);
+    }
+
+    /// <summary>
+    /// Gets active recurring transactions across all users that are due on or before the given date
+    /// </summary>
+    public async Task<IEnumerable<RecurringTransaction>> GetDueAsync(
+        DateTime asOfDate,
+        CancellationToken cancellationToken = default)
+    {
+        var endOfDay = asOfDate.Date.AddDays(1);
+
+        return await _context.RecurringTransactions
+            .Where(r => r.IsActive
+                        && r.NextDueDate < endOfDay
+                        && !r.IsDeleted)
+            .OrderBy(r => r.UserId)
+            .ThenBy(r => r.NextDueDate)
+            .ToListAsync(cancellationToken);
+    }
+
+    /// <summary>
+    /// Gets active recurring transactions for a user
+    /// </summary>
+    public async Task<IEnumerable<RecurringTransaction>> GetActiveByUserIdAsync(
+        Guid userId,
+        CancellationToken cancellationToken = default)
+    {
+        return await _context.RecurringTransactions
+            .Include(r => r.Account)
+            .Include(r => r.Category)
+            .Where(r => r.UserId == userId && r.IsActive && !r.IsDeleted)
+            .OrderBy(r => r.NextDueDate)
+            .ToListAsync(cancellationToken);
+    }
+
+    /// <summary>
+    /// Creates a new recurring transaction
+    /// </summary>
+    public async Task<RecurringTransaction> CreateAsync(
+        RecurringTransaction recurringTransaction,
+        CancellationToken cancellationToken = default)
+    {
+        var entry = await _context.RecurringTransactions.AddAsync(recurringTransaction, cancellationToken);
+        await _context.SaveChangesAsync(cancellationToken);
+
+        // Load navigation properties for mapping
+        await _context.Entry(entry.Entity)
+            .Reference(r => r.Account)
+            .LoadAsync(cancellationToken);
+
+        if (recurringTransaction.CategoryId.HasValue)
+        {
+            await _context.Entry(entry.Entity)
+                .Reference(r => r.Category)
+                .LoadAsync(cancellationToken);
+        }
+
+        return entry.Entity;
+    }
+
+    /// <summary>
+    /// Updates an existing recurring transaction
+    /// </summary>
+    public async Task<RecurringTransaction> UpdateAsync(
+        RecurringTransaction recurringTransaction,
+        CancellationToken cancellationToken = default)
+    {
+        recurringTransaction.UpdatedAt = DateTime.UtcNow;
+        _context.RecurringTransactions.Update(recurringTransaction);
+        await _context.SaveChangesAsync(cancellationToken);
+        return recurringTransaction;
+    }
+
+    /// <summary>
+    /// Soft deletes a recurring transaction for a user
+    /// </summary>
+    public async Task<bool> DeleteAsync(int id, Guid userId, CancellationToken cancellationToken = default)
+    {
+        var recurringTransaction = await _context.RecurringTransactions
+            .FirstOrDefaultAsync(r => r.Id == id && r.UserId == userId && !r.IsDeleted, cancellationToken);
+
+        if (recurringTransaction == null)
+        {
+            return false;
+        }
+
+        recurringTransaction.IsDeleted = true;
+        recurringTransaction.DeletedAt = DateTime.UtcNow;
+        await _context.SaveChangesAsync(cancellationToken);
+        return true;
+    }
+
+    /// <summary>
+    /// Checks whether an occurrence already exists for the given schedule and date
+    /// </summary>
+    public async Task<bool> HasOccurrenceAsync(
+        int recurringTransactionId,
+        DateTime scheduledDate,
+        CancellationToken cancellationToken = default)
+    {
+        var date = scheduledDate.Date;
+        return await _context.RecurringTransactionOccurrences
+            .AnyAsync(o => o.RecurringTransactionId == recurringTransactionId
+                           && o.ScheduledDate == date
+                           && !o.IsDeleted, cancellationToken);
+    }
+
+    /// <summary>
+    /// Creates a new occurrence record
+    /// </summary>
+    public async Task<RecurringTransactionOccurrence> CreateOccurrenceAsync(
+        RecurringTransactionOccurrence occurrence,
+        CancellationToken cancellationToken = default)
+    {
+        occurrence.ScheduledDate = occurrence.ScheduledDate.Date;
+        var entry = await _context.RecurringTransactionOccurrences.AddAsync(occurrence, cancellationToken);
+        await _context.SaveChangesAsync(cancellationToken);
+        return entry.Entity;
+    }
+
+    /// <summary>
+    /// Gets the most recent occurrences for a recurring transaction
+    /// </summary>
+    public async Task<IEnumerable<RecurringTransactionOccurrence>> GetRecentOccurrencesAsync(
+        int recurringTransactionId,
+        Guid userId,
+        int count = 10,
+        CancellationToken cancellationToken = default)
+    {
+        return await _context.RecurringTransactionOccurrences
+            .Where(o => o.RecurringTransactionId == recurringTransactionId
+                        && o.RecurringTransaction.UserId == userId
+                        && !o.IsDeleted)
+            .OrderByDescending(o => o.ScheduledDate)
+            .Take(count)
+            .ToListAsync(cancellationToken);
+    }
+}

--- a/src/WebAPI/MyMascada.WebAPI/Controllers/RecurringTransactionsController.cs
+++ b/src/WebAPI/MyMascada.WebAPI/Controllers/RecurringTransactionsController.cs
@@ -12,6 +12,12 @@ namespace MyMascada.WebAPI.Controllers;
 /// <summary>
 /// Manages user-created recurring transactions (scheduled bills).
 /// Distinct from the heuristic recurring pattern detection.
+///
+/// API conventions:
+/// - All dates are date-only: send "yyyy-MM-dd" strings (timezone-offset ISO
+///   strings can shift across midnight and change the monthly anchor day).
+/// - Amounts are positive and expense-only; auto-created transactions are
+///   recorded with a negative amount. Recurring income is a future direction flag.
 /// </summary>
 [ApiController]
 [ApiVersion("1.0")]
@@ -146,6 +152,10 @@ public class RecurringTransactionsController : ControllerBase
             var result = await _mediator.Send(command);
             return Ok(result);
         }
+        catch (KeyNotFoundException ex)
+        {
+            return NotFound(new { message = ex.Message });
+        }
         catch (ArgumentException ex)
         {
             return BadRequest(new { message = ex.Message });
@@ -206,7 +216,7 @@ public class RecurringTransactionsController : ControllerBase
             var result = await _mediator.Send(command);
             return Ok(result);
         }
-        catch (ArgumentException ex)
+        catch (KeyNotFoundException ex)
         {
             return NotFound(new { message = ex.Message });
         }

--- a/src/WebAPI/MyMascada.WebAPI/Controllers/RecurringTransactionsController.cs
+++ b/src/WebAPI/MyMascada.WebAPI/Controllers/RecurringTransactionsController.cs
@@ -1,0 +1,214 @@
+using Asp.Versioning;
+using MediatR;
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Mvc;
+using MyMascada.Application.Common.Interfaces;
+using MyMascada.Application.Features.RecurringTransactions.Commands;
+using MyMascada.Application.Features.RecurringTransactions.DTOs;
+using MyMascada.Application.Features.RecurringTransactions.Queries;
+
+namespace MyMascada.WebAPI.Controllers;
+
+/// <summary>
+/// Manages user-created recurring transactions (scheduled bills).
+/// Distinct from the heuristic recurring pattern detection.
+/// </summary>
+[ApiController]
+[ApiVersion("1.0")]
+[Route("api/v{version:apiVersion}/recurring-transactions")]
+[Route("api/latest/recurring-transactions")]
+[Authorize]
+public class RecurringTransactionsController : ControllerBase
+{
+    private readonly IMediator _mediator;
+    private readonly ICurrentUserService _currentUserService;
+
+    public RecurringTransactionsController(IMediator mediator, ICurrentUserService currentUserService)
+    {
+        _mediator = mediator;
+        _currentUserService = currentUserService;
+    }
+
+    /// <summary>
+    /// Get all recurring transactions for the current user
+    /// </summary>
+    [HttpGet]
+    public async Task<ActionResult<List<RecurringTransactionDto>>> GetRecurringTransactions(
+        [FromQuery] bool includeInactive = false)
+    {
+        var query = new GetRecurringTransactionsQuery
+        {
+            UserId = _currentUserService.GetUserId(),
+            IncludeInactive = includeInactive
+        };
+
+        var result = await _mediator.Send(query);
+        return Ok(result);
+    }
+
+    /// <summary>
+    /// Get the materialized upcoming schedule for the current user's active recurring transactions
+    /// </summary>
+    [HttpGet("upcoming")]
+    public async Task<ActionResult<List<UpcomingRecurringTransactionDto>>> GetUpcoming(
+        [FromQuery] int daysAhead = 30)
+    {
+        var query = new GetUpcomingRecurringTransactionsQuery
+        {
+            UserId = _currentUserService.GetUserId(),
+            DaysAhead = daysAhead
+        };
+
+        var result = await _mediator.Send(query);
+        return Ok(result);
+    }
+
+    /// <summary>
+    /// Get a single recurring transaction with its recent occurrences
+    /// </summary>
+    [HttpGet("{id:int}")]
+    public async Task<ActionResult<RecurringTransactionDetailDto>> GetRecurringTransaction(int id)
+    {
+        var query = new GetRecurringTransactionQuery
+        {
+            Id = id,
+            UserId = _currentUserService.GetUserId()
+        };
+
+        var result = await _mediator.Send(query);
+        if (result == null)
+        {
+            return NotFound(new { message = $"Recurring transaction with ID {id} not found." });
+        }
+
+        return Ok(result);
+    }
+
+    /// <summary>
+    /// Create a new recurring transaction
+    /// </summary>
+    [HttpPost]
+    public async Task<ActionResult<RecurringTransactionDto>> CreateRecurringTransaction(
+        [FromBody] CreateRecurringTransactionRequest request)
+    {
+        var command = new CreateRecurringTransactionCommand
+        {
+            UserId = _currentUserService.GetUserId(),
+            AccountId = request.AccountId,
+            CategoryId = request.CategoryId,
+            Description = request.Description,
+            Amount = request.Amount,
+            Frequency = request.Frequency,
+            CustomIntervalDays = request.CustomIntervalDays,
+            StartDate = request.StartDate,
+            EndDate = request.EndDate,
+            AutoCreate = request.AutoCreate,
+            Notes = request.Notes
+        };
+
+        try
+        {
+            var result = await _mediator.Send(command);
+            return CreatedAtAction(nameof(GetRecurringTransaction), new { id = result.Id }, result);
+        }
+        catch (ArgumentException ex)
+        {
+            return BadRequest(new { message = ex.Message });
+        }
+    }
+
+    /// <summary>
+    /// Update an existing recurring transaction
+    /// </summary>
+    [HttpPut("{id:int}")]
+    public async Task<ActionResult<RecurringTransactionDto>> UpdateRecurringTransaction(
+        int id,
+        [FromBody] UpdateRecurringTransactionRequest request)
+    {
+        var command = new UpdateRecurringTransactionCommand
+        {
+            Id = id,
+            UserId = _currentUserService.GetUserId(),
+            AccountId = request.AccountId,
+            CategoryId = request.CategoryId,
+            Description = request.Description,
+            Amount = request.Amount,
+            Frequency = request.Frequency,
+            CustomIntervalDays = request.CustomIntervalDays,
+            StartDate = request.StartDate,
+            EndDate = request.EndDate,
+            AutoCreate = request.AutoCreate,
+            Notes = request.Notes
+        };
+
+        try
+        {
+            var result = await _mediator.Send(command);
+            return Ok(result);
+        }
+        catch (ArgumentException ex)
+        {
+            return BadRequest(new { message = ex.Message });
+        }
+    }
+
+    /// <summary>
+    /// Soft delete a recurring transaction
+    /// </summary>
+    [HttpDelete("{id:int}")]
+    public async Task<IActionResult> DeleteRecurringTransaction(int id)
+    {
+        var command = new DeleteRecurringTransactionCommand
+        {
+            Id = id,
+            UserId = _currentUserService.GetUserId()
+        };
+
+        var deleted = await _mediator.Send(command);
+        if (!deleted)
+        {
+            return NotFound(new { message = $"Recurring transaction with ID {id} not found." });
+        }
+
+        return NoContent();
+    }
+
+    /// <summary>
+    /// Pause a recurring transaction (no reminders or auto-created transactions while paused)
+    /// </summary>
+    [HttpPatch("{id:int}/pause")]
+    public async Task<ActionResult<RecurringTransactionDto>> PauseRecurringTransaction(int id)
+    {
+        return await SetActiveAsync(id, isActive: false);
+    }
+
+    /// <summary>
+    /// Resume a paused recurring transaction. The next due date is fast-forwarded
+    /// so occurrences missed while paused are not retroactively fired.
+    /// </summary>
+    [HttpPatch("{id:int}/resume")]
+    public async Task<ActionResult<RecurringTransactionDto>> ResumeRecurringTransaction(int id)
+    {
+        return await SetActiveAsync(id, isActive: true);
+    }
+
+    private async Task<ActionResult<RecurringTransactionDto>> SetActiveAsync(int id, bool isActive)
+    {
+        var command = new SetRecurringTransactionActiveCommand
+        {
+            Id = id,
+            UserId = _currentUserService.GetUserId(),
+            IsActive = isActive
+        };
+
+        try
+        {
+            var result = await _mediator.Send(command);
+            return Ok(result);
+        }
+        catch (ArgumentException ex)
+        {
+            return NotFound(new { message = ex.Message });
+        }
+    }
+}

--- a/src/WebAPI/MyMascada.WebAPI/Controllers/RecurringTransactionsController.cs
+++ b/src/WebAPI/MyMascada.WebAPI/Controllers/RecurringTransactionsController.cs
@@ -121,6 +121,10 @@ public class RecurringTransactionsController : ControllerBase
         {
             return BadRequest(new { message = ex.Message });
         }
+        catch (UnauthorizedAccessException ex)
+        {
+            return StatusCode(StatusCodes.Status403Forbidden, new { message = ex.Message });
+        }
     }
 
     /// <summary>
@@ -159,6 +163,10 @@ public class RecurringTransactionsController : ControllerBase
         catch (ArgumentException ex)
         {
             return BadRequest(new { message = ex.Message });
+        }
+        catch (UnauthorizedAccessException ex)
+        {
+            return StatusCode(StatusCodes.Status403Forbidden, new { message = ex.Message });
         }
     }
 

--- a/src/WebAPI/MyMascada.WebAPI/Extensions/ApplicationServiceExtensions.cs
+++ b/src/WebAPI/MyMascada.WebAPI/Extensions/ApplicationServiceExtensions.cs
@@ -110,6 +110,10 @@ public static class ApplicationServiceExtensions
         services.AddScoped<MyMascada.Application.Features.RecurringPatterns.Services.IRecurringPatternPersistenceService,
             MyMascada.Application.Features.RecurringPatterns.Services.RecurringPatternPersistenceService>();
 
+        // Recurring Transaction processing services (user-created scheduled bills)
+        services.AddScoped<MyMascada.Application.Features.RecurringTransactions.Services.IRecurringTransactionProcessingService,
+            MyMascada.Application.Features.RecurringTransactions.Services.RecurringTransactionProcessingService>();
+
         // Notification services
         services.AddScoped<INotificationService, MyMascada.Infrastructure.Services.Notifications.NotificationService>();
         services.AddScoped<INotificationTriggerService, MyMascada.Infrastructure.Services.Notifications.NotificationTriggerService>();

--- a/src/WebAPI/MyMascada.WebAPI/Extensions/BackgroundJobServiceExtensions.cs
+++ b/src/WebAPI/MyMascada.WebAPI/Extensions/BackgroundJobServiceExtensions.cs
@@ -36,6 +36,10 @@ public static class BackgroundJobServiceExtensions
         services.AddScoped<MyMascada.Application.BackgroundJobs.IRecurringPatternJobService,
             MyMascada.Infrastructure.BackgroundJobs.RecurringPatternJobService>();
 
+        // Recurring transaction job service (user-created scheduled bills)
+        services.AddScoped<MyMascada.Application.BackgroundJobs.IRecurringTransactionJobService,
+            MyMascada.Infrastructure.BackgroundJobs.RecurringTransactionJobService>();
+
         // Expired budget job service
         services.AddScoped<MyMascada.Application.BackgroundJobs.IExpiredBudgetJobService,
             MyMascada.Infrastructure.BackgroundJobs.ExpiredBudgetJobService>();

--- a/src/WebAPI/MyMascada.WebAPI/Extensions/RepositoryServiceExtensions.cs
+++ b/src/WebAPI/MyMascada.WebAPI/Extensions/RepositoryServiceExtensions.cs
@@ -40,6 +40,9 @@ public static class RepositoryServiceExtensions
         // Recurring pattern repositories
         services.AddScoped<IRecurringPatternRepository, RecurringPatternRepository>();
 
+        // Recurring transaction repositories (user-created scheduled bills)
+        services.AddScoped<IRecurringTransactionRepository, RecurringTransactionRepository>();
+
         // Waitlist repositories
         services.AddScoped<IWaitlistRepository, WaitlistRepository>();
         services.AddScoped<IInvitationCodeRepository, InvitationCodeRepository>();

--- a/src/WebAPI/MyMascada.WebAPI/Migrations/20260610005252_AddRecurringTransactions.Designer.cs
+++ b/src/WebAPI/MyMascada.WebAPI/Migrations/20260610005252_AddRecurringTransactions.Designer.cs
@@ -2,6 +2,7 @@
 using System;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using MyMascada.Infrastructure.Data;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
@@ -11,9 +12,11 @@ using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 namespace MyMascada.WebAPI.Migrations
 {
     [DbContext(typeof(ApplicationDbContext))]
-    partial class ApplicationDbContextModelSnapshot : ModelSnapshot
+    [Migration("20260610005252_AddRecurringTransactions")]
+    partial class AddRecurringTransactions
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/src/WebAPI/MyMascada.WebAPI/Migrations/20260610005252_AddRecurringTransactions.cs
+++ b/src/WebAPI/MyMascada.WebAPI/Migrations/20260610005252_AddRecurringTransactions.cs
@@ -1,0 +1,145 @@
+﻿using System;
+using Microsoft.EntityFrameworkCore.Migrations;
+using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
+
+#nullable disable
+
+namespace MyMascada.WebAPI.Migrations
+{
+    /// <inheritdoc />
+    public partial class AddRecurringTransactions : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.CreateTable(
+                name: "RecurringTransactions",
+                columns: table => new
+                {
+                    Id = table.Column<int>(type: "integer", nullable: false)
+                        .Annotation("Npgsql:ValueGenerationStrategy", NpgsqlValueGenerationStrategy.IdentityByDefaultColumn),
+                    UserId = table.Column<Guid>(type: "uuid", nullable: false),
+                    AccountId = table.Column<int>(type: "integer", nullable: false),
+                    CategoryId = table.Column<int>(type: "integer", nullable: true),
+                    Description = table.Column<string>(type: "character varying(200)", maxLength: 200, nullable: false),
+                    Amount = table.Column<decimal>(type: "numeric(18,2)", precision: 18, scale: 2, nullable: false),
+                    Frequency = table.Column<int>(type: "integer", nullable: false),
+                    CustomIntervalDays = table.Column<int>(type: "integer", nullable: true),
+                    StartDate = table.Column<DateTime>(type: "timestamp with time zone", nullable: false),
+                    EndDate = table.Column<DateTime>(type: "timestamp with time zone", nullable: true),
+                    NextDueDate = table.Column<DateTime>(type: "timestamp with time zone", nullable: false),
+                    AutoCreate = table.Column<bool>(type: "boolean", nullable: false, defaultValue: false),
+                    IsActive = table.Column<bool>(type: "boolean", nullable: false, defaultValue: true),
+                    Notes = table.Column<string>(type: "character varying(500)", maxLength: 500, nullable: true),
+                    CreatedAt = table.Column<DateTime>(type: "timestamp with time zone", nullable: false),
+                    UpdatedAt = table.Column<DateTime>(type: "timestamp with time zone", nullable: false),
+                    IsDeleted = table.Column<bool>(type: "boolean", nullable: false),
+                    DeletedAt = table.Column<DateTime>(type: "timestamp with time zone", nullable: true),
+                    CreatedBy = table.Column<string>(type: "text", nullable: true),
+                    UpdatedBy = table.Column<string>(type: "text", nullable: true)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_RecurringTransactions", x => x.Id);
+                    table.ForeignKey(
+                        name: "FK_RecurringTransactions_Accounts_AccountId",
+                        column: x => x.AccountId,
+                        principalTable: "Accounts",
+                        principalColumn: "Id",
+                        onDelete: ReferentialAction.Cascade);
+                    table.ForeignKey(
+                        name: "FK_RecurringTransactions_Categories_CategoryId",
+                        column: x => x.CategoryId,
+                        principalTable: "Categories",
+                        principalColumn: "Id",
+                        onDelete: ReferentialAction.SetNull);
+                    table.ForeignKey(
+                        name: "FK_RecurringTransactions_Users_UserId",
+                        column: x => x.UserId,
+                        principalTable: "Users",
+                        principalColumn: "Id",
+                        onDelete: ReferentialAction.Cascade);
+                });
+
+            migrationBuilder.CreateTable(
+                name: "RecurringTransactionOccurrences",
+                columns: table => new
+                {
+                    Id = table.Column<int>(type: "integer", nullable: false)
+                        .Annotation("Npgsql:ValueGenerationStrategy", NpgsqlValueGenerationStrategy.IdentityByDefaultColumn),
+                    RecurringTransactionId = table.Column<int>(type: "integer", nullable: false),
+                    ScheduledDate = table.Column<DateTime>(type: "timestamp with time zone", nullable: false),
+                    Status = table.Column<int>(type: "integer", nullable: false),
+                    TransactionId = table.Column<int>(type: "integer", nullable: true),
+                    CreatedAt = table.Column<DateTime>(type: "timestamp with time zone", nullable: false),
+                    UpdatedAt = table.Column<DateTime>(type: "timestamp with time zone", nullable: false),
+                    IsDeleted = table.Column<bool>(type: "boolean", nullable: false),
+                    DeletedAt = table.Column<DateTime>(type: "timestamp with time zone", nullable: true),
+                    CreatedBy = table.Column<string>(type: "text", nullable: true),
+                    UpdatedBy = table.Column<string>(type: "text", nullable: true)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_RecurringTransactionOccurrences", x => x.Id);
+                    table.ForeignKey(
+                        name: "FK_RecurringTransactionOccurrences_RecurringTransactions_Recur~",
+                        column: x => x.RecurringTransactionId,
+                        principalTable: "RecurringTransactions",
+                        principalColumn: "Id",
+                        onDelete: ReferentialAction.Cascade);
+                    table.ForeignKey(
+                        name: "FK_RecurringTransactionOccurrences_Transactions_TransactionId",
+                        column: x => x.TransactionId,
+                        principalTable: "Transactions",
+                        principalColumn: "Id",
+                        onDelete: ReferentialAction.SetNull);
+                });
+
+            migrationBuilder.CreateIndex(
+                name: "IX_RecurringTransactionOccurrences_RecurringTransactionId_Sche~",
+                table: "RecurringTransactionOccurrences",
+                columns: new[] { "RecurringTransactionId", "ScheduledDate" },
+                unique: true);
+
+            migrationBuilder.CreateIndex(
+                name: "IX_RecurringTransactionOccurrences_TransactionId",
+                table: "RecurringTransactionOccurrences",
+                column: "TransactionId");
+
+            migrationBuilder.CreateIndex(
+                name: "IX_RecurringTransactions_AccountId",
+                table: "RecurringTransactions",
+                column: "AccountId");
+
+            migrationBuilder.CreateIndex(
+                name: "IX_RecurringTransactions_CategoryId",
+                table: "RecurringTransactions",
+                column: "CategoryId");
+
+            migrationBuilder.CreateIndex(
+                name: "IX_RecurringTransactions_IsActive_NextDueDate",
+                table: "RecurringTransactions",
+                columns: new[] { "IsActive", "NextDueDate" });
+
+            migrationBuilder.CreateIndex(
+                name: "IX_RecurringTransactions_UserId",
+                table: "RecurringTransactions",
+                column: "UserId");
+
+            migrationBuilder.CreateIndex(
+                name: "IX_RecurringTransactions_UserId_IsActive",
+                table: "RecurringTransactions",
+                columns: new[] { "UserId", "IsActive" });
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropTable(
+                name: "RecurringTransactionOccurrences");
+
+            migrationBuilder.DropTable(
+                name: "RecurringTransactions");
+        }
+    }
+}

--- a/src/WebAPI/MyMascada.WebAPI/Program.cs
+++ b/src/WebAPI/MyMascada.WebAPI/Program.cs
@@ -448,6 +448,11 @@ recurringJobManager.AddOrUpdate<MyMascada.Application.BackgroundJobs.IRecurringP
     service => service.ProcessAllUsersAsync(null),
     Hangfire.Cron.Daily(2, 0)); // Run daily at 2:00 AM
 
+recurringJobManager.AddOrUpdate<MyMascada.Application.BackgroundJobs.IRecurringTransactionJobService>(
+    "daily-recurring-transaction-processing",
+    service => service.ProcessAllDueAsync(null),
+    Hangfire.Cron.Daily(2, 30)); // Run daily at 2:30 AM
+
 recurringJobManager.AddOrUpdate<MyMascada.Application.BackgroundJobs.IExpiredBudgetJobService>(
     "daily-expired-budget-processing",
     service => service.ProcessAllUsersAsync(null),

--- a/tests/MyMascada.Tests.Unit/Domain/RecurringTransactionTests.cs
+++ b/tests/MyMascada.Tests.Unit/Domain/RecurringTransactionTests.cs
@@ -352,6 +352,83 @@ public class RecurringTransactionTests
             new DateTime(2026, 6, 8));
     }
 
+    [Fact]
+    public void GetScheduledDates_StaleNextDueDateYearsBehind_StillReturnsWindowDates()
+    {
+        // Daily schedule whose NextDueDate is 2 years stale (long pause / job
+        // downtime). Walking day-by-day would burn all MaxCatchUpIterations
+        // before reaching the window and return an empty list.
+        var schedule = CreateSchedule(
+            RecurrenceFrequency.Custom,
+            new DateTime(2024, 6, 1),
+            customIntervalDays: 1);
+
+        var dates = schedule.GetScheduledDates(new DateTime(2026, 6, 10), new DateTime(2026, 6, 13));
+
+        dates.Should().Equal(
+            new DateTime(2026, 6, 10),
+            new DateTime(2026, 6, 11),
+            new DateTime(2026, 6, 12),
+            new DateTime(2026, 6, 13));
+    }
+
+    [Fact]
+    public void GetScheduledDates_StaleNextDueDate_PreservesScheduleAnchor()
+    {
+        // Weekly anchored on Monday 2025-06-02; a year later the materialized
+        // dates must still fall on the same weekly grid (Mondays).
+        var schedule = CreateSchedule(RecurrenceFrequency.Weekly, new DateTime(2025, 6, 2));
+
+        var dates = schedule.GetScheduledDates(new DateTime(2026, 6, 10), new DateTime(2026, 6, 30));
+
+        dates.Should().Equal(
+            new DateTime(2026, 6, 15),
+            new DateTime(2026, 6, 22),
+            new DateTime(2026, 6, 29));
+    }
+
+    [Fact]
+    public void GetScheduledDates_StaleMonthlySchedule_KeepsAnchorDayClamping()
+    {
+        // Monthly anchored on the 31st, stale for over a year: the window dates
+        // must still clamp to month length (Jun 30) instead of drifting.
+        var schedule = CreateSchedule(RecurrenceFrequency.Monthly, new DateTime(2025, 1, 31));
+
+        var dates = schedule.GetScheduledDates(new DateTime(2026, 6, 1), new DateTime(2026, 7, 31));
+
+        dates.Should().Equal(
+            new DateTime(2026, 6, 30),
+            new DateTime(2026, 7, 31));
+    }
+
+    // --- AdvanceNextDueDateAfter (incremental catch-up) ---
+
+    [Fact]
+    public void AdvanceNextDueDateAfter_SetsOccurrenceFollowingLastFiredDate()
+    {
+        var schedule = CreateSchedule(RecurrenceFrequency.Weekly, new DateTime(2026, 6, 1));
+
+        // Run only processed up to 6/8 (cap reached); next due stays in the past
+        schedule.AdvanceNextDueDateAfter(new DateTime(2026, 6, 8));
+
+        schedule.NextDueDate.Should().Be(new DateTime(2026, 6, 15));
+        schedule.IsActive.Should().BeTrue();
+    }
+
+    [Fact]
+    public void AdvanceNextDueDateAfter_PastEndDate_DeactivatesSchedule()
+    {
+        var schedule = CreateSchedule(
+            RecurrenceFrequency.Weekly,
+            new DateTime(2026, 6, 1),
+            endDate: new DateTime(2026, 6, 10));
+
+        schedule.AdvanceNextDueDateAfter(new DateTime(2026, 6, 8));
+
+        schedule.NextDueDate.Should().Be(new DateTime(2026, 6, 15));
+        schedule.IsActive.Should().BeFalse();
+    }
+
     // --- Pause / Resume ---
 
     [Fact]

--- a/tests/MyMascada.Tests.Unit/Domain/RecurringTransactionTests.cs
+++ b/tests/MyMascada.Tests.Unit/Domain/RecurringTransactionTests.cs
@@ -209,6 +209,79 @@ public class RecurringTransactionTests
         schedule.IsActive.Should().BeTrue();
     }
 
+    // --- AdvanceNextDueDate: far-behind schedules must snap fully past today ---
+
+    [Fact]
+    public void AdvanceNextDueDate_CustomDailyTwoYearsBehind_SnapsToTomorrow()
+    {
+        // A daily schedule 2 years behind has ~730 missed occurrences — far more
+        // than any per-run iteration cap. It must still land strictly after today.
+        var schedule = CreateSchedule(
+            RecurrenceFrequency.Custom,
+            new DateTime(2024, 6, 10),
+            customIntervalDays: 1);
+        var today = new DateTime(2026, 6, 10);
+
+        schedule.AdvanceNextDueDate(today);
+
+        schedule.NextDueDate.Should().Be(new DateTime(2026, 6, 11));
+    }
+
+    [Fact]
+    public void AdvanceNextDueDate_WeeklyTenYearsBehind_SnapsPastTodayPreservingAnchor()
+    {
+        var start = new DateTime(2016, 6, 6); // a Monday
+        var schedule = CreateSchedule(RecurrenceFrequency.Weekly, start);
+        var today = new DateTime(2026, 6, 10);
+
+        schedule.AdvanceNextDueDate(today);
+
+        schedule.NextDueDate.Should().BeAfter(today);
+        schedule.NextDueDate.Should().BeOnOrBefore(today.AddDays(7));
+        schedule.NextDueDate.DayOfWeek.Should().Be(start.DayOfWeek); // anchor weekday preserved
+        ((schedule.NextDueDate - start).Days % 7).Should().Be(0); // exact multiple of the interval
+    }
+
+    [Fact]
+    public void AdvanceNextDueDate_MonthlyFortyYearsBehind_SnapsPastToday()
+    {
+        // 480 calendar steps — exceeds the old 366-iteration cap
+        var schedule = CreateSchedule(RecurrenceFrequency.Monthly, new DateTime(1986, 1, 31));
+        var today = new DateTime(2026, 6, 10);
+
+        schedule.AdvanceNextDueDate(today);
+
+        schedule.NextDueDate.Should().Be(new DateTime(2026, 6, 30)); // anchor day 31 clamped to June 30
+    }
+
+    [Fact]
+    public void AdvanceNextDueDate_CustomDailyDueToday_AdvancesOneDay()
+    {
+        var schedule = CreateSchedule(
+            RecurrenceFrequency.Custom,
+            new DateTime(2026, 6, 10),
+            customIntervalDays: 1);
+
+        schedule.AdvanceNextDueDate(new DateTime(2026, 6, 10));
+
+        schedule.NextDueDate.Should().Be(new DateTime(2026, 6, 11));
+    }
+
+    [Fact]
+    public void Resume_AfterYearsLongPause_SnapsFullyPastToday()
+    {
+        var schedule = CreateSchedule(
+            RecurrenceFrequency.Custom,
+            new DateTime(2023, 1, 1),
+            customIntervalDays: 1);
+        schedule.Pause();
+
+        schedule.Resume(new DateTime(2026, 6, 10));
+
+        schedule.IsActive.Should().BeTrue();
+        schedule.NextDueDate.Should().Be(new DateTime(2026, 6, 11));
+    }
+
     // --- GetDueDates ---
 
     [Fact]

--- a/tests/MyMascada.Tests.Unit/Domain/RecurringTransactionTests.cs
+++ b/tests/MyMascada.Tests.Unit/Domain/RecurringTransactionTests.cs
@@ -1,0 +1,331 @@
+using MyMascada.Domain.Entities;
+using MyMascada.Domain.Enums;
+
+namespace MyMascada.Tests.Unit.Domain;
+
+public class RecurringTransactionTests
+{
+    private static RecurringTransaction CreateSchedule(
+        RecurrenceFrequency frequency,
+        DateTime startDate,
+        int? customIntervalDays = null,
+        DateTime? endDate = null)
+    {
+        return new RecurringTransaction
+        {
+            Id = 1,
+            UserId = Guid.NewGuid(),
+            AccountId = 1,
+            Description = "Test bill",
+            Amount = 50m,
+            Frequency = frequency,
+            CustomIntervalDays = customIntervalDays,
+            StartDate = startDate,
+            EndDate = endDate,
+            NextDueDate = startDate,
+            IsActive = true
+        };
+    }
+
+    // --- CalculateNextDueDate: simple day-based frequencies ---
+
+    [Fact]
+    public void CalculateNextDueDate_Weekly_Adds7Days()
+    {
+        var schedule = CreateSchedule(RecurrenceFrequency.Weekly, new DateTime(2026, 6, 1));
+
+        var next = schedule.CalculateNextDueDate(new DateTime(2026, 6, 1));
+
+        next.Should().Be(new DateTime(2026, 6, 8));
+    }
+
+    [Fact]
+    public void CalculateNextDueDate_Fortnightly_Adds14Days()
+    {
+        var schedule = CreateSchedule(RecurrenceFrequency.Fortnightly, new DateTime(2026, 6, 1));
+
+        var next = schedule.CalculateNextDueDate(new DateTime(2026, 6, 1));
+
+        next.Should().Be(new DateTime(2026, 6, 15));
+    }
+
+    [Fact]
+    public void CalculateNextDueDate_Custom_AddsConfiguredInterval()
+    {
+        var schedule = CreateSchedule(RecurrenceFrequency.Custom, new DateTime(2026, 6, 1), customIntervalDays: 45);
+
+        var next = schedule.CalculateNextDueDate(new DateTime(2026, 6, 1));
+
+        next.Should().Be(new DateTime(2026, 7, 16));
+    }
+
+    [Fact]
+    public void CalculateNextDueDate_CustomWithoutInterval_Throws()
+    {
+        var schedule = CreateSchedule(RecurrenceFrequency.Custom, new DateTime(2026, 6, 1), customIntervalDays: null);
+
+        var act = () => schedule.CalculateNextDueDate(new DateTime(2026, 6, 1));
+
+        act.Should().Throw<InvalidOperationException>();
+    }
+
+    // --- Monthly: calendar math with end-of-month clamping ---
+
+    [Fact]
+    public void CalculateNextDueDate_Monthly_UsesCalendarMonths()
+    {
+        var schedule = CreateSchedule(RecurrenceFrequency.Monthly, new DateTime(2026, 6, 15));
+
+        var next = schedule.CalculateNextDueDate(new DateTime(2026, 6, 15));
+
+        next.Should().Be(new DateTime(2026, 7, 15));
+    }
+
+    [Fact]
+    public void CalculateNextDueDate_MonthlyDue31st_ClampsToFebruary28()
+    {
+        var schedule = CreateSchedule(RecurrenceFrequency.Monthly, new DateTime(2026, 1, 31));
+
+        var next = schedule.CalculateNextDueDate(new DateTime(2026, 1, 31));
+
+        next.Should().Be(new DateTime(2026, 2, 28)); // 2026 is not a leap year
+    }
+
+    [Fact]
+    public void CalculateNextDueDate_MonthlyDue31st_LeapYearClampsToFebruary29()
+    {
+        var schedule = CreateSchedule(RecurrenceFrequency.Monthly, new DateTime(2028, 1, 31));
+
+        var next = schedule.CalculateNextDueDate(new DateTime(2028, 1, 31));
+
+        next.Should().Be(new DateTime(2028, 2, 29)); // 2028 is a leap year
+    }
+
+    [Fact]
+    public void CalculateNextDueDate_MonthlyDue31st_RecoversAnchorDayAfterShortMonth()
+    {
+        // Anchored on the 31st: Jan 31 -> Feb 28 -> Mar 31 (not Mar 28)
+        var schedule = CreateSchedule(RecurrenceFrequency.Monthly, new DateTime(2026, 1, 31));
+
+        var february = schedule.CalculateNextDueDate(new DateTime(2026, 1, 31));
+        var march = schedule.CalculateNextDueDate(february);
+
+        february.Should().Be(new DateTime(2026, 2, 28));
+        march.Should().Be(new DateTime(2026, 3, 31));
+    }
+
+    [Fact]
+    public void CalculateNextDueDate_MonthlyDue30th_ClampsOnlyInFebruary()
+    {
+        var schedule = CreateSchedule(RecurrenceFrequency.Monthly, new DateTime(2026, 1, 30));
+
+        var february = schedule.CalculateNextDueDate(new DateTime(2026, 1, 30));
+        var march = schedule.CalculateNextDueDate(february);
+        var april = schedule.CalculateNextDueDate(march);
+
+        february.Should().Be(new DateTime(2026, 2, 28));
+        march.Should().Be(new DateTime(2026, 3, 30));
+        april.Should().Be(new DateTime(2026, 4, 30));
+    }
+
+    // --- Yearly: calendar math with leap-day clamping ---
+
+    [Fact]
+    public void CalculateNextDueDate_Yearly_UsesCalendarYears()
+    {
+        var schedule = CreateSchedule(RecurrenceFrequency.Yearly, new DateTime(2026, 3, 10));
+
+        var next = schedule.CalculateNextDueDate(new DateTime(2026, 3, 10));
+
+        next.Should().Be(new DateTime(2027, 3, 10));
+    }
+
+    [Fact]
+    public void CalculateNextDueDate_YearlyOnLeapDay_ClampsToFeb28ThenRecovers()
+    {
+        var schedule = CreateSchedule(RecurrenceFrequency.Yearly, new DateTime(2024, 2, 29));
+
+        var y2025 = schedule.CalculateNextDueDate(new DateTime(2024, 2, 29));
+        var y2026 = schedule.CalculateNextDueDate(y2025);
+        var y2027 = schedule.CalculateNextDueDate(y2026);
+        var y2028 = schedule.CalculateNextDueDate(y2027);
+
+        y2025.Should().Be(new DateTime(2025, 2, 28));
+        y2026.Should().Be(new DateTime(2026, 2, 28));
+        y2027.Should().Be(new DateTime(2027, 2, 28));
+        y2028.Should().Be(new DateTime(2028, 2, 29)); // leap year recovers the anchor day
+    }
+
+    [Fact]
+    public void CalculateNextDueDate_PreservesUtcKind()
+    {
+        var start = new DateTime(2026, 1, 31, 0, 0, 0, DateTimeKind.Utc);
+        var schedule = CreateSchedule(RecurrenceFrequency.Monthly, start);
+
+        var next = schedule.CalculateNextDueDate(start);
+
+        next.Kind.Should().Be(DateTimeKind.Utc);
+    }
+
+    // --- AdvanceNextDueDate ---
+
+    [Fact]
+    public void AdvanceNextDueDate_SkipsAllMissedOccurrences()
+    {
+        var schedule = CreateSchedule(RecurrenceFrequency.Weekly, new DateTime(2026, 6, 1));
+
+        // 3 weeks of missed runs: 6/1, 6/8, 6/15 are all <= 6/15
+        schedule.AdvanceNextDueDate(new DateTime(2026, 6, 15));
+
+        schedule.NextDueDate.Should().Be(new DateTime(2026, 6, 22));
+        schedule.IsActive.Should().BeTrue();
+    }
+
+    [Fact]
+    public void AdvanceNextDueDate_PastEndDate_DeactivatesSchedule()
+    {
+        var schedule = CreateSchedule(
+            RecurrenceFrequency.Weekly,
+            new DateTime(2026, 6, 1),
+            endDate: new DateTime(2026, 6, 10));
+
+        schedule.AdvanceNextDueDate(new DateTime(2026, 6, 8));
+
+        schedule.NextDueDate.Should().Be(new DateTime(2026, 6, 15));
+        schedule.IsActive.Should().BeFalse();
+    }
+
+    [Fact]
+    public void AdvanceNextDueDate_BeforeEndDate_StaysActive()
+    {
+        var schedule = CreateSchedule(
+            RecurrenceFrequency.Weekly,
+            new DateTime(2026, 6, 1),
+            endDate: new DateTime(2026, 12, 31));
+
+        schedule.AdvanceNextDueDate(new DateTime(2026, 6, 1));
+
+        schedule.NextDueDate.Should().Be(new DateTime(2026, 6, 8));
+        schedule.IsActive.Should().BeTrue();
+    }
+
+    // --- GetDueDates ---
+
+    [Fact]
+    public void GetDueDates_ReturnsAllDatesUpToToday()
+    {
+        var schedule = CreateSchedule(RecurrenceFrequency.Weekly, new DateTime(2026, 6, 1));
+
+        var dueDates = schedule.GetDueDates(new DateTime(2026, 6, 15));
+
+        dueDates.Should().Equal(
+            new DateTime(2026, 6, 1),
+            new DateTime(2026, 6, 8),
+            new DateTime(2026, 6, 15));
+    }
+
+    [Fact]
+    public void GetDueDates_NotYetDue_ReturnsEmpty()
+    {
+        var schedule = CreateSchedule(RecurrenceFrequency.Weekly, new DateTime(2026, 6, 10));
+
+        var dueDates = schedule.GetDueDates(new DateTime(2026, 6, 9));
+
+        dueDates.Should().BeEmpty();
+    }
+
+    [Fact]
+    public void GetDueDates_StopsAtEndDate()
+    {
+        var schedule = CreateSchedule(
+            RecurrenceFrequency.Weekly,
+            new DateTime(2026, 6, 1),
+            endDate: new DateTime(2026, 6, 10));
+
+        var dueDates = schedule.GetDueDates(new DateTime(2026, 6, 30));
+
+        dueDates.Should().Equal(
+            new DateTime(2026, 6, 1),
+            new DateTime(2026, 6, 8));
+    }
+
+    // --- GetScheduledDates (upcoming materialization) ---
+
+    [Fact]
+    public void GetScheduledDates_ReturnsDatesWithinWindow()
+    {
+        var schedule = CreateSchedule(RecurrenceFrequency.Weekly, new DateTime(2026, 6, 1));
+
+        var dates = schedule.GetScheduledDates(new DateTime(2026, 6, 1), new DateTime(2026, 6, 20));
+
+        dates.Should().Equal(
+            new DateTime(2026, 6, 1),
+            new DateTime(2026, 6, 8),
+            new DateTime(2026, 6, 15));
+    }
+
+    [Fact]
+    public void GetScheduledDates_RespectsEndDate()
+    {
+        var schedule = CreateSchedule(
+            RecurrenceFrequency.Weekly,
+            new DateTime(2026, 6, 1),
+            endDate: new DateTime(2026, 6, 8));
+
+        var dates = schedule.GetScheduledDates(new DateTime(2026, 6, 1), new DateTime(2026, 6, 30));
+
+        dates.Should().Equal(
+            new DateTime(2026, 6, 1),
+            new DateTime(2026, 6, 8));
+    }
+
+    // --- Pause / Resume ---
+
+    [Fact]
+    public void Pause_SetsInactive()
+    {
+        var schedule = CreateSchedule(RecurrenceFrequency.Monthly, new DateTime(2026, 6, 1));
+
+        schedule.Pause();
+
+        schedule.IsActive.Should().BeFalse();
+    }
+
+    [Fact]
+    public void Resume_WithPastDueDate_FastForwardsPastToday()
+    {
+        var schedule = CreateSchedule(RecurrenceFrequency.Weekly, new DateTime(2026, 6, 1));
+        schedule.Pause();
+
+        schedule.Resume(new DateTime(2026, 6, 20));
+
+        schedule.IsActive.Should().BeTrue();
+        schedule.NextDueDate.Should().Be(new DateTime(2026, 6, 22));
+    }
+
+    [Fact]
+    public void Resume_WithFutureDueDate_KeepsNextDueDate()
+    {
+        var schedule = CreateSchedule(RecurrenceFrequency.Weekly, new DateTime(2026, 7, 1));
+        schedule.Pause();
+
+        schedule.Resume(new DateTime(2026, 6, 20));
+
+        schedule.IsActive.Should().BeTrue();
+        schedule.NextDueDate.Should().Be(new DateTime(2026, 7, 1));
+    }
+
+    [Fact]
+    public void Resume_PastEndDate_StaysInactive()
+    {
+        var schedule = CreateSchedule(
+            RecurrenceFrequency.Weekly,
+            new DateTime(2026, 6, 1),
+            endDate: new DateTime(2026, 6, 10));
+        schedule.Pause();
+
+        schedule.Resume(new DateTime(2026, 6, 20));
+
+        schedule.IsActive.Should().BeFalse();
+    }
+}

--- a/tests/MyMascada.Tests.Unit/Features/RecurringTransactions/Commands/RecurringTransactionCommandAuthorizationTests.cs
+++ b/tests/MyMascada.Tests.Unit/Features/RecurringTransactions/Commands/RecurringTransactionCommandAuthorizationTests.cs
@@ -1,0 +1,160 @@
+using MyMascada.Application.Common.Interfaces;
+using MyMascada.Application.Features.RecurringTransactions.Commands;
+using MyMascada.Domain.Entities;
+using MyMascada.Domain.Enums;
+
+namespace MyMascada.Tests.Unit.Features.RecurringTransactions.Commands;
+
+/// <summary>
+/// Auto-create schedules materialize real transactions via CreateTransactionCommand,
+/// which requires modify access (owner or Manager share). Viewer-only accounts must
+/// be rejected when the schedule is created/updated, not when the nightly job fails.
+/// </summary>
+public class RecurringTransactionCommandAuthorizationTests
+{
+    private readonly IRecurringTransactionRepository _recurringTransactionRepository =
+        Substitute.For<IRecurringTransactionRepository>();
+    private readonly IAccountRepository _accountRepository = Substitute.For<IAccountRepository>();
+    private readonly ICategoryRepository _categoryRepository = Substitute.For<ICategoryRepository>();
+    private readonly IAccountAccessService _accountAccessService = Substitute.For<IAccountAccessService>();
+
+    private readonly Guid _userId = Guid.NewGuid();
+    private const int AccountId = 7;
+
+    public RecurringTransactionCommandAuthorizationTests()
+    {
+        // Account is visible to the user (owner or any accepted share role)
+        _accountRepository.GetByIdAsync(AccountId, _userId)
+            .Returns(new Account { Id = AccountId, Name = "Shared account" });
+
+        _recurringTransactionRepository.CreateAsync(
+                Arg.Any<RecurringTransaction>(), Arg.Any<CancellationToken>())
+            .Returns(ci => ci.Arg<RecurringTransaction>());
+        _recurringTransactionRepository.UpdateAsync(
+                Arg.Any<RecurringTransaction>(), Arg.Any<CancellationToken>())
+            .Returns(ci => ci.Arg<RecurringTransaction>());
+        _recurringTransactionRepository.GetByIdAsync(1, _userId, Arg.Any<CancellationToken>())
+            .Returns(ExistingSchedule());
+    }
+
+    private CreateRecurringTransactionCommandHandler CreateHandler() =>
+        new(_recurringTransactionRepository, _accountRepository, _categoryRepository, _accountAccessService);
+
+    private UpdateRecurringTransactionCommandHandler UpdateHandler() =>
+        new(_recurringTransactionRepository, _accountRepository, _categoryRepository, _accountAccessService);
+
+    private CreateRecurringTransactionCommand CreateCommand(bool autoCreate) => new()
+    {
+        UserId = _userId,
+        AccountId = AccountId,
+        Description = "Internet bill",
+        Amount = 89.99m,
+        Frequency = RecurrenceFrequency.Monthly,
+        StartDate = DateTime.UtcNow.Date,
+        AutoCreate = autoCreate
+    };
+
+    private UpdateRecurringTransactionCommand UpdateCommand(bool autoCreate) => new()
+    {
+        Id = 1,
+        UserId = _userId,
+        AccountId = AccountId,
+        Description = "Internet bill",
+        Amount = 89.99m,
+        Frequency = RecurrenceFrequency.Monthly,
+        StartDate = DateTime.UtcNow.Date,
+        AutoCreate = autoCreate
+    };
+
+    private RecurringTransaction ExistingSchedule() => new()
+    {
+        Id = 1,
+        UserId = _userId,
+        AccountId = AccountId,
+        Description = "Internet bill",
+        Amount = 89.99m,
+        Frequency = RecurrenceFrequency.Monthly,
+        StartDate = DateTime.UtcNow.Date,
+        NextDueDate = DateTime.UtcNow.Date,
+        AutoCreate = false,
+        IsActive = true
+    };
+
+    private void SetModifyAccess(bool canModify)
+    {
+        _accountAccessService.CanModifyAccountAsync(_userId, AccountId).Returns(canModify);
+    }
+
+    [Fact]
+    public async Task Create_AutoCreateOnViewerOnlyAccount_ThrowsUnauthorized()
+    {
+        SetModifyAccess(false);
+
+        var act = () => CreateHandler().Handle(CreateCommand(autoCreate: true), CancellationToken.None);
+
+        await act.Should().ThrowAsync<UnauthorizedAccessException>();
+        await _recurringTransactionRepository.DidNotReceive().CreateAsync(
+            Arg.Any<RecurringTransaction>(), Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task Create_ReminderOnlyOnViewerOnlyAccount_Succeeds()
+    {
+        // Reminders only notify the schedule owner — view access is enough.
+        SetModifyAccess(false);
+
+        var dto = await CreateHandler().Handle(CreateCommand(autoCreate: false), CancellationToken.None);
+
+        dto.AutoCreate.Should().BeFalse();
+        await _recurringTransactionRepository.Received(1).CreateAsync(
+            Arg.Any<RecurringTransaction>(), Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task Create_AutoCreateWithModifyAccess_Succeeds()
+    {
+        SetModifyAccess(true);
+
+        var dto = await CreateHandler().Handle(CreateCommand(autoCreate: true), CancellationToken.None);
+
+        dto.AutoCreate.Should().BeTrue();
+        await _recurringTransactionRepository.Received(1).CreateAsync(
+            Arg.Any<RecurringTransaction>(), Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task Update_TogglingAutoCreateOnViewerOnlyAccount_ThrowsUnauthorized()
+    {
+        SetModifyAccess(false);
+
+        var act = () => UpdateHandler().Handle(UpdateCommand(autoCreate: true), CancellationToken.None);
+
+        await act.Should().ThrowAsync<UnauthorizedAccessException>();
+        await _recurringTransactionRepository.DidNotReceive().UpdateAsync(
+            Arg.Any<RecurringTransaction>(), Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task Update_ReminderOnlyOnViewerOnlyAccount_Succeeds()
+    {
+        SetModifyAccess(false);
+
+        var dto = await UpdateHandler().Handle(UpdateCommand(autoCreate: false), CancellationToken.None);
+
+        dto.AutoCreate.Should().BeFalse();
+        await _recurringTransactionRepository.Received(1).UpdateAsync(
+            Arg.Any<RecurringTransaction>(), Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task Update_AutoCreateWithModifyAccess_Succeeds()
+    {
+        SetModifyAccess(true);
+
+        var dto = await UpdateHandler().Handle(UpdateCommand(autoCreate: true), CancellationToken.None);
+
+        dto.AutoCreate.Should().BeTrue();
+        await _recurringTransactionRepository.Received(1).UpdateAsync(
+            Arg.Any<RecurringTransaction>(), Arg.Any<CancellationToken>());
+    }
+}

--- a/tests/MyMascada.Tests.Unit/Features/RecurringTransactions/Services/RecurringTransactionProcessingServiceTests.cs
+++ b/tests/MyMascada.Tests.Unit/Features/RecurringTransactions/Services/RecurringTransactionProcessingServiceTests.cs
@@ -43,7 +43,8 @@ public class RecurringTransactionProcessingServiceTests
         DateTime nextDueDate,
         RecurrenceFrequency frequency = RecurrenceFrequency.Monthly,
         DateTime? endDate = null,
-        int id = 1)
+        int id = 1,
+        int? customIntervalDays = null)
     {
         return new RecurringTransaction
         {
@@ -54,6 +55,7 @@ public class RecurringTransactionProcessingServiceTests
             Description = "Internet bill",
             Amount = 89.99m,
             Frequency = frequency,
+            CustomIntervalDays = customIntervalDays,
             StartDate = nextDueDate,
             EndDate = endDate,
             NextDueDate = nextDueDate,
@@ -353,6 +355,36 @@ public class RecurringTransactionProcessingServiceTests
             Arg.Any<RecurringTransactionOccurrence>(), Arg.Any<CancellationToken>());
 
         schedule.NextDueDate.Should().Be(new DateTime(2026, 6, 17));
+    }
+
+    [Fact]
+    public async Task ProcessDueAsync_MoreDueDatesThanCatchUpCap_ContinuesFromLastFiredDateInsteadOfSkipping()
+    {
+        // Daily schedule 400 days behind: one run can only materialize
+        // MaxCatchUpIterations (366) occurrences. The schedule must then point
+        // at the day AFTER the last fired occurrence — still in the past, so
+        // the next nightly run picks it up and keeps catching up — instead of
+        // snapping past today and silently losing the remaining 34 days.
+        var firstDue = Today.AddDays(-400);
+        var schedule = CreateSchedule(
+            autoCreate: true,
+            nextDueDate: firstDue,
+            frequency: RecurrenceFrequency.Custom,
+            customIntervalDays: 1);
+        SetupDue(schedule);
+        _mediator.Send(Arg.Any<CreateTransactionCommand>(), Arg.Any<CancellationToken>())
+            .Returns(new TransactionDto { Id = 42 });
+
+        var result = await _service.ProcessDueAsync(Today);
+
+        result.TransactionsCreated.Should().Be(RecurringTransaction.MaxCatchUpIterations);
+
+        // Last fired date = firstDue + 365 days; next due = the day after it
+        var expectedNextDue = firstDue.AddDays(RecurringTransaction.MaxCatchUpIterations);
+        schedule.NextDueDate.Should().Be(expectedNextDue);
+        schedule.NextDueDate.Should().BeOnOrBefore(Today, "the remaining occurrences must stay due for the next run");
+        schedule.IsActive.Should().BeTrue();
+        await _repository.Received(1).UpdateAsync(schedule, Arg.Any<CancellationToken>());
     }
 
     [Fact]

--- a/tests/MyMascada.Tests.Unit/Features/RecurringTransactions/Services/RecurringTransactionProcessingServiceTests.cs
+++ b/tests/MyMascada.Tests.Unit/Features/RecurringTransactions/Services/RecurringTransactionProcessingServiceTests.cs
@@ -26,6 +26,16 @@ public class RecurringTransactionProcessingServiceTests
             _mediator,
             _notificationTriggerService,
             Substitute.For<ILogger<RecurringTransactionProcessingService>>());
+
+        // Default: account exists; occurrence claims succeed and echo the claim back.
+        _repository.AccountExistsAsync(Arg.Any<int>(), Arg.Any<CancellationToken>())
+            .Returns(true);
+        _repository.TryCreateOccurrenceAsync(
+                Arg.Any<RecurringTransactionOccurrence>(), Arg.Any<CancellationToken>())
+            .Returns(ci => ci.Arg<RecurringTransactionOccurrence>());
+        _repository.UpdateOccurrenceAsync(
+                Arg.Any<RecurringTransactionOccurrence>(), Arg.Any<CancellationToken>())
+            .Returns(ci => ci.Arg<RecurringTransactionOccurrence>());
     }
 
     private RecurringTransaction CreateSchedule(
@@ -60,18 +70,43 @@ public class RecurringTransactionProcessingServiceTests
     }
 
     [Fact]
-    public async Task ProcessDueAsync_AutoCreateSchedule_CreatesPendingNegativeTransaction()
+    public async Task ProcessDueAsync_AutoCreateSchedule_ClaimsThenCreatesPendingNegativeTransaction()
     {
         var schedule = CreateSchedule(autoCreate: true, nextDueDate: Today);
         SetupDue(schedule);
         _mediator.Send(Arg.Any<CreateTransactionCommand>(), Arg.Any<CancellationToken>())
             .Returns(new TransactionDto { Id = 42 });
 
+        // Snapshot the claim at insert time — the same object is mutated to
+        // Created afterwards, so a Received() predicate would see the final state.
+        RecurringTransactionOccurrence? claimAtInsert = null;
+        _repository.TryCreateOccurrenceAsync(
+                Arg.Any<RecurringTransactionOccurrence>(), Arg.Any<CancellationToken>())
+            .Returns(ci =>
+            {
+                var occurrence = ci.Arg<RecurringTransactionOccurrence>();
+                claimAtInsert = new RecurringTransactionOccurrence
+                {
+                    RecurringTransactionId = occurrence.RecurringTransactionId,
+                    ScheduledDate = occurrence.ScheduledDate,
+                    Status = occurrence.Status,
+                    TransactionId = occurrence.TransactionId
+                };
+                return occurrence;
+            });
+
         var result = await _service.ProcessDueAsync(Today);
 
         result.TransactionsCreated.Should().Be(1);
         result.RemindersSent.Should().Be(0);
         result.SchedulesProcessed.Should().Be(1);
+
+        // The occurrence row is claimed (Pending) BEFORE the transaction is created
+        claimAtInsert.Should().NotBeNull();
+        claimAtInsert!.RecurringTransactionId.Should().Be(schedule.Id);
+        claimAtInsert.ScheduledDate.Should().Be(Today);
+        claimAtInsert.Status.Should().Be(RecurringTransactionOccurrenceStatus.Pending);
+        claimAtInsert.TransactionId.Should().BeNull();
 
         await _mediator.Received(1).Send(
             Arg.Is<CreateTransactionCommand>(c =>
@@ -85,11 +120,10 @@ public class RecurringTransactionProcessingServiceTests
                 && c.AllowDuplicates),
             Arg.Any<CancellationToken>());
 
-        await _repository.Received(1).CreateOccurrenceAsync(
+        // ... and the claim is completed with the transaction id afterwards
+        await _repository.Received(1).UpdateOccurrenceAsync(
             Arg.Is<RecurringTransactionOccurrence>(o =>
-                o.RecurringTransactionId == schedule.Id
-                && o.ScheduledDate == Today
-                && o.Status == RecurringTransactionOccurrenceStatus.Created
+                o.Status == RecurringTransactionOccurrenceStatus.Created
                 && o.TransactionId == 42),
             Arg.Any<CancellationToken>());
 
@@ -113,7 +147,7 @@ public class RecurringTransactionProcessingServiceTests
 
         await _mediator.DidNotReceive().Send(Arg.Any<CreateTransactionCommand>(), Arg.Any<CancellationToken>());
 
-        await _repository.Received(1).CreateOccurrenceAsync(
+        await _repository.Received(1).UpdateOccurrenceAsync(
             Arg.Is<RecurringTransactionOccurrence>(o =>
                 o.Status == RecurringTransactionOccurrenceStatus.Notified
                 && o.TransactionId == null),
@@ -137,8 +171,14 @@ public class RecurringTransactionProcessingServiceTests
     {
         var schedule = CreateSchedule(autoCreate: true, nextDueDate: Today);
         SetupDue(schedule);
-        _repository.HasOccurrenceAsync(schedule.Id, Today, Arg.Any<CancellationToken>())
-            .Returns(true); // occurrence already recorded by an earlier run
+        _repository.GetOccurrenceAsync(schedule.Id, Today, Arg.Any<CancellationToken>())
+            .Returns(new RecurringTransactionOccurrence
+            {
+                RecurringTransactionId = schedule.Id,
+                ScheduledDate = Today,
+                Status = RecurringTransactionOccurrenceStatus.Created,
+                TransactionId = 42
+            }); // already fired by an earlier run
 
         var result = await _service.ProcessDueAsync(Today);
 
@@ -146,12 +186,150 @@ public class RecurringTransactionProcessingServiceTests
         result.OccurrencesSkipped.Should().Be(1);
 
         await _mediator.DidNotReceive().Send(Arg.Any<CreateTransactionCommand>(), Arg.Any<CancellationToken>());
-        await _repository.DidNotReceive().CreateOccurrenceAsync(
+        await _repository.DidNotReceive().TryCreateOccurrenceAsync(
+            Arg.Any<RecurringTransactionOccurrence>(), Arg.Any<CancellationToken>());
+        await _repository.DidNotReceive().UpdateOccurrenceAsync(
             Arg.Any<RecurringTransactionOccurrence>(), Arg.Any<CancellationToken>());
 
         // Schedule is still advanced so it doesn't stay overdue
         schedule.NextDueDate.Should().BeAfter(Today);
         await _repository.Received(1).UpdateAsync(schedule, Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task ProcessDueAsync_ConcurrentRunLosesClaimRace_SkipsWithoutFiring()
+    {
+        var schedule = CreateSchedule(autoCreate: true, nextDueDate: Today);
+        SetupDue(schedule);
+        _repository.TryCreateOccurrenceAsync(
+                Arg.Any<RecurringTransactionOccurrence>(), Arg.Any<CancellationToken>())
+            .Returns((RecurringTransactionOccurrence?)null); // unique index rejected the insert
+
+        var result = await _service.ProcessDueAsync(Today);
+
+        result.TransactionsCreated.Should().Be(0);
+        result.OccurrencesSkipped.Should().Be(1);
+
+        await _mediator.DidNotReceive().Send(Arg.Any<CreateTransactionCommand>(), Arg.Any<CancellationToken>());
+        await _notificationTriggerService.DidNotReceiveWithAnyArgs()
+            .NotifyTransactionReminderAsync(default, default!, default, default, default);
+    }
+
+    [Fact]
+    public async Task ProcessDueAsync_StalePendingClaim_IsCompletedWithoutNewClaim()
+    {
+        // A previous run crashed after claiming the occurrence but before creating
+        // the transaction — the next run must finish it, not fire a duplicate.
+        var schedule = CreateSchedule(autoCreate: true, nextDueDate: Today);
+        SetupDue(schedule);
+        var staleClaim = new RecurringTransactionOccurrence
+        {
+            Id = 10,
+            RecurringTransactionId = schedule.Id,
+            ScheduledDate = Today,
+            Status = RecurringTransactionOccurrenceStatus.Pending
+        };
+        _repository.GetOccurrenceAsync(schedule.Id, Today, Arg.Any<CancellationToken>())
+            .Returns(staleClaim);
+        _mediator.Send(Arg.Any<CreateTransactionCommand>(), Arg.Any<CancellationToken>())
+            .Returns(new TransactionDto { Id = 77 });
+
+        var result = await _service.ProcessDueAsync(Today);
+
+        result.TransactionsCreated.Should().Be(1);
+        result.OccurrencesSkipped.Should().Be(0);
+
+        await _repository.DidNotReceive().TryCreateOccurrenceAsync(
+            Arg.Any<RecurringTransactionOccurrence>(), Arg.Any<CancellationToken>());
+
+        staleClaim.Status.Should().Be(RecurringTransactionOccurrenceStatus.Created);
+        staleClaim.TransactionId.Should().Be(77);
+        await _repository.Received(1).UpdateOccurrenceAsync(staleClaim, Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task ProcessDueAsync_FailureBetweenClaimAndTransaction_SecondRunCreatesExactlyOneTransaction()
+    {
+        // Simulate two nightly runs against a shared in-memory occurrence store:
+        // run 1 claims the occurrence, then the transaction creation fails;
+        // run 2 finds the Pending claim and completes it. Exactly one transaction
+        // must exist at the end and no duplicate occurrence rows.
+        var schedule = CreateSchedule(autoCreate: true, nextDueDate: Today);
+        var store = new Dictionary<DateTime, RecurringTransactionOccurrence>();
+
+        _repository.GetDueAsync(Arg.Any<DateTime>(), Arg.Any<CancellationToken>())
+            .Returns(_ => new List<RecurringTransaction> { schedule });
+        _repository.GetOccurrenceAsync(schedule.Id, Arg.Any<DateTime>(), Arg.Any<CancellationToken>())
+            .Returns(ci => store.GetValueOrDefault(ci.ArgAt<DateTime>(1).Date));
+        _repository.TryCreateOccurrenceAsync(
+                Arg.Any<RecurringTransactionOccurrence>(), Arg.Any<CancellationToken>())
+            .Returns(ci =>
+            {
+                var occurrence = ci.Arg<RecurringTransactionOccurrence>();
+                if (store.ContainsKey(occurrence.ScheduledDate.Date))
+                {
+                    return null; // unique index violation
+                }
+
+                store[occurrence.ScheduledDate.Date] = occurrence;
+                return occurrence;
+            });
+
+        var failNextSend = true;
+        var transactionsCreated = 0;
+        _mediator.Send(Arg.Any<CreateTransactionCommand>(), Arg.Any<CancellationToken>())
+            .Returns<TransactionDto>(_ =>
+            {
+                if (failNextSend)
+                {
+                    // First run: transient failure AFTER the claim was persisted
+                    failNextSend = false;
+                    throw new InvalidOperationException("transient db failure");
+                }
+
+                transactionsCreated++;
+                return new TransactionDto { Id = 42 };
+            });
+
+        // Run 1 — fails between claim and transaction creation
+        var firstRun = await _service.ProcessDueAsync(Today);
+        firstRun.SchedulesFailed.Should().Be(1);
+        firstRun.TransactionsCreated.Should().Be(0);
+        store.Should().HaveCount(1);
+        store[Today].Status.Should().Be(RecurringTransactionOccurrenceStatus.Pending);
+        _repository.Received(1).ResetChangeTracking();
+
+        // Run 2 — recovers the stale claim instead of replaying the bill
+        var secondRun = await _service.ProcessDueAsync(Today);
+        secondRun.SchedulesFailed.Should().Be(0);
+        secondRun.TransactionsCreated.Should().Be(1);
+
+        transactionsCreated.Should().Be(1); // exactly one real transaction, ever
+        store.Should().HaveCount(1); // no duplicate occurrence rows
+        store[Today].Status.Should().Be(RecurringTransactionOccurrenceStatus.Created);
+        store[Today].TransactionId.Should().Be(42);
+    }
+
+    [Fact]
+    public async Task ProcessDueAsync_FailedSchedule_ResetsChangeTrackingAndContinues()
+    {
+        var failing = CreateSchedule(autoCreate: true, nextDueDate: Today, id: 1);
+        var healthy = CreateSchedule(autoCreate: false, nextDueDate: Today, id: 2);
+        SetupDue(failing, healthy);
+        _mediator.Send(Arg.Any<CreateTransactionCommand>(), Arg.Any<CancellationToken>())
+            .Returns<TransactionDto>(_ => throw new InvalidOperationException("boom"));
+
+        var result = await _service.ProcessDueAsync(Today);
+
+        result.SchedulesFailed.Should().Be(1);
+        result.SchedulesProcessed.Should().Be(1);
+        result.RemindersSent.Should().Be(1);
+
+        // The poisoned change tracker is cleared so the healthy schedule can save
+        _repository.Received(1).ResetChangeTracking();
+
+        await _notificationTriggerService.Received(1).NotifyTransactionReminderAsync(
+            _userId, "Internet bill", 89.99m, Today, Arg.Any<CancellationToken>());
     }
 
     [Fact]
@@ -169,7 +347,9 @@ public class RecurringTransactionProcessingServiceTests
         var result = await _service.ProcessDueAsync(Today);
 
         result.TransactionsCreated.Should().Be(3);
-        await _repository.Received(3).CreateOccurrenceAsync(
+        await _repository.Received(3).TryCreateOccurrenceAsync(
+            Arg.Any<RecurringTransactionOccurrence>(), Arg.Any<CancellationToken>());
+        await _repository.Received(3).UpdateOccurrenceAsync(
             Arg.Any<RecurringTransactionOccurrence>(), Arg.Any<CancellationToken>());
 
         schedule.NextDueDate.Should().Be(new DateTime(2026, 6, 17));
@@ -195,22 +375,26 @@ public class RecurringTransactionProcessingServiceTests
     }
 
     [Fact]
-    public async Task ProcessDueAsync_OneScheduleFails_OthersStillProcessed()
+    public async Task ProcessDueAsync_AccountSoftDeleted_DeactivatesScheduleWithoutFiring()
     {
-        var failing = CreateSchedule(autoCreate: true, nextDueDate: Today, id: 1);
-        var healthy = CreateSchedule(autoCreate: false, nextDueDate: Today, id: 2);
-        SetupDue(failing, healthy);
-        _mediator.Send(Arg.Any<CreateTransactionCommand>(), Arg.Any<CancellationToken>())
-            .Returns<TransactionDto>(_ => throw new InvalidOperationException("boom"));
+        var schedule = CreateSchedule(autoCreate: true, nextDueDate: Today);
+        SetupDue(schedule);
+        _repository.AccountExistsAsync(schedule.AccountId, Arg.Any<CancellationToken>())
+            .Returns(false);
 
         var result = await _service.ProcessDueAsync(Today);
 
-        result.SchedulesFailed.Should().Be(1);
-        result.SchedulesProcessed.Should().Be(1);
-        result.RemindersSent.Should().Be(1);
+        result.SchedulesDeactivated.Should().Be(1);
+        result.TransactionsCreated.Should().Be(0);
+        result.RemindersSent.Should().Be(0);
+        schedule.IsActive.Should().BeFalse();
 
-        await _notificationTriggerService.Received(1).NotifyTransactionReminderAsync(
-            _userId, "Internet bill", 89.99m, Today, Arg.Any<CancellationToken>());
+        await _mediator.DidNotReceive().Send(Arg.Any<CreateTransactionCommand>(), Arg.Any<CancellationToken>());
+        await _notificationTriggerService.DidNotReceiveWithAnyArgs()
+            .NotifyTransactionReminderAsync(default, default!, default, default, default);
+        await _repository.DidNotReceive().TryCreateOccurrenceAsync(
+            Arg.Any<RecurringTransactionOccurrence>(), Arg.Any<CancellationToken>());
+        await _repository.Received(1).UpdateAsync(schedule, Arg.Any<CancellationToken>());
     }
 
     [Fact]

--- a/tests/MyMascada.Tests.Unit/Features/RecurringTransactions/Services/RecurringTransactionProcessingServiceTests.cs
+++ b/tests/MyMascada.Tests.Unit/Features/RecurringTransactions/Services/RecurringTransactionProcessingServiceTests.cs
@@ -1,0 +1,229 @@
+using MediatR;
+using Microsoft.Extensions.Logging;
+using MyMascada.Application.Common.Interfaces;
+using MyMascada.Application.Features.RecurringTransactions.Services;
+using MyMascada.Application.Features.Transactions.Commands;
+using MyMascada.Application.Features.Transactions.DTOs;
+using MyMascada.Domain.Entities;
+using MyMascada.Domain.Enums;
+
+namespace MyMascada.Tests.Unit.Features.RecurringTransactions.Services;
+
+public class RecurringTransactionProcessingServiceTests
+{
+    private readonly IRecurringTransactionRepository _repository = Substitute.For<IRecurringTransactionRepository>();
+    private readonly IMediator _mediator = Substitute.For<IMediator>();
+    private readonly INotificationTriggerService _notificationTriggerService = Substitute.For<INotificationTriggerService>();
+    private readonly RecurringTransactionProcessingService _service;
+
+    private readonly Guid _userId = Guid.NewGuid();
+    private static readonly DateTime Today = new(2026, 6, 10);
+
+    public RecurringTransactionProcessingServiceTests()
+    {
+        _service = new RecurringTransactionProcessingService(
+            _repository,
+            _mediator,
+            _notificationTriggerService,
+            Substitute.For<ILogger<RecurringTransactionProcessingService>>());
+    }
+
+    private RecurringTransaction CreateSchedule(
+        bool autoCreate,
+        DateTime nextDueDate,
+        RecurrenceFrequency frequency = RecurrenceFrequency.Monthly,
+        DateTime? endDate = null,
+        int id = 1)
+    {
+        return new RecurringTransaction
+        {
+            Id = id,
+            UserId = _userId,
+            AccountId = 7,
+            CategoryId = 3,
+            Description = "Internet bill",
+            Amount = 89.99m,
+            Frequency = frequency,
+            StartDate = nextDueDate,
+            EndDate = endDate,
+            NextDueDate = nextDueDate,
+            AutoCreate = autoCreate,
+            IsActive = true,
+            Notes = "ISP plan"
+        };
+    }
+
+    private void SetupDue(params RecurringTransaction[] schedules)
+    {
+        _repository.GetDueAsync(Arg.Any<DateTime>(), Arg.Any<CancellationToken>())
+            .Returns(schedules.ToList());
+    }
+
+    [Fact]
+    public async Task ProcessDueAsync_AutoCreateSchedule_CreatesPendingNegativeTransaction()
+    {
+        var schedule = CreateSchedule(autoCreate: true, nextDueDate: Today);
+        SetupDue(schedule);
+        _mediator.Send(Arg.Any<CreateTransactionCommand>(), Arg.Any<CancellationToken>())
+            .Returns(new TransactionDto { Id = 42 });
+
+        var result = await _service.ProcessDueAsync(Today);
+
+        result.TransactionsCreated.Should().Be(1);
+        result.RemindersSent.Should().Be(0);
+        result.SchedulesProcessed.Should().Be(1);
+
+        await _mediator.Received(1).Send(
+            Arg.Is<CreateTransactionCommand>(c =>
+                c.UserId == _userId
+                && c.AccountId == 7
+                && c.CategoryId == 3
+                && c.Amount == -89.99m // expenses are stored negative
+                && c.Status == TransactionStatus.Pending
+                && c.TransactionDate == Today
+                && c.Description == "Internet bill"
+                && c.AllowDuplicates),
+            Arg.Any<CancellationToken>());
+
+        await _repository.Received(1).CreateOccurrenceAsync(
+            Arg.Is<RecurringTransactionOccurrence>(o =>
+                o.RecurringTransactionId == schedule.Id
+                && o.ScheduledDate == Today
+                && o.Status == RecurringTransactionOccurrenceStatus.Created
+                && o.TransactionId == 42),
+            Arg.Any<CancellationToken>());
+
+        await _notificationTriggerService.DidNotReceiveWithAnyArgs()
+            .NotifyTransactionReminderAsync(default, default!, default, default, default);
+    }
+
+    [Fact]
+    public async Task ProcessDueAsync_RemindOnlySchedule_SendsReminderInsteadOfCreating()
+    {
+        var schedule = CreateSchedule(autoCreate: false, nextDueDate: Today);
+        SetupDue(schedule);
+
+        var result = await _service.ProcessDueAsync(Today);
+
+        result.RemindersSent.Should().Be(1);
+        result.TransactionsCreated.Should().Be(0);
+
+        await _notificationTriggerService.Received(1).NotifyTransactionReminderAsync(
+            _userId, "Internet bill", 89.99m, Today, Arg.Any<CancellationToken>());
+
+        await _mediator.DidNotReceive().Send(Arg.Any<CreateTransactionCommand>(), Arg.Any<CancellationToken>());
+
+        await _repository.Received(1).CreateOccurrenceAsync(
+            Arg.Is<RecurringTransactionOccurrence>(o =>
+                o.Status == RecurringTransactionOccurrenceStatus.Notified
+                && o.TransactionId == null),
+            Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task ProcessDueAsync_AdvancesNextDueDatePastToday()
+    {
+        var schedule = CreateSchedule(autoCreate: false, nextDueDate: Today);
+        SetupDue(schedule);
+
+        await _service.ProcessDueAsync(Today);
+
+        schedule.NextDueDate.Should().Be(new DateTime(2026, 7, 10));
+        await _repository.Received(1).UpdateAsync(schedule, Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task ProcessDueAsync_RunTwiceInSameDay_IsIdempotent()
+    {
+        var schedule = CreateSchedule(autoCreate: true, nextDueDate: Today);
+        SetupDue(schedule);
+        _repository.HasOccurrenceAsync(schedule.Id, Today, Arg.Any<CancellationToken>())
+            .Returns(true); // occurrence already recorded by an earlier run
+
+        var result = await _service.ProcessDueAsync(Today);
+
+        result.TransactionsCreated.Should().Be(0);
+        result.OccurrencesSkipped.Should().Be(1);
+
+        await _mediator.DidNotReceive().Send(Arg.Any<CreateTransactionCommand>(), Arg.Any<CancellationToken>());
+        await _repository.DidNotReceive().CreateOccurrenceAsync(
+            Arg.Any<RecurringTransactionOccurrence>(), Arg.Any<CancellationToken>());
+
+        // Schedule is still advanced so it doesn't stay overdue
+        schedule.NextDueDate.Should().BeAfter(Today);
+        await _repository.Received(1).UpdateAsync(schedule, Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task ProcessDueAsync_MissedDays_CatchesUpEachScheduledDate()
+    {
+        // Weekly schedule that was last due 2 weeks ago: 5/27, 6/3, 6/10 are all due
+        var schedule = CreateSchedule(
+            autoCreate: true,
+            nextDueDate: new DateTime(2026, 5, 27),
+            frequency: RecurrenceFrequency.Weekly);
+        SetupDue(schedule);
+        _mediator.Send(Arg.Any<CreateTransactionCommand>(), Arg.Any<CancellationToken>())
+            .Returns(new TransactionDto { Id = 42 });
+
+        var result = await _service.ProcessDueAsync(Today);
+
+        result.TransactionsCreated.Should().Be(3);
+        await _repository.Received(3).CreateOccurrenceAsync(
+            Arg.Any<RecurringTransactionOccurrence>(), Arg.Any<CancellationToken>());
+
+        schedule.NextDueDate.Should().Be(new DateTime(2026, 6, 17));
+    }
+
+    [Fact]
+    public async Task ProcessDueAsync_SchedulePastEndDate_IsDeactivated()
+    {
+        var schedule = CreateSchedule(
+            autoCreate: false,
+            nextDueDate: Today,
+            frequency: RecurrenceFrequency.Weekly,
+            endDate: Today); // last occurrence is today
+
+        SetupDue(schedule);
+
+        var result = await _service.ProcessDueAsync(Today);
+
+        result.RemindersSent.Should().Be(1);
+        result.SchedulesDeactivated.Should().Be(1);
+        schedule.IsActive.Should().BeFalse();
+        await _repository.Received(1).UpdateAsync(schedule, Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task ProcessDueAsync_OneScheduleFails_OthersStillProcessed()
+    {
+        var failing = CreateSchedule(autoCreate: true, nextDueDate: Today, id: 1);
+        var healthy = CreateSchedule(autoCreate: false, nextDueDate: Today, id: 2);
+        SetupDue(failing, healthy);
+        _mediator.Send(Arg.Any<CreateTransactionCommand>(), Arg.Any<CancellationToken>())
+            .Returns<TransactionDto>(_ => throw new InvalidOperationException("boom"));
+
+        var result = await _service.ProcessDueAsync(Today);
+
+        result.SchedulesFailed.Should().Be(1);
+        result.SchedulesProcessed.Should().Be(1);
+        result.RemindersSent.Should().Be(1);
+
+        await _notificationTriggerService.Received(1).NotifyTransactionReminderAsync(
+            _userId, "Internet bill", 89.99m, Today, Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task ProcessDueAsync_NoDueSchedules_DoesNothing()
+    {
+        SetupDue();
+
+        var result = await _service.ProcessDueAsync(Today);
+
+        result.SchedulesProcessed.Should().Be(0);
+        result.TransactionsCreated.Should().Be(0);
+        result.RemindersSent.Should().Be(0);
+        await _repository.DidNotReceive().UpdateAsync(
+            Arg.Any<RecurringTransaction>(), Arg.Any<CancellationToken>());
+    }
+}

--- a/tests/MyMascada.Tests.Unit/Features/RecurringTransactions/Services/RecurringTransactionProcessingServiceTests.cs
+++ b/tests/MyMascada.Tests.Unit/Features/RecurringTransactions/Services/RecurringTransactionProcessingServiceTests.cs
@@ -14,6 +14,8 @@ public class RecurringTransactionProcessingServiceTests
     private readonly IRecurringTransactionRepository _repository = Substitute.For<IRecurringTransactionRepository>();
     private readonly IMediator _mediator = Substitute.For<IMediator>();
     private readonly INotificationTriggerService _notificationTriggerService = Substitute.For<INotificationTriggerService>();
+    private readonly IAccountAccessService _accountAccessService = Substitute.For<IAccountAccessService>();
+    private readonly FakeUnitOfWork _unitOfWork = new();
     private readonly RecurringTransactionProcessingService _service;
 
     private readonly Guid _userId = Guid.NewGuid();
@@ -25,10 +27,17 @@ public class RecurringTransactionProcessingServiceTests
             _repository,
             _mediator,
             _notificationTriggerService,
+            _accountAccessService,
+            _unitOfWork,
             Substitute.For<ILogger<RecurringTransactionProcessingService>>());
 
-        // Default: account exists; occurrence claims succeed and echo the claim back.
+        // Default: account exists and the owner retains full access; occurrence
+        // claims succeed and echo the claim back.
         _repository.AccountExistsAsync(Arg.Any<int>(), Arg.Any<CancellationToken>())
+            .Returns(true);
+        _accountAccessService.CanModifyAccountAsync(Arg.Any<Guid>(), Arg.Any<int>())
+            .Returns(true);
+        _accountAccessService.CanAccessAccountAsync(Arg.Any<Guid>(), Arg.Any<int>())
             .Returns(true);
         _repository.TryCreateOccurrenceAsync(
                 Arg.Any<RecurringTransactionOccurrence>(), Arg.Any<CancellationToken>())
@@ -313,6 +322,139 @@ public class RecurringTransactionProcessingServiceTests
     }
 
     [Fact]
+    public async Task ProcessDueAsync_AutoCreate_TransactionInsertAndOccurrenceFinalizeShareOneDbTransaction()
+    {
+        var schedule = CreateSchedule(autoCreate: true, nextDueDate: Today);
+        SetupDue(schedule);
+        _mediator.Send(Arg.Any<CreateTransactionCommand>(), Arg.Any<CancellationToken>())
+            .Returns(_ =>
+            {
+                _unitOfWork.Events.Add("createTransaction");
+                return new TransactionDto { Id = 42 };
+            });
+        _repository.UpdateOccurrenceAsync(
+                Arg.Any<RecurringTransactionOccurrence>(), Arg.Any<CancellationToken>())
+            .Returns(ci =>
+            {
+                _unitOfWork.Events.Add("finalizeOccurrence");
+                return ci.Arg<RecurringTransactionOccurrence>();
+            });
+
+        await _service.ProcessDueAsync(Today);
+
+        // Both writes happen inside the same ambient transaction, committed after both
+        _unitOfWork.Events.Should().Equal("begin", "createTransaction", "finalizeOccurrence", "commit");
+    }
+
+    [Fact]
+    public async Task ProcessDueAsync_CrashBetweenTransactionInsertAndOccurrenceFinalize_CannotDoubleCreate()
+    {
+        // Reproduces the reviewed crash window: CreateTransactionCommand succeeds
+        // but the process dies / the occurrence update fails before the claim is
+        // marked Created. With the ambient DB transaction both writes roll back
+        // together, so the recovery run re-creates the transaction exactly once.
+        // The fake unit of work mirrors DB semantics: writes staged inside an
+        // uncommitted transaction are discarded; reads return fresh copies (the
+        // real job detaches everything via ResetChangeTracking after a failure).
+        var schedule = CreateSchedule(autoCreate: true, nextDueDate: Today);
+        _repository.GetDueAsync(Arg.Any<DateTime>(), Arg.Any<CancellationToken>())
+            .Returns(_ => new List<RecurringTransaction> { schedule });
+
+        static RecurringTransactionOccurrence Clone(RecurringTransactionOccurrence o) => new()
+        {
+            Id = o.Id,
+            RecurringTransactionId = o.RecurringTransactionId,
+            ScheduledDate = o.ScheduledDate,
+            Status = o.Status,
+            TransactionId = o.TransactionId
+        };
+
+        // Durable store. Claims commit immediately (they are inserted before the
+        // ambient transaction begins); reads hand out copies so in-memory mutations
+        // by the service cannot leak into "the database".
+        var store = new Dictionary<DateTime, RecurringTransactionOccurrence>();
+        _repository.GetOccurrenceAsync(schedule.Id, Arg.Any<DateTime>(), Arg.Any<CancellationToken>())
+            .Returns(ci =>
+            {
+                var row = store.GetValueOrDefault(ci.ArgAt<DateTime>(1).Date);
+                return row == null ? null : Clone(row);
+            });
+        _repository.TryCreateOccurrenceAsync(
+                Arg.Any<RecurringTransactionOccurrence>(), Arg.Any<CancellationToken>())
+            .Returns(ci =>
+            {
+                var occurrence = ci.Arg<RecurringTransactionOccurrence>();
+                if (store.ContainsKey(occurrence.ScheduledDate.Date))
+                {
+                    return null; // unique index violation
+                }
+
+                store[occurrence.ScheduledDate.Date] = Clone(occurrence);
+                return occurrence;
+            });
+
+        // Writes staged inside the ambient transaction become durable only on commit
+        var committedTransactions = 0;
+        var stagedTransactions = 0;
+        RecurringTransactionOccurrence? stagedOccurrence = null;
+        _unitOfWork.OnCommit = () =>
+        {
+            committedTransactions += stagedTransactions;
+            stagedTransactions = 0;
+            if (stagedOccurrence != null)
+            {
+                store[stagedOccurrence.ScheduledDate.Date] = stagedOccurrence;
+                stagedOccurrence = null;
+            }
+        };
+        _unitOfWork.OnRollback = () =>
+        {
+            stagedTransactions = 0;
+            stagedOccurrence = null;
+        };
+
+        _mediator.Send(Arg.Any<CreateTransactionCommand>(), Arg.Any<CancellationToken>())
+            .Returns(_ =>
+            {
+                stagedTransactions++; // the money record insert SUCCEEDED
+                return new TransactionDto { Id = 42 };
+            });
+
+        var failNextFinalize = true;
+        _repository.UpdateOccurrenceAsync(
+                Arg.Any<RecurringTransactionOccurrence>(), Arg.Any<CancellationToken>())
+            .Returns(ci =>
+            {
+                if (failNextFinalize)
+                {
+                    failNextFinalize = false; // run 1 dies AFTER the transaction insert
+                    throw new InvalidOperationException("process died before occurrence finalize");
+                }
+
+                stagedOccurrence = Clone(ci.Arg<RecurringTransactionOccurrence>());
+                return ci.Arg<RecurringTransactionOccurrence>();
+            });
+
+        // Run 1 — transaction inserted, finalize failed → the whole unit rolls back
+        var firstRun = await _service.ProcessDueAsync(Today);
+        firstRun.SchedulesFailed.Should().Be(1);
+        firstRun.TransactionsCreated.Should().Be(0);
+        committedTransactions.Should().Be(0, "the rolled-back transaction must not be durable");
+        store[Today].Status.Should().Be(RecurringTransactionOccurrenceStatus.Pending);
+        store[Today].TransactionId.Should().BeNull();
+
+        // Run 2 — recovers the stale Pending claim and fires exactly once
+        var secondRun = await _service.ProcessDueAsync(Today);
+        secondRun.SchedulesFailed.Should().Be(0);
+        secondRun.TransactionsCreated.Should().Be(1);
+
+        committedTransactions.Should().Be(1); // exactly one durable money record, ever
+        store.Should().HaveCount(1); // no duplicate occurrence rows
+        store[Today].Status.Should().Be(RecurringTransactionOccurrenceStatus.Created);
+        store[Today].TransactionId.Should().Be(42);
+    }
+
+    [Fact]
     public async Task ProcessDueAsync_FailedSchedule_ResetsChangeTrackingAndContinues()
     {
         var failing = CreateSchedule(autoCreate: true, nextDueDate: Today, id: 1);
@@ -430,6 +572,69 @@ public class RecurringTransactionProcessingServiceTests
     }
 
     [Fact]
+    public async Task ProcessDueAsync_AutoCreateWithModifyAccessRevoked_PausesScheduleWithoutFiring()
+    {
+        // Share revoked/downgraded after the schedule was created: auto-create
+        // would fail CreateTransactionCommand's modify-access check every night.
+        var schedule = CreateSchedule(autoCreate: true, nextDueDate: Today);
+        SetupDue(schedule);
+        _accountAccessService.CanModifyAccountAsync(_userId, schedule.AccountId).Returns(false);
+
+        var result = await _service.ProcessDueAsync(Today);
+
+        result.SchedulesDeactivated.Should().Be(1);
+        result.TransactionsCreated.Should().Be(0);
+        result.SchedulesFailed.Should().Be(0);
+        schedule.IsActive.Should().BeFalse();
+
+        await _mediator.DidNotReceive().Send(Arg.Any<CreateTransactionCommand>(), Arg.Any<CancellationToken>());
+        await _repository.DidNotReceive().TryCreateOccurrenceAsync(
+            Arg.Any<RecurringTransactionOccurrence>(), Arg.Any<CancellationToken>());
+        await _repository.Received(1).UpdateAsync(schedule, Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task ProcessDueAsync_RemindOnlyWithViewAccessRevoked_PausesScheduleWithoutGhostReminder()
+    {
+        // The user can no longer see the account at all — keeping the nightly
+        // reminder alive would notify about an account they have no access to.
+        var schedule = CreateSchedule(autoCreate: false, nextDueDate: Today);
+        SetupDue(schedule);
+        _accountAccessService.CanAccessAccountAsync(_userId, schedule.AccountId).Returns(false);
+
+        var result = await _service.ProcessDueAsync(Today);
+
+        result.SchedulesDeactivated.Should().Be(1);
+        result.RemindersSent.Should().Be(0);
+        schedule.IsActive.Should().BeFalse();
+
+        await _notificationTriggerService.DidNotReceiveWithAnyArgs()
+            .NotifyTransactionReminderAsync(default, default!, default, default, default);
+        await _repository.DidNotReceive().TryCreateOccurrenceAsync(
+            Arg.Any<RecurringTransactionOccurrence>(), Arg.Any<CancellationToken>());
+        await _repository.Received(1).UpdateAsync(schedule, Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task ProcessDueAsync_RemindOnlyDowngradedToViewer_StillSendsReminder()
+    {
+        // Viewer access is enough for reminder-only schedules — only modify
+        // access was lost, so the reminder keeps firing.
+        var schedule = CreateSchedule(autoCreate: false, nextDueDate: Today);
+        SetupDue(schedule);
+        _accountAccessService.CanModifyAccountAsync(_userId, schedule.AccountId).Returns(false);
+
+        var result = await _service.ProcessDueAsync(Today);
+
+        result.RemindersSent.Should().Be(1);
+        result.SchedulesDeactivated.Should().Be(0);
+        schedule.IsActive.Should().BeTrue();
+
+        await _notificationTriggerService.Received(1).NotifyTransactionReminderAsync(
+            _userId, "Internet bill", 89.99m, Today, Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
     public async Task ProcessDueAsync_NoDueSchedules_DoesNothing()
     {
         SetupDue();
@@ -441,5 +646,51 @@ public class RecurringTransactionProcessingServiceTests
         result.RemindersSent.Should().Be(0);
         await _repository.DidNotReceive().UpdateAsync(
             Arg.Any<RecurringTransaction>(), Arg.Any<CancellationToken>());
+    }
+
+    /// <summary>
+    /// Hand-rolled IUnitOfWork fake: records begin/commit/rollback events so tests
+    /// can assert what runs inside the ambient transaction, and exposes OnCommit /
+    /// OnRollback hooks so tests can simulate database durability (writes staged
+    /// inside an uncommitted transaction are discarded on rollback).
+    /// </summary>
+    private sealed class FakeUnitOfWork : IUnitOfWork
+    {
+        public List<string> Events { get; } = new();
+        public Action? OnCommit { get; set; }
+        public Action? OnRollback { get; set; }
+
+        public Task<IUnitOfWorkTransaction> BeginTransactionAsync(CancellationToken cancellationToken = default)
+        {
+            Events.Add("begin");
+            return Task.FromResult<IUnitOfWorkTransaction>(new FakeTransaction(this));
+        }
+
+        private sealed class FakeTransaction : IUnitOfWorkTransaction
+        {
+            private readonly FakeUnitOfWork _owner;
+            private bool _committed;
+
+            public FakeTransaction(FakeUnitOfWork owner) => _owner = owner;
+
+            public Task CommitAsync(CancellationToken cancellationToken = default)
+            {
+                _committed = true;
+                _owner.Events.Add("commit");
+                _owner.OnCommit?.Invoke();
+                return Task.CompletedTask;
+            }
+
+            public ValueTask DisposeAsync()
+            {
+                if (!_committed)
+                {
+                    _owner.Events.Add("rollback");
+                    _owner.OnRollback?.Invoke();
+                }
+
+                return ValueTask.CompletedTask;
+            }
+        }
     }
 }

--- a/tests/MyMascada.Tests.Unit/Features/RecurringTransactions/Validators/RecurringTransactionCommandValidatorTests.cs
+++ b/tests/MyMascada.Tests.Unit/Features/RecurringTransactions/Validators/RecurringTransactionCommandValidatorTests.cs
@@ -1,0 +1,240 @@
+using MyMascada.Application.Features.RecurringTransactions.Commands;
+using MyMascada.Application.Features.RecurringTransactions.Validators;
+using MyMascada.Domain.Enums;
+
+namespace MyMascada.Tests.Unit.Features.RecurringTransactions.Validators;
+
+public class RecurringTransactionCommandValidatorTests
+{
+    private readonly CreateRecurringTransactionCommandValidator _createValidator = new();
+    private readonly UpdateRecurringTransactionCommandValidator _updateValidator = new();
+
+    private static CreateRecurringTransactionCommand ValidCommand()
+    {
+        return new CreateRecurringTransactionCommand
+        {
+            UserId = Guid.NewGuid(),
+            AccountId = 1,
+            CategoryId = 2,
+            Description = "Rent",
+            Amount = 1200m,
+            Frequency = RecurrenceFrequency.Monthly,
+            StartDate = new DateTime(2026, 7, 1),
+            EndDate = new DateTime(2027, 7, 1),
+            AutoCreate = false,
+            Notes = "Apartment rent"
+        };
+    }
+
+    [Fact]
+    public void Validate_ValidCommand_Passes()
+    {
+        var result = _createValidator.Validate(ValidCommand());
+
+        result.IsValid.Should().BeTrue();
+    }
+
+    [Theory]
+    [InlineData(0)]
+    [InlineData(-10)]
+    public void Validate_NonPositiveAmount_Fails(decimal amount)
+    {
+        var command = ValidCommand();
+        command.Amount = amount;
+
+        var result = _createValidator.Validate(command);
+
+        result.IsValid.Should().BeFalse();
+        result.Errors.Should().Contain(e => e.PropertyName == nameof(command.Amount));
+    }
+
+    [Fact]
+    public void Validate_InvalidAccountId_Fails()
+    {
+        var command = ValidCommand();
+        command.AccountId = 0;
+
+        var result = _createValidator.Validate(command);
+
+        result.IsValid.Should().BeFalse();
+        result.Errors.Should().Contain(e => e.PropertyName == nameof(command.AccountId));
+    }
+
+    [Fact]
+    public void Validate_EmptyDescription_Fails()
+    {
+        var command = ValidCommand();
+        command.Description = "";
+
+        var result = _createValidator.Validate(command);
+
+        result.IsValid.Should().BeFalse();
+        result.Errors.Should().Contain(e => e.PropertyName == nameof(command.Description));
+    }
+
+    [Fact]
+    public void Validate_DescriptionTooLong_Fails()
+    {
+        var command = ValidCommand();
+        command.Description = new string('x', 201);
+
+        var result = _createValidator.Validate(command);
+
+        result.IsValid.Should().BeFalse();
+    }
+
+    [Fact]
+    public void Validate_EndDateBeforeStartDate_Fails()
+    {
+        var command = ValidCommand();
+        command.StartDate = new DateTime(2026, 7, 1);
+        command.EndDate = new DateTime(2026, 6, 30);
+
+        var result = _createValidator.Validate(command);
+
+        result.IsValid.Should().BeFalse();
+        result.Errors.Should().Contain(e => e.PropertyName == nameof(command.EndDate));
+    }
+
+    [Fact]
+    public void Validate_EndDateEqualToStartDate_Passes()
+    {
+        var command = ValidCommand();
+        command.StartDate = new DateTime(2026, 7, 1);
+        command.EndDate = new DateTime(2026, 7, 1);
+
+        var result = _createValidator.Validate(command);
+
+        result.IsValid.Should().BeTrue();
+    }
+
+    [Fact]
+    public void Validate_NoEndDate_Passes()
+    {
+        var command = ValidCommand();
+        command.EndDate = null;
+
+        var result = _createValidator.Validate(command);
+
+        result.IsValid.Should().BeTrue();
+    }
+
+    [Fact]
+    public void Validate_CustomFrequencyWithoutInterval_Fails()
+    {
+        var command = ValidCommand();
+        command.Frequency = RecurrenceFrequency.Custom;
+        command.CustomIntervalDays = null;
+
+        var result = _createValidator.Validate(command);
+
+        result.IsValid.Should().BeFalse();
+        result.Errors.Should().Contain(e => e.PropertyName == nameof(command.CustomIntervalDays));
+    }
+
+    [Theory]
+    [InlineData(0)]
+    [InlineData(-1)]
+    [InlineData(367)]
+    public void Validate_CustomIntervalOutOfRange_Fails(int intervalDays)
+    {
+        var command = ValidCommand();
+        command.Frequency = RecurrenceFrequency.Custom;
+        command.CustomIntervalDays = intervalDays;
+
+        var result = _createValidator.Validate(command);
+
+        result.IsValid.Should().BeFalse();
+        result.Errors.Should().Contain(e => e.PropertyName == nameof(command.CustomIntervalDays));
+    }
+
+    [Theory]
+    [InlineData(1)]
+    [InlineData(30)]
+    [InlineData(366)]
+    public void Validate_CustomIntervalInRange_Passes(int intervalDays)
+    {
+        var command = ValidCommand();
+        command.Frequency = RecurrenceFrequency.Custom;
+        command.CustomIntervalDays = intervalDays;
+
+        var result = _createValidator.Validate(command);
+
+        result.IsValid.Should().BeTrue();
+    }
+
+    [Fact]
+    public void Validate_NonCustomFrequency_IgnoresIntervalDays()
+    {
+        var command = ValidCommand();
+        command.Frequency = RecurrenceFrequency.Monthly;
+        command.CustomIntervalDays = null;
+
+        var result = _createValidator.Validate(command);
+
+        result.IsValid.Should().BeTrue();
+    }
+
+    [Fact]
+    public void Validate_InvalidFrequency_Fails()
+    {
+        var command = ValidCommand();
+        command.Frequency = (RecurrenceFrequency)99;
+
+        var result = _createValidator.Validate(command);
+
+        result.IsValid.Should().BeFalse();
+        result.Errors.Should().Contain(e => e.PropertyName == nameof(command.Frequency));
+    }
+
+    [Fact]
+    public void Validate_NotesTooLong_Fails()
+    {
+        var command = ValidCommand();
+        command.Notes = new string('x', 501);
+
+        var result = _createValidator.Validate(command);
+
+        result.IsValid.Should().BeFalse();
+        result.Errors.Should().Contain(e => e.PropertyName == nameof(command.Notes));
+    }
+
+    [Fact]
+    public void ValidateUpdate_InvalidId_Fails()
+    {
+        var command = new UpdateRecurringTransactionCommand
+        {
+            Id = 0,
+            UserId = Guid.NewGuid(),
+            AccountId = 1,
+            Description = "Rent",
+            Amount = 1200m,
+            Frequency = RecurrenceFrequency.Monthly,
+            StartDate = new DateTime(2026, 7, 1)
+        };
+
+        var result = _updateValidator.Validate(command);
+
+        result.IsValid.Should().BeFalse();
+        result.Errors.Should().Contain(e => e.PropertyName == nameof(command.Id));
+    }
+
+    [Fact]
+    public void ValidateUpdate_ValidCommand_Passes()
+    {
+        var command = new UpdateRecurringTransactionCommand
+        {
+            Id = 5,
+            UserId = Guid.NewGuid(),
+            AccountId = 1,
+            Description = "Rent",
+            Amount = 1200m,
+            Frequency = RecurrenceFrequency.Weekly,
+            StartDate = new DateTime(2026, 7, 1)
+        };
+
+        var result = _updateValidator.Validate(command);
+
+        result.IsValid.Should().BeTrue();
+    }
+}

--- a/tests/MyMascada.Tests.Unit/Repositories/RecurringTransactionRepositoryTests.cs
+++ b/tests/MyMascada.Tests.Unit/Repositories/RecurringTransactionRepositoryTests.cs
@@ -193,4 +193,95 @@ public class RecurringTransactionRepositoryTests : IDisposable
 
         recent.Should().BeEmpty();
     }
+
+    [Fact]
+    public async Task GetOccurrenceAsync_ReturnsMatchingOccurrenceOrNull()
+    {
+        var created = await _repository.CreateAsync(NewSchedule());
+        var date = new DateTime(2026, 6, 15, 0, 0, 0, DateTimeKind.Utc);
+
+        (await _repository.GetOccurrenceAsync(created.Id, date)).Should().BeNull();
+
+        await _repository.CreateOccurrenceAsync(new RecurringTransactionOccurrence
+        {
+            RecurringTransactionId = created.Id,
+            ScheduledDate = date,
+            Status = RecurringTransactionOccurrenceStatus.Pending
+        });
+
+        var found = await _repository.GetOccurrenceAsync(created.Id, date);
+        found.Should().NotBeNull();
+        found!.Status.Should().Be(RecurringTransactionOccurrenceStatus.Pending);
+        (await _repository.GetOccurrenceAsync(created.Id, date.AddDays(1))).Should().BeNull();
+    }
+
+    [Fact]
+    public async Task TryCreateOccurrenceAsync_Succeeds_AndPersistsClaim()
+    {
+        var created = await _repository.CreateAsync(NewSchedule());
+        var date = new DateTime(2026, 6, 15, 0, 0, 0, DateTimeKind.Utc);
+
+        var claim = await _repository.TryCreateOccurrenceAsync(new RecurringTransactionOccurrence
+        {
+            RecurringTransactionId = created.Id,
+            ScheduledDate = date,
+            Status = RecurringTransactionOccurrenceStatus.Pending
+        });
+
+        claim.Should().NotBeNull();
+        claim!.Id.Should().BeGreaterThan(0);
+        (await _repository.HasOccurrenceAsync(created.Id, date)).Should().BeTrue();
+    }
+
+    [Fact]
+    public async Task UpdateOccurrenceAsync_PersistsCompletion()
+    {
+        var created = await _repository.CreateAsync(NewSchedule());
+        var date = new DateTime(2026, 6, 15, 0, 0, 0, DateTimeKind.Utc);
+        var claim = await _repository.CreateOccurrenceAsync(new RecurringTransactionOccurrence
+        {
+            RecurringTransactionId = created.Id,
+            ScheduledDate = date,
+            Status = RecurringTransactionOccurrenceStatus.Pending
+        });
+
+        claim.Status = RecurringTransactionOccurrenceStatus.Created;
+        claim.TransactionId = 42;
+        await _repository.UpdateOccurrenceAsync(claim);
+
+        var stored = await _context.RecurringTransactionOccurrences.SingleAsync();
+        stored.Status.Should().Be(RecurringTransactionOccurrenceStatus.Created);
+        stored.TransactionId.Should().Be(42);
+    }
+
+    [Fact]
+    public async Task AccountExistsAsync_TracksSoftDeletion()
+    {
+        (await _repository.AccountExistsAsync(_accountId)).Should().BeTrue();
+        (await _repository.AccountExistsAsync(_accountId + 999)).Should().BeFalse();
+
+        var account = await _context.Accounts.SingleAsync(a => a.Id == _accountId);
+        account.IsDeleted = true;
+        account.DeletedAt = DateTime.UtcNow;
+        await _context.SaveChangesAsync();
+
+        (await _repository.AccountExistsAsync(_accountId)).Should().BeFalse();
+    }
+
+    [Fact]
+    public async Task ResetChangeTracking_AllowsSubsequentSaves()
+    {
+        var created = await _repository.CreateAsync(NewSchedule());
+
+        _repository.ResetChangeTracking();
+
+        // Detached entities can still be updated and saved afterwards
+        created.Description = "Updated after reset";
+        await _repository.UpdateAsync(created);
+
+        var stored = await _context.RecurringTransactions
+            .AsNoTracking()
+            .SingleAsync(r => r.Id == created.Id);
+        stored.Description.Should().Be("Updated after reset");
+    }
 }

--- a/tests/MyMascada.Tests.Unit/Repositories/RecurringTransactionRepositoryTests.cs
+++ b/tests/MyMascada.Tests.Unit/Repositories/RecurringTransactionRepositoryTests.cs
@@ -1,0 +1,196 @@
+using Microsoft.EntityFrameworkCore;
+using MyMascada.Domain.Entities;
+using MyMascada.Domain.Enums;
+using MyMascada.Infrastructure.Data;
+using MyMascada.Infrastructure.Repositories;
+
+namespace MyMascada.Tests.Unit.Repositories;
+
+public class RecurringTransactionRepositoryTests : IDisposable
+{
+    private readonly ApplicationDbContext _context;
+    private readonly RecurringTransactionRepository _repository;
+    private readonly Guid _userId = Guid.NewGuid();
+    private readonly Guid _otherUserId = Guid.NewGuid();
+    private int _accountId;
+
+    public RecurringTransactionRepositoryTests()
+    {
+        var options = new DbContextOptionsBuilder<ApplicationDbContext>()
+            .UseInMemoryDatabase(databaseName: Guid.NewGuid().ToString())
+            .Options;
+
+        _context = new ApplicationDbContext(options);
+        _repository = new RecurringTransactionRepository(_context);
+
+        var account = new Account { Name = "Checking", UserId = _userId };
+        _context.Accounts.Add(account);
+        _context.SaveChanges();
+        _accountId = account.Id;
+    }
+
+    public void Dispose()
+    {
+        _context.Dispose();
+        GC.SuppressFinalize(this);
+    }
+
+    private RecurringTransaction NewSchedule(
+        Guid? userId = null,
+        bool isActive = true,
+        DateTime? nextDueDate = null)
+    {
+        return new RecurringTransaction
+        {
+            UserId = userId ?? _userId,
+            AccountId = _accountId,
+            Description = "Gym membership",
+            Amount = 25m,
+            Frequency = RecurrenceFrequency.Monthly,
+            StartDate = new DateTime(2026, 1, 15, 0, 0, 0, DateTimeKind.Utc),
+            NextDueDate = nextDueDate ?? new DateTime(2026, 6, 15, 0, 0, 0, DateTimeKind.Utc),
+            IsActive = isActive
+        };
+    }
+
+    [Fact]
+    public async Task CreateAsync_PersistsSchedule()
+    {
+        var created = await _repository.CreateAsync(NewSchedule());
+
+        created.Id.Should().BeGreaterThan(0);
+        (await _context.RecurringTransactions.CountAsync()).Should().Be(1);
+    }
+
+    [Fact]
+    public async Task GetByIdAsync_WrongUser_ReturnsNull()
+    {
+        var created = await _repository.CreateAsync(NewSchedule());
+
+        var result = await _repository.GetByIdAsync(created.Id, _otherUserId);
+
+        result.Should().BeNull();
+    }
+
+    [Fact]
+    public async Task GetByUserIdAsync_ExcludesInactiveByDefault()
+    {
+        await _repository.CreateAsync(NewSchedule(isActive: true));
+        await _repository.CreateAsync(NewSchedule(isActive: false));
+
+        var activeOnly = await _repository.GetByUserIdAsync(_userId);
+        var all = await _repository.GetByUserIdAsync(_userId, includeInactive: true);
+
+        activeOnly.Should().HaveCount(1);
+        all.Should().HaveCount(2);
+    }
+
+    [Fact]
+    public async Task GetDueAsync_ReturnsOnlyActiveDueSchedules()
+    {
+        var asOf = new DateTime(2026, 6, 15, 0, 0, 0, DateTimeKind.Utc);
+        var dueToday = await _repository.CreateAsync(NewSchedule(nextDueDate: asOf));
+        await _repository.CreateAsync(NewSchedule(nextDueDate: asOf.AddDays(1))); // future
+        await _repository.CreateAsync(NewSchedule(nextDueDate: asOf, isActive: false)); // paused
+
+        var due = (await _repository.GetDueAsync(asOf)).ToList();
+
+        due.Should().ContainSingle().Which.Id.Should().Be(dueToday.Id);
+    }
+
+    [Fact]
+    public async Task GetDueAsync_IncludesOverdueSchedules()
+    {
+        var asOf = new DateTime(2026, 6, 15, 0, 0, 0, DateTimeKind.Utc);
+        await _repository.CreateAsync(NewSchedule(nextDueDate: asOf.AddDays(-10)));
+
+        var due = await _repository.GetDueAsync(asOf);
+
+        due.Should().HaveCount(1);
+    }
+
+    [Fact]
+    public async Task DeleteAsync_SoftDeletes()
+    {
+        var created = await _repository.CreateAsync(NewSchedule());
+
+        var deleted = await _repository.DeleteAsync(created.Id, _userId);
+
+        deleted.Should().BeTrue();
+        (await _repository.GetByIdAsync(created.Id, _userId)).Should().BeNull();
+
+        var raw = await _context.RecurringTransactions
+            .IgnoreQueryFilters()
+            .SingleAsync(r => r.Id == created.Id);
+        raw.IsDeleted.Should().BeTrue();
+        raw.DeletedAt.Should().NotBeNull();
+    }
+
+    [Fact]
+    public async Task DeleteAsync_WrongUser_ReturnsFalse()
+    {
+        var created = await _repository.CreateAsync(NewSchedule());
+
+        var deleted = await _repository.DeleteAsync(created.Id, _otherUserId);
+
+        deleted.Should().BeFalse();
+    }
+
+    [Fact]
+    public async Task HasOccurrenceAsync_DetectsExistingScheduledDate()
+    {
+        var created = await _repository.CreateAsync(NewSchedule());
+        var date = new DateTime(2026, 6, 15, 0, 0, 0, DateTimeKind.Utc);
+
+        (await _repository.HasOccurrenceAsync(created.Id, date)).Should().BeFalse();
+
+        await _repository.CreateOccurrenceAsync(new RecurringTransactionOccurrence
+        {
+            RecurringTransactionId = created.Id,
+            ScheduledDate = date,
+            Status = RecurringTransactionOccurrenceStatus.Notified
+        });
+
+        (await _repository.HasOccurrenceAsync(created.Id, date)).Should().BeTrue();
+        (await _repository.HasOccurrenceAsync(created.Id, date.AddDays(1))).Should().BeFalse();
+    }
+
+    [Fact]
+    public async Task GetRecentOccurrencesAsync_ReturnsNewestFirstLimited()
+    {
+        var created = await _repository.CreateAsync(NewSchedule());
+        var baseDate = new DateTime(2026, 1, 15, 0, 0, 0, DateTimeKind.Utc);
+
+        for (var i = 0; i < 5; i++)
+        {
+            await _repository.CreateOccurrenceAsync(new RecurringTransactionOccurrence
+            {
+                RecurringTransactionId = created.Id,
+                ScheduledDate = baseDate.AddMonths(i),
+                Status = RecurringTransactionOccurrenceStatus.Notified
+            });
+        }
+
+        var recent = (await _repository.GetRecentOccurrencesAsync(created.Id, _userId, count: 3)).ToList();
+
+        recent.Should().HaveCount(3);
+        recent.First().ScheduledDate.Should().Be(baseDate.AddMonths(4));
+        recent.Should().BeInDescendingOrder(o => o.ScheduledDate);
+    }
+
+    [Fact]
+    public async Task GetRecentOccurrencesAsync_WrongUser_ReturnsEmpty()
+    {
+        var created = await _repository.CreateAsync(NewSchedule());
+        await _repository.CreateOccurrenceAsync(new RecurringTransactionOccurrence
+        {
+            RecurringTransactionId = created.Id,
+            ScheduledDate = new DateTime(2026, 6, 15, 0, 0, 0, DateTimeKind.Utc),
+            Status = RecurringTransactionOccurrenceStatus.Notified
+        });
+
+        var recent = await _repository.GetRecentOccurrencesAsync(created.Id, _otherUserId);
+
+        recent.Should().BeEmpty();
+    }
+}


### PR DESCRIPTION
Continuation of #330 (auto-closed by GitHub when its base branch `feat/mobile-push-notifications` was deleted on #327's merge — same commits, now rebased onto main; clean rebase, 1245 unit tests green).

All review discussion and dispositions live in #330: 3 review rounds fully addressed (claim-first idempotency + one-DB-transaction crash-window fix, access re-checks in the job with auto-pause, viewer/AutoCreate authorization, catch-up snap math). See #330 for the complete summary comments.

## Summary
- User-created recurring transactions: CRUD at `/api/v1/recurring-transactions` + pause/resume/upcoming
- Daily Hangfire job: auto-create real transactions or push reminders (via the #327 pipeline), calendar-anchored date math, crash-safe idempotency
- Expense-only by design; mobile UI ships in mymascada-mobile#109

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added recurring transaction management with configurable recurrence patterns (weekly, fortnightly, monthly, yearly, custom intervals).
  * Users can set recurring transactions to automatically create transactions or send reminders when due.
  * New REST API endpoints for creating, viewing, updating, pausing, and resuming recurring transactions.
  * Added upcoming schedule preview showing all due dates within a configurable time window.

* **Chores**
  * Added daily background job to process due recurring transactions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->