### PR TITLE
feat(features): per-user feature flags with admin overrides

### DIFF
--- a/src/Core/MyMascada.Application/Common/Interfaces/IUserFeatureService.cs
+++ b/src/Core/MyMascada.Application/Common/Interfaces/IUserFeatureService.cs
@@ -1,0 +1,31 @@
+namespace MyMascada.Application.Common.Interfaces;
+
+/// <summary>
+/// Resolves user-facing feature toggles for a given user. The effective value of
+/// a feature is its per-user override (if any) falling back to the launch default,
+/// AND-ed with the global capability (a feature can't be on for a user if the
+/// server isn't configured for it).
+/// </summary>
+public interface IUserFeatureService
+{
+    /// <summary>Effective on/off for every known feature, ready to send to the client.</summary>
+    Task<IReadOnlyDictionary<string, bool>> GetResolvedAsync(
+        Guid userId, CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// The raw admin view: each known feature with its launch default, the user's
+    /// explicit override (null if none), and the resolved effective value.
+    /// </summary>
+    Task<IReadOnlyList<UserFeatureState>> GetAdminViewAsync(
+        Guid userId, CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// Set or clear a per-user override. Passing <paramref name="enabled"/> = null
+    /// removes the override so the feature falls back to its launch default.
+    /// </summary>
+    Task SetOverrideAsync(
+        Guid userId, string featureKey, bool? enabled, CancellationToken cancellationToken = default);
+}
+
+/// <summary>Admin-facing per-feature state for a single user.</summary>
+public record UserFeatureState(string Key, bool LaunchDefault, bool? Override, bool Effective);

--- a/src/Core/MyMascada.Domain/Entities/UserFeatureFlag.cs
+++ b/src/Core/MyMascada.Domain/Entities/UserFeatureFlag.cs
@@ -1,0 +1,19 @@
+using MyMascada.Domain.Common;
+
+namespace MyMascada.Domain.Entities;
+
+/// <summary>
+/// A per-user override for a user-facing feature toggle (e.g. the AI assistant,
+/// receipt scanning, bank connections). When no row exists for a (user, feature)
+/// pair the feature falls back to its launch default. Managed by admins.
+/// </summary>
+public class UserFeatureFlag : BaseEntity<int>
+{
+    public Guid UserId { get; set; }
+
+    /// <summary>Stable key from <see cref="MyMascada.Domain.Features.UserFeatureKeys"/>.</summary>
+    public string FeatureKey { get; set; } = string.Empty;
+
+    /// <summary>Explicit per-user value overriding the launch default.</summary>
+    public bool Enabled { get; set; }
+}

--- a/src/Core/MyMascada.Domain/Features/UserFeatureKeys.cs
+++ b/src/Core/MyMascada.Domain/Features/UserFeatureKeys.cs
@@ -1,0 +1,35 @@
+namespace MyMascada.Domain.Features;
+
+/// <summary>
+/// Catalogue of user-facing feature toggles and their launch defaults.
+///
+/// These are distinct from the global <c>IFeatureFlags</c> (which describe what
+/// the server is *configured* to do). A feature is shown to a user only when it
+/// is enabled for them AND the corresponding global capability is available.
+/// </summary>
+public static class UserFeatureKeys
+{
+    /// <summary>AI assistant / chat ("Ask Alce"). Expensive — off until billing is defined.</summary>
+    public const string AiAssistant = "ai_assistant";
+
+    /// <summary>On-device camera receipt scanning.</summary>
+    public const string ReceiptScan = "receipt_scan";
+
+    /// <summary>Bank connections / Akahu sync.</summary>
+    public const string BankConnections = "bank_connections";
+
+    /// <summary>
+    /// Every known feature with its launch default. All gated features default to
+    /// OFF for v1 so nothing expensive or unfinished is exposed until explicitly
+    /// enabled (globally via config, or per-user via the admin module).
+    /// </summary>
+    public static readonly IReadOnlyDictionary<string, bool> LaunchDefaults =
+        new Dictionary<string, bool>
+        {
+            [AiAssistant] = false,
+            [ReceiptScan] = false,
+            [BankConnections] = false,
+        };
+
+    public static readonly IReadOnlyCollection<string> All = LaunchDefaults.Keys.ToArray();
+}

--- a/src/Infrastructure/MyMascada.Infrastructure/Data/ApplicationDbContext.cs
+++ b/src/Infrastructure/MyMascada.Infrastructure/Data/ApplicationDbContext.cs
@@ -58,6 +58,7 @@ public class ApplicationDbContext : DbContext
     public DbSet<Notification> Notifications => Set<Notification>();
     public DbSet<NotificationPreference> NotificationPreferences => Set<NotificationPreference>();
     public DbSet<UserDevice> UserDevices => Set<UserDevice>();
+    public DbSet<UserFeatureFlag> UserFeatureFlags => Set<UserFeatureFlag>();
     public DbSet<CategorizationHistory> CategorizationHistories => Set<CategorizationHistory>();
     public DbSet<AiCategorizationUsage> AiCategorizationUsages => Set<AiCategorizationUsage>();
 
@@ -1115,6 +1116,23 @@ public class ApplicationDbContext : DbContext
             // One row per FCM token regardless of user — registration reassigns ownership.
             entity.HasIndex(e => e.FcmToken).IsUnique();
             entity.HasIndex(e => e.UserId);
+
+            entity.HasQueryFilter(e => !e.IsDeleted);
+        });
+
+        // UserFeatureFlag configuration (per-user feature toggles / overrides)
+        modelBuilder.Entity<UserFeatureFlag>(entity =>
+        {
+            entity.HasKey(e => e.Id);
+            entity.Property(e => e.UserId).IsRequired();
+            entity.HasOne<User>()
+                .WithMany()
+                .HasForeignKey(e => e.UserId)
+                .OnDelete(DeleteBehavior.Cascade);
+            entity.Property(e => e.FeatureKey).IsRequired().HasMaxLength(64);
+
+            // At most one override per (user, feature).
+            entity.HasIndex(e => new { e.UserId, e.FeatureKey }).IsUnique();
 
             entity.HasQueryFilter(e => !e.IsDeleted);
         });

--- a/src/Infrastructure/MyMascada.Infrastructure/Services/UserFeatureService.cs
+++ b/src/Infrastructure/MyMascada.Infrastructure/Services/UserFeatureService.cs
@@ -1,0 +1,107 @@
+using Microsoft.EntityFrameworkCore;
+using MyMascada.Application.Common.Interfaces;
+using MyMascada.Domain.Entities;
+using MyMascada.Domain.Features;
+using MyMascada.Infrastructure.Data;
+
+namespace MyMascada.Infrastructure.Services;
+
+/// <summary>
+/// Resolves per-user feature toggles: effective = (override ?? launch default)
+/// AND the global capability for that feature.
+/// </summary>
+public class UserFeatureService : IUserFeatureService
+{
+    private readonly ApplicationDbContext _db;
+    private readonly IFeatureFlags _global;
+
+    public UserFeatureService(ApplicationDbContext db, IFeatureFlags global)
+    {
+        _db = db;
+        _global = global;
+    }
+
+    /// <summary>
+    /// Whether the server is configured for a feature at all. A feature can never
+    /// be on for a user if the underlying capability isn't available.
+    /// </summary>
+    private bool GlobalCapability(string key) => key switch
+    {
+        UserFeatureKeys.AiAssistant => _global.HasGlobalAiKey,
+        UserFeatureKeys.BankConnections => _global.BankSync,
+        UserFeatureKeys.ReceiptScan => true, // on-device, always available
+        _ => false,
+    };
+
+    public async Task<IReadOnlyDictionary<string, bool>> GetResolvedAsync(
+        Guid userId, CancellationToken cancellationToken = default)
+    {
+        var overrides = await LoadOverridesAsync(userId, cancellationToken);
+        var result = new Dictionary<string, bool>(UserFeatureKeys.All.Count);
+        foreach (var (key, launchDefault) in UserFeatureKeys.LaunchDefaults)
+        {
+            var desired = overrides.TryGetValue(key, out var o) ? o : launchDefault;
+            result[key] = desired && GlobalCapability(key);
+        }
+        return result;
+    }
+
+    public async Task<IReadOnlyList<UserFeatureState>> GetAdminViewAsync(
+        Guid userId, CancellationToken cancellationToken = default)
+    {
+        var overrides = await LoadOverridesAsync(userId, cancellationToken);
+        var states = new List<UserFeatureState>(UserFeatureKeys.All.Count);
+        foreach (var (key, launchDefault) in UserFeatureKeys.LaunchDefaults)
+        {
+            bool? ov = overrides.TryGetValue(key, out var o) ? o : null;
+            var desired = ov ?? launchDefault;
+            states.Add(new UserFeatureState(key, launchDefault, ov, desired && GlobalCapability(key)));
+        }
+        return states;
+    }
+
+    public async Task SetOverrideAsync(
+        Guid userId, string featureKey, bool? enabled, CancellationToken cancellationToken = default)
+    {
+        if (!UserFeatureKeys.LaunchDefaults.ContainsKey(featureKey))
+        {
+            throw new ArgumentException($"Unknown feature key '{featureKey}'.", nameof(featureKey));
+        }
+
+        var existing = await _db.UserFeatureFlags
+            .FirstOrDefaultAsync(f => f.UserId == userId && f.FeatureKey == featureKey, cancellationToken);
+
+        if (enabled is null)
+        {
+            // Clear the override → fall back to the launch default.
+            if (existing is not null)
+            {
+                _db.UserFeatureFlags.Remove(existing);
+                await _db.SaveChangesAsync(cancellationToken);
+            }
+            return;
+        }
+
+        if (existing is null)
+        {
+            _db.UserFeatureFlags.Add(new UserFeatureFlag
+            {
+                UserId = userId,
+                FeatureKey = featureKey,
+                Enabled = enabled.Value,
+            });
+        }
+        else
+        {
+            existing.Enabled = enabled.Value;
+        }
+
+        await _db.SaveChangesAsync(cancellationToken);
+    }
+
+    private async Task<Dictionary<string, bool>> LoadOverridesAsync(
+        Guid userId, CancellationToken cancellationToken) =>
+        await _db.UserFeatureFlags
+            .Where(f => f.UserId == userId)
+            .ToDictionaryAsync(f => f.FeatureKey, f => f.Enabled, cancellationToken);
+}

--- a/src/WebAPI/MyMascada.WebAPI/Controllers/AdminController.cs
+++ b/src/WebAPI/MyMascada.WebAPI/Controllers/AdminController.cs
@@ -19,17 +19,23 @@ public class AdminController : ControllerBase
     private readonly IWaitlistRepository _waitlistRepository;
     private readonly IInvitationCodeRepository _invitationCodeRepository;
     private readonly IAiTokenTracker _aiTokenTracker;
+    private readonly IUserRepository _userRepository;
+    private readonly IUserFeatureService _userFeatures;
 
     public AdminController(
         IMediator mediator,
         IWaitlistRepository waitlistRepository,
         IInvitationCodeRepository invitationCodeRepository,
-        IAiTokenTracker aiTokenTracker)
+        IAiTokenTracker aiTokenTracker,
+        IUserRepository userRepository,
+        IUserFeatureService userFeatures)
     {
         _mediator = mediator;
         _waitlistRepository = waitlistRepository;
         _invitationCodeRepository = invitationCodeRepository;
         _aiTokenTracker = aiTokenTracker;
+        _userRepository = userRepository;
+        _userFeatures = userFeatures;
     }
 
     [HttpGet("waitlist")]
@@ -92,6 +98,67 @@ public class AdminController : ControllerBase
         var summary = await _aiTokenTracker.GetAdminSummaryAsync(from, to);
         return Ok(summary);
     }
+
+    /// <summary>
+    /// Look up a user's per-feature state (launch default, override, effective) by
+    /// email. Used by the admin module to enable/disable gated features per user
+    /// (e.g. turn on bank connections for a single account).
+    /// </summary>
+    [HttpGet("users/features")]
+    public async Task<IActionResult> GetUserFeatures([FromQuery] string email, CancellationToken cancellationToken)
+    {
+        if (string.IsNullOrWhiteSpace(email)) return BadRequest(new { message = "email is required" });
+
+        var user = await _userRepository.GetByEmailAsync(email.Trim());
+        if (user == null) return NotFound(new { message = "User not found" });
+
+        var features = await _userFeatures.GetAdminViewAsync(user.Id, cancellationToken);
+        return Ok(new
+        {
+            userId = user.Id,
+            email = user.Email,
+            features
+        });
+    }
+
+    /// <summary>
+    /// Set or clear a per-user feature override. <c>enabled = null</c> clears the
+    /// override so the feature falls back to its launch default.
+    /// </summary>
+    [HttpPut("users/features")]
+    public async Task<IActionResult> SetUserFeature([FromBody] SetUserFeatureRequest request, CancellationToken cancellationToken)
+    {
+        if (string.IsNullOrWhiteSpace(request.Email)) return BadRequest(new { message = "email is required" });
+        if (string.IsNullOrWhiteSpace(request.FeatureKey)) return BadRequest(new { message = "featureKey is required" });
+
+        var user = await _userRepository.GetByEmailAsync(request.Email.Trim());
+        if (user == null) return NotFound(new { message = "User not found" });
+
+        try
+        {
+            await _userFeatures.SetOverrideAsync(user.Id, request.FeatureKey, request.Enabled, cancellationToken);
+        }
+        catch (ArgumentException ex)
+        {
+            return BadRequest(new { message = ex.Message });
+        }
+
+        var features = await _userFeatures.GetAdminViewAsync(user.Id, cancellationToken);
+        return Ok(new
+        {
+            userId = user.Id,
+            email = user.Email,
+            features
+        });
+    }
+}
+
+public class SetUserFeatureRequest
+{
+    public string Email { get; set; } = string.Empty;
+    public string FeatureKey { get; set; } = string.Empty;
+    /// <summary>true = force on, false = force off, null = clear override.</summary>
+    public bool? Enabled { get; set; }
 }
 
 public class GenerateInvitationRequest

--- a/src/WebAPI/MyMascada.WebAPI/Controllers/FeaturesController.cs
+++ b/src/WebAPI/MyMascada.WebAPI/Controllers/FeaturesController.cs
@@ -12,10 +12,17 @@ namespace MyMascada.WebAPI.Controllers;
 public class FeaturesController : ControllerBase
 {
     private readonly IFeatureFlags _featureFlags;
+    private readonly IUserFeatureService _userFeatures;
+    private readonly ICurrentUserService _currentUser;
 
-    public FeaturesController(IFeatureFlags featureFlags)
+    public FeaturesController(
+        IFeatureFlags featureFlags,
+        IUserFeatureService userFeatures,
+        ICurrentUserService currentUser)
     {
         _featureFlags = featureFlags;
+        _userFeatures = userFeatures;
+        _currentUser = currentUser;
     }
 
     [HttpGet]
@@ -32,6 +39,21 @@ public class FeaturesController : ControllerBase
         };
 
         return Ok(response);
+    }
+
+    /// <summary>
+    /// Per-user feature toggles for the authenticated caller. The client uses this
+    /// to gate UI (Ask Alce, receipt scan, bank connections). Each value is already
+    /// AND-ed with the global capability, so the client can trust it directly.
+    /// </summary>
+    [HttpGet("me")]
+    [Authorize]
+    public async Task<ActionResult<IReadOnlyDictionary<string, bool>>> GetMyFeatures(
+        CancellationToken cancellationToken)
+    {
+        var userId = _currentUser.GetUserId();
+        var resolved = await _userFeatures.GetResolvedAsync(userId, cancellationToken);
+        return Ok(resolved);
     }
 }
 

--- a/src/WebAPI/MyMascada.WebAPI/Extensions/RepositoryServiceExtensions.cs
+++ b/src/WebAPI/MyMascada.WebAPI/Extensions/RepositoryServiceExtensions.cs
@@ -1,6 +1,7 @@
 using MyMascada.Application.Common.Interfaces;
 using MyMascada.Infrastructure.Data;
 using MyMascada.Infrastructure.Repositories;
+using MyMascada.Infrastructure.Services;
 
 namespace MyMascada.WebAPI.Extensions;
 
@@ -13,6 +14,7 @@ public static class RepositoryServiceExtensions
 
         // Core repositories
         services.AddScoped<IUserRepository, UserRepository>();
+        services.AddScoped<IUserFeatureService, UserFeatureService>();
         services.AddScoped<ITransactionRepository, TransactionRepository>();
         services.AddScoped<IAccountRepository, AccountRepository>();
         services.AddScoped<ICategoryRepository, CategoryRepository>();

--- a/src/WebAPI/MyMascada.WebAPI/Migrations/20260613021938_AddUserFeatureFlags.Designer.cs
+++ b/src/WebAPI/MyMascada.WebAPI/Migrations/20260613021938_AddUserFeatureFlags.Designer.cs
@@ -2,6 +2,7 @@
 using System;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using MyMascada.Infrastructure.Data;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
@@ -11,9 +12,11 @@ using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 namespace MyMascada.WebAPI.Migrations
 {
     [DbContext(typeof(ApplicationDbContext))]
-    partial class ApplicationDbContextModelSnapshot : ModelSnapshot
+    [Migration("20260613021938_AddUserFeatureFlags")]
+    partial class AddUserFeatureFlags
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/src/WebAPI/MyMascada.WebAPI/Migrations/20260613021938_AddUserFeatureFlags.cs
+++ b/src/WebAPI/MyMascada.WebAPI/Migrations/20260613021938_AddUserFeatureFlags.cs
@@ -1,0 +1,56 @@
+﻿using System;
+using Microsoft.EntityFrameworkCore.Migrations;
+using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
+
+#nullable disable
+
+namespace MyMascada.WebAPI.Migrations
+{
+    /// <inheritdoc />
+    public partial class AddUserFeatureFlags : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.CreateTable(
+                name: "UserFeatureFlags",
+                columns: table => new
+                {
+                    Id = table.Column<int>(type: "integer", nullable: false)
+                        .Annotation("Npgsql:ValueGenerationStrategy", NpgsqlValueGenerationStrategy.IdentityByDefaultColumn),
+                    UserId = table.Column<Guid>(type: "uuid", nullable: false),
+                    FeatureKey = table.Column<string>(type: "character varying(64)", maxLength: 64, nullable: false),
+                    Enabled = table.Column<bool>(type: "boolean", nullable: false),
+                    CreatedAt = table.Column<DateTime>(type: "timestamp with time zone", nullable: false),
+                    UpdatedAt = table.Column<DateTime>(type: "timestamp with time zone", nullable: false),
+                    IsDeleted = table.Column<bool>(type: "boolean", nullable: false),
+                    DeletedAt = table.Column<DateTime>(type: "timestamp with time zone", nullable: true),
+                    CreatedBy = table.Column<string>(type: "text", nullable: true),
+                    UpdatedBy = table.Column<string>(type: "text", nullable: true)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_UserFeatureFlags", x => x.Id);
+                    table.ForeignKey(
+                        name: "FK_UserFeatureFlags_Users_UserId",
+                        column: x => x.UserId,
+                        principalTable: "Users",
+                        principalColumn: "Id",
+                        onDelete: ReferentialAction.Cascade);
+                });
+
+            migrationBuilder.CreateIndex(
+                name: "IX_UserFeatureFlags_UserId_FeatureKey",
+                table: "UserFeatureFlags",
+                columns: new[] { "UserId", "FeatureKey" },
+                unique: true);
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropTable(
+                name: "UserFeatureFlags");
+        }
+    }
+}


### PR DESCRIPTION
## Summary

Adds a **per-user feature toggle layer** on top of the existing global `IFeatureFlags` (which describe what the *server* is configured to do). This lets us launch without exposing expensive or unfinished features, while still enabling them for individual users from the admin module.

**Effective value for a user = `(per-user override ?? launch default)` AND `global capability`.** A feature can never be on for a user if the server isn't configured for it (e.g. bank connections require Akahu to be enabled server-side).

### Gated features (all default **OFF** for launch)
| Key | Feature | Global capability gate |
|-----|---------|------------------------|
| `ai_assistant` | Ask Alce / AI chat (expensive, billing TBD) | `HasGlobalAiKey` |
| `receipt_scan` | On-device camera receipt scanning | always (on-device) |
| `bank_connections` | Akahu bank sync | `Akahu:Enabled` |

This directly supports the launch plan: hide AI assistant, receipt scan, and Akahu for everyone by default — but flip `bank_connections` on for a single account via the admin module.

## Changes
- **Domain**: `UserFeatureFlag` entity + `UserFeatureKeys` catalogue/launch defaults.
- **Application**: `IUserFeatureService` (resolve / admin view / set override) + `UserFeatureState` record.
- **Infrastructure**: `UserFeatureService`, `DbSet` with a unique `(UserId, FeatureKey)` index and cascade FK, EF migration `AddUserFeatureFlags`.
- **WebAPI**:
  - `GET /api/latest/features/me` (authenticated) — resolved flags for the mobile client, already AND-ed with global capability so the client can trust them directly.
  - `GET /api/latest/admin/users/features?email=` and `PUT /api/latest/admin/users/features` (`[AdminApiKey]`) — look up a user's per-feature state by email and set/clear an override (`enabled: null` clears).

## Testing
Verified end-to-end against the dev DB with the new build (admin key + `Akahu:Enabled=true`):
- `GET /features/me` → all gated features `false` by default.
- Admin `GET` → state list (`launchDefault` / `override` / `effective`).
- Admin `PUT enabled:true` for `bank_connections` → `override:true, effective:true`; `/features/me` then returns `bank_connections:true`.
- `PUT enabled:null` clears the override (falls back to default).
- Unknown feature key → `400`; bad/missing admin key → `401`; unauthenticated `/features/me` → `401`.

## Follow-ups (separate PRs)
- Admin module UI (mymascada-landing) to toggle these per user.
- Mobile app gating (read `/features/me`, fail-closed) for Ask Alce, receipt scan, and Akahu.
- Deployment: set `Admin:ApiKey` and (when ready) `Akahu:Enabled=true` + credentials so `bank_connections` can be enabled per user.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## New Features

* Users can now view their available features through a dedicated endpoint
* Administrators can manage individual user access to specific features through new admin tools
* Added per-user management for AI Assistant, Receipt Scan, and Bank Connections features

<!-- end of auto-generated comment: release notes by coderabbit.ai -->