### PR TITLE
fix(tests): repair main CI - FakeUnitOfWork missing IsolationLevel overload

### DIFF
--- a/tests/MyMascada.Tests.Unit/Features/RecurringTransactions/Services/RecurringTransactionProcessingServiceTests.cs
+++ b/tests/MyMascada.Tests.Unit/Features/RecurringTransactions/Services/RecurringTransactionProcessingServiceTests.cs
@@ -1,3 +1,4 @@
+using System.Data;
 using MediatR;
 using Microsoft.Extensions.Logging;
 using MyMascada.Application.Common.Interfaces;
@@ -659,6 +660,10 @@ public class RecurringTransactionProcessingServiceTests
         public List<string> Events { get; } = new();
         public Action? OnCommit { get; set; }
         public Action? OnRollback { get; set; }
+
+        public Task<IUnitOfWorkTransaction> BeginTransactionAsync(
+            IsolationLevel isolationLevel, CancellationToken cancellationToken = default) =>
+            BeginTransactionAsync(cancellationToken);
 
         public Task<IUnitOfWorkTransaction> BeginTransactionAsync(CancellationToken cancellationToken = default)
         {


### PR DESCRIPTION
Main's CI is red: #331 and #332 merged in quick succession and were never built together — #332's `FakeUnitOfWork` predates the `BeginTransactionAsync(IsolationLevel, CancellationToken)` overload #331 added to `IUnitOfWork`. Test-compile-only failure (production code and the Fly deploy were unaffected).

One-line fake implementation delegating to the existing method + `using System.Data;`. Full unit suite green locally: **1339/1339**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Updated test infrastructure to support transaction isolation level parameters in transaction handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->