### PR TITLE
fix(reconciliation): normalize DateTime kinds to UTC before hitting PostgreSQL

### DIFF
--- a/src/Core/MyMascada.Application/Features/Reconciliation/Commands/CreateAkahuReconciliationCommand.cs
+++ b/src/Core/MyMascada.Application/Features/Reconciliation/Commands/CreateAkahuReconciliationCommand.cs
@@ -4,6 +4,7 @@ using MyMascada.Application.Common.Interfaces;
 using MyMascada.Application.Features.BankConnections.DTOs;
 using MyMascada.Application.Features.Reconciliation.DTOs;
 using MyMascada.Application.Features.Reconciliation.Services;
+using MyMascada.Domain.Common;
 using MyMascada.Domain.Entities;
 using MyMascada.Domain.Enums;
 using ProviderBankTransactionDto = MyMascada.Application.Features.BankConnections.DTOs.BankTransactionDto;
@@ -103,12 +104,8 @@ public class CreateAkahuReconciliationCommandHandler
         }
 
         // Normalize dates to UTC for PostgreSQL compatibility
-        var startDateUtc = request.StartDate.Kind == DateTimeKind.Unspecified
-            ? DateTime.SpecifyKind(request.StartDate, DateTimeKind.Utc)
-            : request.StartDate.ToUniversalTime();
-        var endDateUtc = request.EndDate.Kind == DateTimeKind.Unspecified
-            ? DateTime.SpecifyKind(request.EndDate, DateTimeKind.Utc)
-            : request.EndDate.ToUniversalTime();
+        var startDateUtc = DateTimeProvider.ToUtc(request.StartDate);
+        var endDateUtc = DateTimeProvider.ToUtc(request.EndDate);
 
         // Build the connection config
         var connectionConfig = BuildConnectionConfig(bankConnection);

--- a/src/Core/MyMascada.Application/Features/Reconciliation/Commands/CreateReconciliationCommand.cs
+++ b/src/Core/MyMascada.Application/Features/Reconciliation/Commands/CreateReconciliationCommand.cs
@@ -1,6 +1,7 @@
 using MediatR;
 using MyMascada.Application.Common.Interfaces;
 using MyMascada.Application.Features.Reconciliation.DTOs;
+using MyMascada.Domain.Common;
 using MyMascada.Domain.Entities;
 using MyMascada.Domain.Enums;
 
@@ -51,12 +52,16 @@ public class CreateReconciliationCommandHandler : IRequestHandler<CreateReconcil
         // Calculate the current balance from transactions
         var calculatedBalance = await _transactionRepository.GetAccountBalanceAsync(request.AccountId, request.UserId);
 
+        // Normalize the statement end date to UTC for PostgreSQL compatibility
+        // (clients may send dates without timezone info, which parse as Kind=Unspecified)
+        var statementEndDateUtc = DateTimeProvider.ToUtc(request.StatementEndDate);
+
         // Create the reconciliation
         var reconciliation = new Domain.Entities.Reconciliation
         {
             AccountId = request.AccountId,
             ReconciliationDate = DateTime.UtcNow,
-            StatementEndDate = request.StatementEndDate,
+            StatementEndDate = statementEndDateUtc,
             StatementEndBalance = request.StatementEndBalance,
             CalculatedBalance = calculatedBalance,
             Status = ReconciliationStatus.InProgress,
@@ -82,7 +87,7 @@ public class CreateReconciliationCommandHandler : IRequestHandler<CreateReconcil
         {
             AccountId = request.AccountId,
             AccountName = account.Name,
-            StatementEndDate = request.StatementEndDate,
+            StatementEndDate = statementEndDateUtc,
             StatementEndBalance = request.StatementEndBalance,
             CalculatedBalance = calculatedBalance,
             BalanceDifference = savedReconciliation.BalanceDifference

--- a/src/Core/MyMascada.Application/Features/Reconciliation/Commands/ManualMatchTransactionCommand.cs
+++ b/src/Core/MyMascada.Application/Features/Reconciliation/Commands/ManualMatchTransactionCommand.cs
@@ -2,6 +2,7 @@ using MediatR;
 using MyMascada.Application.Common.Interfaces;
 using MyMascada.Application.Features.Reconciliation.DTOs;
 using MyMascada.Application.Features.Reconciliation.Services;
+using MyMascada.Domain.Common;
 using MyMascada.Domain.Entities;
 using MyMascada.Domain.Enums;
 
@@ -58,13 +59,19 @@ public class ManualMatchTransactionCommandHandler : IRequestHandler<ManualMatchT
                 throw new ArgumentException($"Transaction with ID {request.SystemTransactionId} not found or does not belong to user");
         }
 
+        // Normalize the bank transaction date to UTC for PostgreSQL compatibility
+        // (clients may send dates without timezone info, which parse as Kind=Unspecified)
+        var bankTransaction = request.BankTransaction is null
+            ? null
+            : request.BankTransaction with { TransactionDate = DateTimeProvider.ToUtc(request.BankTransaction.TransactionDate) };
+
         // Calculate match confidence if both transactions are available
         decimal? matchConfidence = null;
         MatchAnalysisDto? matchAnalysis = null;
-        if (systemTransaction != null && request.BankTransaction != null)
+        if (systemTransaction != null && bankTransaction != null)
         {
-            matchConfidence = _matchConfidenceCalculator.CalculateMatchConfidence(systemTransaction, request.BankTransaction);
-            matchAnalysis = _matchConfidenceCalculator.AnalyzeMatch(systemTransaction, request.BankTransaction);
+            matchConfidence = _matchConfidenceCalculator.CalculateMatchConfidence(systemTransaction, bankTransaction);
+            matchAnalysis = _matchConfidenceCalculator.AnalyzeMatch(systemTransaction, bankTransaction);
         }
 
         // Create new reconciliation item
@@ -72,11 +79,11 @@ public class ManualMatchTransactionCommandHandler : IRequestHandler<ManualMatchT
         {
             ReconciliationId = request.ReconciliationId,
             TransactionId = request.SystemTransactionId,
-            ItemType = DetermineItemType(request.SystemTransactionId, request.BankTransaction),
+            ItemType = DetermineItemType(request.SystemTransactionId, bankTransaction),
             MatchConfidence = matchConfidence,
             MatchMethod = MatchMethod.Manual,
-            BankReferenceData = request.BankTransaction != null 
-                ? System.Text.Json.JsonSerializer.Serialize(request.BankTransaction) 
+            BankReferenceData = bankTransaction != null
+                ? System.Text.Json.JsonSerializer.Serialize(bankTransaction)
                 : null,
             CreatedBy = request.UserId.ToString(),
             UpdatedBy = request.UserId.ToString()
@@ -93,7 +100,7 @@ public class ManualMatchTransactionCommandHandler : IRequestHandler<ManualMatchT
             ItemType = reconciliationItem.ItemType,
             MatchConfidence = reconciliationItem.MatchConfidence,
             MatchMethod = reconciliationItem.MatchMethod,
-            BankTransaction = request.BankTransaction,
+            BankTransaction = bankTransaction,
             SystemTransaction = systemTransaction != null
                 ? new TransactionDetailsDto
                 {

--- a/src/Core/MyMascada.Application/Features/Reconciliation/Commands/MatchTransactionsCommand.cs
+++ b/src/Core/MyMascada.Application/Features/Reconciliation/Commands/MatchTransactionsCommand.cs
@@ -2,6 +2,7 @@ using MediatR;
 using MyMascada.Application.Common.Interfaces;
 using MyMascada.Application.Features.Reconciliation.DTOs;
 using MyMascada.Application.Features.Reconciliation.Services;
+using MyMascada.Domain.Common;
 using MyMascada.Domain.Entities;
 using MyMascada.Domain.Enums;
 
@@ -60,8 +61,14 @@ public class MatchTransactionsCommandHandler : IRequestHandler<MatchTransactions
         // Note: This includes both reviewed and unreviewed transactions for comprehensive reconciliation
         // Includes already-reconciled transactions so they can match against bank transactions
         // and avoid being incorrectly recommended as new imports
-        var startDate = request.StartDate ?? reconciliation.StatementEndDate.AddDays(-30);
-        var endDate = request.EndDate ?? reconciliation.StatementEndDate;
+        // Normalize dates to UTC for PostgreSQL compatibility
+        // (clients may send dates without timezone info, which parse as Kind=Unspecified)
+        var startDate = DateTimeProvider.ToUtc(request.StartDate ?? reconciliation.StatementEndDate.AddDays(-30));
+        var endDate = DateTimeProvider.ToUtc(request.EndDate ?? reconciliation.StatementEndDate);
+
+        var bankTransactions = request.BankTransactions
+            .Select(bt => bt with { TransactionDate = DateTimeProvider.ToUtc(bt.TransactionDate) })
+            .ToList();
 
         var accountTransactions = await _transactionRepository.GetByDateRangeAsync(
             request.UserId,
@@ -82,7 +89,7 @@ public class MatchTransactionsCommandHandler : IRequestHandler<MatchTransactions
         var matchingRequest = new TransactionMatchRequest
         {
             ReconciliationId = request.ReconciliationId,
-            BankTransactions = request.BankTransactions,
+            BankTransactions = bankTransactions,
             StartDate = startDate,
             EndDate = endDate,
             ToleranceAmount = request.ToleranceAmount,
@@ -159,7 +166,7 @@ public class MatchTransactionsCommandHandler : IRequestHandler<MatchTransactions
 
         auditLog.SetDetails(new
         {
-            BankTransactionCount = request.BankTransactions.Count(),
+            BankTransactionCount = bankTransactions.Count,
             AppTransactionCount = accountTransactions.Count(),
             ExactMatches = matchingResult.ExactMatches,
             FuzzyMatches = matchingResult.FuzzyMatches,

--- a/src/Core/MyMascada.Application/Features/Reconciliation/Commands/UpdateReconciliationCommand.cs
+++ b/src/Core/MyMascada.Application/Features/Reconciliation/Commands/UpdateReconciliationCommand.cs
@@ -1,6 +1,7 @@
 using MediatR;
 using MyMascada.Application.Common.Interfaces;
 using MyMascada.Application.Features.Reconciliation.DTOs;
+using MyMascada.Domain.Common;
 using MyMascada.Domain.Entities;
 using MyMascada.Domain.Enums;
 
@@ -58,9 +59,9 @@ public class UpdateReconciliationCommandHandler : IRequestHandler<UpdateReconcil
             Notes = reconciliation.Notes
         };
 
-        // Update fields
+        // Update fields (normalize dates to UTC for PostgreSQL compatibility)
         if (request.StatementEndDate.HasValue)
-            reconciliation.StatementEndDate = request.StatementEndDate.Value;
+            reconciliation.StatementEndDate = DateTimeProvider.ToUtc(request.StatementEndDate.Value);
 
         if (request.StatementEndBalance.HasValue)
             reconciliation.StatementEndBalance = request.StatementEndBalance.Value;

--- a/src/Core/MyMascada.Application/Features/Reconciliation/Queries/GetReconciliationsQuery.cs
+++ b/src/Core/MyMascada.Application/Features/Reconciliation/Queries/GetReconciliationsQuery.cs
@@ -1,6 +1,7 @@
 using MediatR;
 using MyMascada.Application.Common.Interfaces;
 using MyMascada.Application.Features.Reconciliation.DTOs;
+using MyMascada.Domain.Common;
 using MyMascada.Domain.Enums;
 
 namespace MyMascada.Application.Features.Reconciliation.Queries;
@@ -39,8 +40,10 @@ public class GetReconciliationsQueryHandler : IRequestHandler<GetReconciliations
             request.PageSize,
             request.AccountId,
             request.Status,
-            request.StartDate,
-            request.EndDate,
+            // Normalize dates to UTC for PostgreSQL compatibility
+            // (clients may send dates without timezone info, which parse as Kind=Unspecified)
+            DateTimeProvider.ToUtc(request.StartDate),
+            DateTimeProvider.ToUtc(request.EndDate),
             request.SortBy,
             request.SortDirection);
 

--- a/tests/MyMascada.Tests.Unit/Features/Reconciliation/Commands/CreateReconciliationCommandTests.cs
+++ b/tests/MyMascada.Tests.Unit/Features/Reconciliation/Commands/CreateReconciliationCommandTests.cs
@@ -1,0 +1,148 @@
+using FluentAssertions;
+using MyMascada.Application.Common.Interfaces;
+using MyMascada.Application.Features.Reconciliation.Commands;
+using MyMascada.Domain.Entities;
+using NSubstitute;
+using Xunit;
+
+namespace MyMascada.Tests.Unit.Features.Reconciliation.Commands;
+
+public class CreateReconciliationCommandTests
+{
+    private readonly IReconciliationRepository _reconciliationRepository;
+    private readonly IReconciliationAuditLogRepository _auditLogRepository;
+    private readonly IAccountRepository _accountRepository;
+    private readonly ITransactionRepository _transactionRepository;
+    private readonly IAccountAccessService _accountAccessService;
+    private readonly CreateReconciliationCommandHandler _handler;
+
+    private readonly Guid _userId = Guid.NewGuid();
+    private readonly int _accountId = 1;
+
+    public CreateReconciliationCommandTests()
+    {
+        _reconciliationRepository = Substitute.For<IReconciliationRepository>();
+        _auditLogRepository = Substitute.For<IReconciliationAuditLogRepository>();
+        _accountRepository = Substitute.For<IAccountRepository>();
+        _transactionRepository = Substitute.For<ITransactionRepository>();
+        _accountAccessService = Substitute.For<IAccountAccessService>();
+
+        _accountRepository.GetByIdAsync(_accountId, _userId)
+            .Returns(new Account { Id = _accountId, UserId = _userId, Name = "Test Account" });
+        _accountAccessService.CanModifyAccountAsync(_userId, _accountId).Returns(true);
+        _transactionRepository.GetAccountBalanceAsync(_accountId, _userId).Returns(1000m);
+
+        // Echo back the entity passed to AddAsync (simulating a save that assigns an ID)
+        _reconciliationRepository.AddAsync(Arg.Any<MyMascada.Domain.Entities.Reconciliation>())
+            .Returns(callInfo =>
+            {
+                var reconciliation = callInfo.Arg<MyMascada.Domain.Entities.Reconciliation>();
+                reconciliation.Id = 1;
+                return reconciliation;
+            });
+
+        _handler = new CreateReconciliationCommandHandler(
+            _reconciliationRepository,
+            _auditLogRepository,
+            _accountRepository,
+            _transactionRepository,
+            _accountAccessService);
+    }
+
+    [Fact]
+    public async Task Handle_WithUnspecifiedKindStatementEndDate_StoresDateAsUtc()
+    {
+        // Arrange — mobile clients send ISO dates without timezone info (e.g. "2026-06-12T00:00:00.000"),
+        // which ASP.NET parses as DateTimeKind.Unspecified. Npgsql rejects Unspecified for timestamptz.
+        var unspecifiedDate = DateTime.Parse("2026-06-12T00:00:00.000");
+        unspecifiedDate.Kind.Should().Be(DateTimeKind.Unspecified, "precondition: parsed date must be Unspecified");
+
+        var command = new CreateReconciliationCommand
+        {
+            UserId = _userId,
+            AccountId = _accountId,
+            StatementEndDate = unspecifiedDate,
+            StatementEndBalance = 950m
+        };
+
+        // Act
+        var result = await _handler.Handle(command, CancellationToken.None);
+
+        // Assert — the date must reach the repository with Kind=Utc and the same wall-clock value
+        await _reconciliationRepository.Received(1).AddAsync(Arg.Is<MyMascada.Domain.Entities.Reconciliation>(r =>
+            r.StatementEndDate.Kind == DateTimeKind.Utc &&
+            r.StatementEndDate == DateTime.SpecifyKind(unspecifiedDate, DateTimeKind.Utc)));
+
+        result.StatementEndDate.Kind.Should().Be(DateTimeKind.Utc);
+        result.StatementEndDate.Should().Be(DateTime.SpecifyKind(unspecifiedDate, DateTimeKind.Utc));
+    }
+
+    [Fact]
+    public async Task Handle_WithLocalKindStatementEndDate_ConvertsToUniversalTime()
+    {
+        // Arrange
+        var localDate = new DateTime(2026, 6, 12, 0, 0, 0, DateTimeKind.Local);
+
+        var command = new CreateReconciliationCommand
+        {
+            UserId = _userId,
+            AccountId = _accountId,
+            StatementEndDate = localDate,
+            StatementEndBalance = 950m
+        };
+
+        // Act
+        var result = await _handler.Handle(command, CancellationToken.None);
+
+        // Assert
+        await _reconciliationRepository.Received(1).AddAsync(Arg.Is<MyMascada.Domain.Entities.Reconciliation>(r =>
+            r.StatementEndDate.Kind == DateTimeKind.Utc &&
+            r.StatementEndDate == localDate.ToUniversalTime()));
+
+        result.StatementEndDate.Kind.Should().Be(DateTimeKind.Utc);
+    }
+
+    [Fact]
+    public async Task Handle_WithUtcKindStatementEndDate_PreservesValue()
+    {
+        // Arrange
+        var utcDate = new DateTime(2026, 6, 12, 0, 0, 0, DateTimeKind.Utc);
+
+        var command = new CreateReconciliationCommand
+        {
+            UserId = _userId,
+            AccountId = _accountId,
+            StatementEndDate = utcDate,
+            StatementEndBalance = 950m
+        };
+
+        // Act
+        var result = await _handler.Handle(command, CancellationToken.None);
+
+        // Assert
+        await _reconciliationRepository.Received(1).AddAsync(Arg.Is<MyMascada.Domain.Entities.Reconciliation>(r =>
+            r.StatementEndDate.Kind == DateTimeKind.Utc &&
+            r.StatementEndDate == utcDate));
+
+        result.StatementEndDate.Should().Be(utcDate);
+    }
+
+    [Fact]
+    public async Task Handle_WithNonExistentAccount_ThrowsArgumentException()
+    {
+        // Arrange
+        _accountRepository.GetByIdAsync(_accountId, _userId).Returns((Account?)null);
+
+        var command = new CreateReconciliationCommand
+        {
+            UserId = _userId,
+            AccountId = _accountId,
+            StatementEndDate = DateTime.UtcNow,
+            StatementEndBalance = 950m
+        };
+
+        // Act & Assert
+        await Assert.ThrowsAsync<ArgumentException>(() =>
+            _handler.Handle(command, CancellationToken.None));
+    }
+}

--- a/tests/MyMascada.Tests.Unit/Features/Reconciliation/Commands/ManualMatchTransactionCommandTests.cs
+++ b/tests/MyMascada.Tests.Unit/Features/Reconciliation/Commands/ManualMatchTransactionCommandTests.cs
@@ -154,6 +154,42 @@ public class ManualMatchTransactionCommandTests
     }
 
     [Fact]
+    public async Task Handle_WithUnspecifiedKindBankTransactionDate_NormalizesDateToUtc()
+    {
+        // Arrange — unsuffixed ISO dates parse as DateTimeKind.Unspecified, which Npgsql rejects for timestamptz
+        var reconciliation = CreateTestReconciliation();
+        _reconciliationRepository.GetByIdAsync(_reconciliationId, _userId)
+            .Returns(reconciliation);
+
+        var unspecifiedDate = DateTime.Parse("2026-06-12T00:00:00.000");
+        unspecifiedDate.Kind.Should().Be(DateTimeKind.Unspecified, "precondition: parsed date must be Unspecified");
+
+        var bankTransaction = CreateTestBankTransaction() with { TransactionDate = unspecifiedDate };
+
+        var command = new ManualMatchTransactionCommand
+        {
+            UserId = _userId,
+            ReconciliationId = _reconciliationId,
+            SystemTransactionId = null,
+            BankTransaction = bankTransaction
+        };
+
+        // Act
+        var result = await _handler.Handle(command, CancellationToken.None);
+
+        // Assert — the bank transaction date must be normalized to UTC
+        result.BankTransaction.Should().NotBeNull();
+        result.BankTransaction!.TransactionDate.Kind.Should().Be(DateTimeKind.Utc);
+        result.BankTransaction.TransactionDate.Should().Be(DateTime.SpecifyKind(unspecifiedDate, DateTimeKind.Utc));
+
+        // The serialized bank reference data persisted with the item must carry the normalized UTC date
+        await _reconciliationItemRepository.Received(1).AddAsync(Arg.Is<ReconciliationItem>(item =>
+            item.ItemType == ReconciliationItemType.UnmatchedBank &&
+            item.BankReferenceData != null &&
+            item.BankReferenceData.Contains("2026-06-12T00:00:00.000Z")));
+    }
+
+    [Fact]
     public async Task Handle_WithNonExistentReconciliation_ThrowsArgumentException()
     {
         // Arrange

--- a/tests/MyMascada.Tests.Unit/Features/Reconciliation/Commands/UpdateReconciliationCommandTests.cs
+++ b/tests/MyMascada.Tests.Unit/Features/Reconciliation/Commands/UpdateReconciliationCommandTests.cs
@@ -1,0 +1,133 @@
+using FluentAssertions;
+using MyMascada.Application.Common.Interfaces;
+using MyMascada.Application.Features.Reconciliation.Commands;
+using MyMascada.Domain.Entities;
+using MyMascada.Domain.Enums;
+using NSubstitute;
+using Xunit;
+
+namespace MyMascada.Tests.Unit.Features.Reconciliation.Commands;
+
+public class UpdateReconciliationCommandTests
+{
+    private readonly IReconciliationRepository _reconciliationRepository;
+    private readonly IReconciliationAuditLogRepository _auditLogRepository;
+    private readonly IAccountRepository _accountRepository;
+    private readonly IAccountAccessService _accountAccessService;
+    private readonly UpdateReconciliationCommandHandler _handler;
+
+    private readonly Guid _userId = Guid.NewGuid();
+    private readonly int _reconciliationId = 1;
+    private readonly int _accountId = 1;
+
+    public UpdateReconciliationCommandTests()
+    {
+        _reconciliationRepository = Substitute.For<IReconciliationRepository>();
+        _auditLogRepository = Substitute.For<IReconciliationAuditLogRepository>();
+        _accountRepository = Substitute.For<IAccountRepository>();
+        _accountAccessService = Substitute.For<IAccountAccessService>();
+
+        _accountRepository.GetByIdAsync(_accountId, _userId)
+            .Returns(new Account { Id = _accountId, UserId = _userId, Name = "Test Account" });
+        _accountAccessService.CanModifyAccountAsync(_userId, _accountId).Returns(true);
+
+        _handler = new UpdateReconciliationCommandHandler(
+            _reconciliationRepository,
+            _auditLogRepository,
+            _accountRepository,
+            _accountAccessService);
+    }
+
+    [Fact]
+    public async Task Handle_WithUnspecifiedKindStatementEndDate_StoresDateAsUtc()
+    {
+        // Arrange — unsuffixed ISO dates parse as DateTimeKind.Unspecified, which Npgsql rejects for timestamptz
+        var reconciliation = CreateTestReconciliation();
+        _reconciliationRepository.GetByIdAsync(_reconciliationId, _userId).Returns(reconciliation);
+
+        var unspecifiedDate = DateTime.Parse("2026-06-12T00:00:00.000");
+        unspecifiedDate.Kind.Should().Be(DateTimeKind.Unspecified, "precondition: parsed date must be Unspecified");
+
+        var command = new UpdateReconciliationCommand
+        {
+            UserId = _userId,
+            ReconciliationId = _reconciliationId,
+            StatementEndDate = unspecifiedDate
+        };
+
+        // Act
+        var result = await _handler.Handle(command, CancellationToken.None);
+
+        // Assert
+        await _reconciliationRepository.Received(1).UpdateAsync(Arg.Is<MyMascada.Domain.Entities.Reconciliation>(r =>
+            r.StatementEndDate.Kind == DateTimeKind.Utc &&
+            r.StatementEndDate == DateTime.SpecifyKind(unspecifiedDate, DateTimeKind.Utc)));
+
+        result.StatementEndDate.Kind.Should().Be(DateTimeKind.Utc);
+        result.StatementEndDate.Should().Be(DateTime.SpecifyKind(unspecifiedDate, DateTimeKind.Utc));
+    }
+
+    [Fact]
+    public async Task Handle_WithLocalKindStatementEndDate_ConvertsToUniversalTime()
+    {
+        // Arrange
+        var reconciliation = CreateTestReconciliation();
+        _reconciliationRepository.GetByIdAsync(_reconciliationId, _userId).Returns(reconciliation);
+
+        var localDate = new DateTime(2026, 6, 12, 0, 0, 0, DateTimeKind.Local);
+
+        var command = new UpdateReconciliationCommand
+        {
+            UserId = _userId,
+            ReconciliationId = _reconciliationId,
+            StatementEndDate = localDate
+        };
+
+        // Act
+        var result = await _handler.Handle(command, CancellationToken.None);
+
+        // Assert
+        await _reconciliationRepository.Received(1).UpdateAsync(Arg.Is<MyMascada.Domain.Entities.Reconciliation>(r =>
+            r.StatementEndDate.Kind == DateTimeKind.Utc &&
+            r.StatementEndDate == localDate.ToUniversalTime()));
+
+        result.StatementEndDate.Kind.Should().Be(DateTimeKind.Utc);
+    }
+
+    [Fact]
+    public async Task Handle_WithoutStatementEndDate_KeepsExistingDate()
+    {
+        // Arrange
+        var reconciliation = CreateTestReconciliation();
+        var originalDate = reconciliation.StatementEndDate;
+        _reconciliationRepository.GetByIdAsync(_reconciliationId, _userId).Returns(reconciliation);
+
+        var command = new UpdateReconciliationCommand
+        {
+            UserId = _userId,
+            ReconciliationId = _reconciliationId,
+            Notes = "Just updating notes"
+        };
+
+        // Act
+        var result = await _handler.Handle(command, CancellationToken.None);
+
+        // Assert
+        result.StatementEndDate.Should().Be(originalDate);
+        result.Notes.Should().Be("Just updating notes");
+    }
+
+    private MyMascada.Domain.Entities.Reconciliation CreateTestReconciliation()
+    {
+        return new MyMascada.Domain.Entities.Reconciliation
+        {
+            Id = _reconciliationId,
+            AccountId = _accountId,
+            StatementEndDate = DateTime.UtcNow,
+            StatementEndBalance = 1000m,
+            Status = ReconciliationStatus.InProgress,
+            CreatedBy = _userId.ToString(),
+            UpdatedBy = _userId.ToString()
+        };
+    }
+}


### PR DESCRIPTION
## Problem

`POST /api/v1/reconciliation` returned **500** when a client sent `statementEndDate` as an ISO string without timezone info (e.g. `"2026-06-12T00:00:00.000"`). ASP.NET model binding parses that as `DateTime` with `Kind=Unspecified`, and Npgsql rejects it when writing to a `timestamp with time zone` column:

```
System.ArgumentException: Cannot write DateTime with Kind=Unspecified to PostgreSQL type 'timestamp with time zone', only UTC is supported.
   at MyMascada.Infrastructure.Repositories.ReconciliationRepository.AddAsync (ReconciliationRepository.cs:106)
   at CreateReconciliationCommandHandler.Handle (CreateReconciliationCommand.cs:69)
   at ReconciliationController.CreateReconciliation (ReconciliationController.cs:141)
```

**Which client surfaced it:** the mobile app, which sends unsuffixed ISO dates. The web app always sends `'Z'`-suffixed UTC dates, so it never hit this. A 500 for a parseable date is wrong regardless — it should be normalized.

## Root cause

The reconciliation command handlers passed request `DateTime`s straight to the repository without normalizing `DateTimeKind`. `CreateAkahuReconciliationCommand` and `ImportUnmatchedTransactionsCommand` already normalized; the rest of the feature did not.

## Fix

Normalize at the application boundary using the existing shared helper `DateTimeProvider.ToUtc` (`Unspecified` → `DateTime.SpecifyKind(..., Utc)`, `Local` → `ToUniversalTime()`, `Utc` → unchanged):

- **CreateReconciliationCommand** — `StatementEndDate` (the reported 500)
- **UpdateReconciliationCommand** — `StatementEndDate?`
- **MatchTransactionsCommand** — `StartDate?`, `EndDate?` (used in an EF date-range query) and each `BankTransaction.TransactionDate`
- **ManualMatchTransactionCommand** — `BankTransaction.TransactionDate` (serialized into `BankReferenceData`, later re-read and written to a timestamptz on import)
- **GetReconciliationsQuery** — `StartDate?`/`EndDate?` (bound via `[FromQuery]`, which never goes through JSON converters; they reach an EF `Where` on timestamptz with the same failure mode)
- **CreateAkahuReconciliationCommand** — replaced its hand-rolled inline normalization with the shared `DateTimeProvider.ToUtc` helper (no behavior change)

No global Npgsql/EF settings were touched (no `EnableLegacyTimestampBehavior`).

## Testing

Backend-only change — no screenshots. Verified with unit tests (xUnit + NSubstitute + FluentAssertions, following the existing handler-test idiom):

- New `CreateReconciliationCommandTests`: an `Unspecified`-kind date (parsed from `"2026-06-12T00:00:00.000"`, the exact mobile payload shape) no longer throws and reaches the repository with `Kind=Utc` and the same wall-clock value; `Local` is converted via `ToUniversalTime`; `Utc` passes through unchanged.
- New `UpdateReconciliationCommandTests`: same normalization on update; date untouched when not supplied.
- Extended `ManualMatchTransactionCommandTests`: an `Unspecified`-kind bank transaction date is normalized to UTC in both the returned DTO and the persisted `BankReferenceData` JSON.

Results:
- `dotnet build MyMascada.sln` — clean (0 errors)
- `dotnet test tests/MyMascada.Tests.Unit` — **1347 passed, 0 failed** (56 in the Reconciliation feature)

## Risks / follow-ups

- Low risk: `ToUtc` is a no-op for the UTC dates the web app already sends.
- Other features may have similar unnormalized `DateTime` inputs; out of scope here, worth a follow-up audit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved consistency of date/time handling across reconciliation features by ensuring all dates are properly normalized to UTC. This affects transaction creation, updates, matching operations, and date-based filtering to provide reliable behavior regardless of input date format.

* **Tests**
  * Added comprehensive unit test suites to validate date/time normalization behavior in reconciliation commands across various date scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->