### PR TITLE
fix(recurring): stop one merchant splitting into duplicate upcoming bills

### DIFF
--- a/src/Core/MyMascada.Application/Common/Interfaces/IRecurringPatternRepository.cs
+++ b/src/Core/MyMascada.Application/Common/Interfaces/IRecurringPatternRepository.cs
@@ -83,6 +83,22 @@ public interface IRecurringPatternRepository
     /// </summary>
     Task<RecurringPattern> UpsertAsync(RecurringPattern pattern, CancellationToken cancellationToken = default);
 
+    /// <summary>
+    /// Merges duplicate recurring patterns into a single canonical pattern.
+    /// Re-parents the occurrence history of <paramref name="duplicatePatternIds"/> onto
+    /// <paramref name="canonicalPatternId"/>, applies the supplied merged field values to the
+    /// canonical pattern, then soft-deletes the duplicates. All changes are saved together.
+    /// </summary>
+    Task MergeDuplicatePatternsAsync(
+        Guid userId,
+        int canonicalPatternId,
+        IEnumerable<int> duplicatePatternIds,
+        int mergedOccurrenceCount,
+        decimal mergedAverageAmount,
+        DateTime mergedLastObservedAt,
+        DateTime mergedNextExpectedDate,
+        CancellationToken cancellationToken = default);
+
     // Occurrence operations
 
     /// <summary>

--- a/src/Core/MyMascada.Application/Common/Interfaces/IRecurringPatternRepository.cs
+++ b/src/Core/MyMascada.Application/Common/Interfaces/IRecurringPatternRepository.cs
@@ -86,17 +86,31 @@ public interface IRecurringPatternRepository
     /// <summary>
     /// Merges duplicate recurring patterns into a single canonical pattern.
     /// Re-parents the occurrence history of <paramref name="duplicatePatternIds"/> onto
-    /// <paramref name="canonicalPatternId"/>, applies the supplied merged field values to the
-    /// canonical pattern, then soft-deletes the duplicates. All changes are saved together.
+    /// <paramref name="canonicalPatternId"/>, applies the supplied merged field values
+    /// (including the rewritten <paramref name="mergedNormalizedKey"/>) to the canonical
+    /// pattern, then soft-deletes the duplicates. All changes are saved together.
     /// </summary>
     Task MergeDuplicatePatternsAsync(
         Guid userId,
         int canonicalPatternId,
         IEnumerable<int> duplicatePatternIds,
+        string mergedNormalizedKey,
         int mergedOccurrenceCount,
         decimal mergedAverageAmount,
         DateTime mergedLastObservedAt,
         DateTime mergedNextExpectedDate,
+        CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// Rewrites the <see cref="RecurringPattern.NormalizedMerchantKey"/> of a single pattern
+    /// (used to migrate a lone stale row to the current normalizer's output so subsequent
+    /// exact-key upserts update it rather than creating a new duplicate). No-op if the value
+    /// is unchanged or the pattern is not found.
+    /// </summary>
+    Task UpdateNormalizedKeyAsync(
+        Guid userId,
+        int patternId,
+        string normalizedKey,
         CancellationToken cancellationToken = default);
 
     // Occurrence operations

--- a/src/Core/MyMascada.Application/Features/RecurringPatterns/Services/RecurringPatternPersistenceService.cs
+++ b/src/Core/MyMascada.Application/Features/RecurringPatterns/Services/RecurringPatternPersistenceService.cs
@@ -267,19 +267,19 @@ public class RecurringPatternPersistenceService : IRecurringPatternPersistenceSe
         // (e.g. before the reconciliation pass has run), consolidate them here so the user
         // never sees the same merchant more than once. Keep the soonest-due / highest-confidence
         // pattern and prefer the most recently observed amount.
-        var consolidatedPatterns = ConsolidateByMerchant(upcomingPatterns, today);
+        var consolidated = MerchantConsolidation.ConsolidateUpcoming(upcomingPatterns, today);
 
-        var bills = consolidatedPatterns.Select(p => new UpcomingBillDto
+        var bills = consolidated.Select(c => new UpcomingBillDto
         {
-            PatternId = p.Id,
-            MerchantName = p.MerchantName,
-            ExpectedAmount = Math.Round(p.AverageAmount, 2),
-            ExpectedDate = p.NextExpectedDate,
-            DaysUntilDue = p.GetDaysUntilDue(today),
-            ConfidenceScore = Math.Round(p.Confidence, 2),
-            ConfidenceLevel = p.GetConfidenceLevel(),
-            Interval = p.GetIntervalName(),
-            OccurrenceCount = p.OccurrenceCount
+            PatternId = c.Pattern.Id,
+            MerchantName = c.Pattern.MerchantName,
+            ExpectedAmount = Math.Round(c.DisplayAmount, 2),
+            ExpectedDate = c.Pattern.NextExpectedDate,
+            DaysUntilDue = c.Pattern.GetDaysUntilDue(today),
+            ConfidenceScore = Math.Round(c.Pattern.Confidence, 2),
+            ConfidenceLevel = c.Pattern.GetConfidenceLevel(),
+            Interval = c.Pattern.GetIntervalName(),
+            OccurrenceCount = c.Pattern.OccurrenceCount
         })
         .OrderBy(b => b.DaysUntilDue)
         .ThenByDescending(b => b.ConfidenceScore)
@@ -291,50 +291,6 @@ public class RecurringPatternPersistenceService : IRecurringPatternPersistenceSe
             TotalBillsCount = bills.Count,
             TotalExpectedAmount = bills.Sum(b => b.ExpectedAmount)
         };
-    }
-
-    /// <summary>
-    /// Collapses patterns that resolve to the same merchant (identical normalized key, or
-    /// near-duplicate via the shared similarity rule) into a single representative pattern.
-    /// The representative is the soonest-due, then highest-confidence pattern; its amount is
-    /// taken from the most recently observed pattern in the group.
-    /// </summary>
-    private static List<RecurringPattern> ConsolidateByMerchant(
-        IEnumerable<RecurringPattern> patterns,
-        DateTime today)
-    {
-        var patternList = patterns.ToList();
-        if (patternList.Count <= 1)
-            return patternList;
-
-        // Build a similarity grouping over the distinct normalized keys.
-        var keys = patternList
-            .Select(p => p.NormalizedMerchantKey ?? string.Empty)
-            .ToList();
-        var canonicalByKey = MerchantNormalizer.GroupSimilarKeys(keys);
-
-        var grouped = patternList
-            .GroupBy(p => canonicalByKey.TryGetValue(p.NormalizedMerchantKey ?? string.Empty, out var canonical)
-                ? canonical
-                : (p.NormalizedMerchantKey ?? string.Empty));
-
-        var result = new List<RecurringPattern>();
-        foreach (var group in grouped)
-        {
-            // Representative = soonest due, then highest confidence.
-            var representative = group
-                .OrderBy(p => p.GetDaysUntilDue(today))
-                .ThenByDescending(p => p.Confidence)
-                .First();
-
-            // Prefer the most recently observed amount across the duplicate rows.
-            var mostRecent = group.OrderByDescending(p => p.LastObservedAt).First();
-            representative.AverageAmount = mostRecent.AverageAmount;
-
-            result.Add(representative);
-        }
-
-        return result;
     }
 
     #region Private Helper Methods
@@ -413,13 +369,20 @@ public class RecurringPatternPersistenceService : IRecurringPatternPersistenceSe
             if (activePatterns.Count <= 1)
                 return;
 
+            // Re-normalize the stored keys first: rows persisted by an older normalizer may
+            // still carry reference tokens or doubled words (e.g. "ami insurance amiinsurance"),
+            // which must be cleaned before grouping so they collapse with freshly-detected keys.
+            var normalizedByPattern = activePatterns.ToDictionary(
+                p => p,
+                p => MerchantNormalizer.Normalize(p.NormalizedMerchantKey));
+
             var canonicalByKey = MerchantNormalizer.GroupSimilarKeys(
-                activePatterns.Select(p => p.NormalizedMerchantKey ?? string.Empty).ToList());
+                normalizedByPattern.Values.ToList());
 
             var groups = activePatterns
-                .GroupBy(p => canonicalByKey.TryGetValue(p.NormalizedMerchantKey ?? string.Empty, out var canonical)
+                .GroupBy(p => canonicalByKey.TryGetValue(normalizedByPattern[p], out var canonical)
                     ? canonical
-                    : (p.NormalizedMerchantKey ?? string.Empty))
+                    : normalizedByPattern[p])
                 .Where(g => g.Count() > 1)
                 .ToList();
 

--- a/src/Core/MyMascada.Application/Features/RecurringPatterns/Services/RecurringPatternPersistenceService.cs
+++ b/src/Core/MyMascada.Application/Features/RecurringPatterns/Services/RecurringPatternPersistenceService.cs
@@ -357,33 +357,37 @@ public class RecurringPatternPersistenceService : IRecurringPatternPersistenceSe
 
     /// <summary>
     /// Reconciles already-persisted <see cref="RecurringPattern"/> rows for a user so existing
-    /// accounts self-heal. Active patterns are grouped by normalized/similar merchant key:
-    ///  - groups with more than one member are merged into a single canonical pattern (most
-    ///    occurrences, then highest confidence) with merged occurrence counts, the most recent
-    ///    amount/next-expected-date, and the rewritten normalized key; the rest are soft-deleted.
+    /// accounts self-heal. ALL non-deleted patterns (any status) are grouped by normalized/similar
+    /// merchant key — including Paused/Cancelled rows, so an exact-key upsert in the next detection
+    /// pass updates them rather than inserting a fresh Active duplicate (which would resurrect a
+    /// user-paused bill):
+    ///  - groups with more than one member are merged into a single canonical pattern with merged
+    ///    occurrence counts, the most recent amount/next-expected-date, and the rewritten
+    ///    normalized key; the rest are soft-deleted. The canonical is chosen to preserve explicit
+    ///    user intent (a Paused/Cancelled row wins over Active), so merging never silently
+    ///    un-pauses a merchant.
     ///  - a lone member whose stored key differs from the current normalizer output has its key
-    ///    migrated, so the next detection pass's exact-key upsert updates it rather than creating
-    ///    a fresh duplicate.
+    ///    migrated.
     /// </summary>
     private async Task ReconcileDuplicatePatternsAsync(Guid userId, CancellationToken cancellationToken)
     {
         try
         {
-            var activePatterns = (await _patternRepository.GetActiveAsync(userId, cancellationToken)).ToList();
-            if (activePatterns.Count == 0)
+            var patterns = (await _patternRepository.GetByUserIdAsync(userId, includeOccurrences: false, cancellationToken)).ToList();
+            if (patterns.Count == 0)
                 return;
 
             // Re-normalize the stored keys first: rows persisted by an older normalizer may
             // still carry reference tokens or doubled words (e.g. "ami insurance amiinsurance"),
             // which must be cleaned before grouping so they collapse with freshly-detected keys.
-            var normalizedByPattern = activePatterns.ToDictionary(
+            var normalizedByPattern = patterns.ToDictionary(
                 p => p,
                 p => MerchantNormalizer.Normalize(p.NormalizedMerchantKey));
 
             var canonicalByKey = MerchantNormalizer.GroupSimilarKeys(
                 normalizedByPattern.Values.ToList());
 
-            var groups = activePatterns
+            var groups = patterns
                 .GroupBy(p => canonicalByKey.TryGetValue(normalizedByPattern[p], out var canonical)
                     ? canonical
                     : normalizedByPattern[p])
@@ -409,9 +413,12 @@ public class RecurringPatternPersistenceService : IRecurringPatternPersistenceSe
                     continue;
                 }
 
-                // Keep the strongest pattern: most occurrences, then highest confidence.
+                // Choose the canonical so explicit user intent survives the merge: prefer a
+                // Paused/Cancelled row (user actions that MergeDuplicatePatternsAsync preserves)
+                // over Active/AtRisk, then the strongest by occurrences and confidence.
                 var canonicalPattern = members
-                    .OrderByDescending(p => p.OccurrenceCount)
+                    .OrderByDescending(p => IsUserManagedStatus(p.Status))
+                    .ThenByDescending(p => p.OccurrenceCount)
                     .ThenByDescending(p => p.Confidence)
                     .First();
 
@@ -442,6 +449,13 @@ public class RecurringPatternPersistenceService : IRecurringPatternPersistenceSe
             _logger.LogError(ex, "Failed to reconcile duplicate recurring patterns for user {UserId}", userId);
         }
     }
+
+    /// <summary>
+    /// Whether a status reflects an explicit user action (Paused/Cancelled) that must survive a
+    /// duplicate merge, as opposed to system-managed states (Active/AtRisk).
+    /// </summary>
+    private static bool IsUserManagedStatus(RecurringPatternStatus status)
+        => status is RecurringPatternStatus.Paused or RecurringPatternStatus.Cancelled;
 
     private RecurringPattern? DetectPattern(string merchantKey, List<Transaction> transactions, DateTime today)
     {

--- a/src/Core/MyMascada.Application/Features/RecurringPatterns/Services/RecurringPatternPersistenceService.cs
+++ b/src/Core/MyMascada.Application/Features/RecurringPatterns/Services/RecurringPatternPersistenceService.cs
@@ -356,17 +356,21 @@ public class RecurringPatternPersistenceService : IRecurringPatternPersistenceSe
     }
 
     /// <summary>
-    /// Merges already-persisted duplicate <see cref="RecurringPattern"/> rows for a user.
-    /// Active patterns are grouped by normalized/similar merchant key; one canonical pattern
-    /// is kept (most occurrences, then highest confidence) with merged occurrence counts and
-    /// the most recent amount/next-expected-date, and the rest are soft-deleted.
+    /// Reconciles already-persisted <see cref="RecurringPattern"/> rows for a user so existing
+    /// accounts self-heal. Active patterns are grouped by normalized/similar merchant key:
+    ///  - groups with more than one member are merged into a single canonical pattern (most
+    ///    occurrences, then highest confidence) with merged occurrence counts, the most recent
+    ///    amount/next-expected-date, and the rewritten normalized key; the rest are soft-deleted.
+    ///  - a lone member whose stored key differs from the current normalizer output has its key
+    ///    migrated, so the next detection pass's exact-key upsert updates it rather than creating
+    ///    a fresh duplicate.
     /// </summary>
     private async Task ReconcileDuplicatePatternsAsync(Guid userId, CancellationToken cancellationToken)
     {
         try
         {
             var activePatterns = (await _patternRepository.GetActiveAsync(userId, cancellationToken)).ToList();
-            if (activePatterns.Count <= 1)
+            if (activePatterns.Count == 0)
                 return;
 
             // Re-normalize the stored keys first: rows persisted by an older normalizer may
@@ -383,12 +387,27 @@ public class RecurringPatternPersistenceService : IRecurringPatternPersistenceSe
                 .GroupBy(p => canonicalByKey.TryGetValue(normalizedByPattern[p], out var canonical)
                     ? canonical
                     : normalizedByPattern[p])
-                .Where(g => g.Count() > 1)
                 .ToList();
 
             foreach (var group in groups)
             {
                 var members = group.ToList();
+
+                if (members.Count == 1)
+                {
+                    // Lone row: migrate a stale stored key to the normalized form so the next
+                    // exact-key upsert updates this row instead of creating a duplicate.
+                    var only = members[0];
+                    var migratedKey = group.Key;
+                    if (!string.IsNullOrWhiteSpace(migratedKey) && only.NormalizedMerchantKey != migratedKey)
+                    {
+                        await _patternRepository.UpdateNormalizedKeyAsync(userId, only.Id, migratedKey, cancellationToken);
+                        _logger.LogInformation(
+                            "Migrated normalized key for recurring pattern {PatternId} to '{NormalizedKey}'",
+                            only.Id, migratedKey);
+                    }
+                    continue;
+                }
 
                 // Keep the strongest pattern: most occurrences, then highest confidence.
                 var canonicalPattern = members
@@ -405,6 +424,7 @@ public class RecurringPatternPersistenceService : IRecurringPatternPersistenceSe
                     userId,
                     canonicalPattern.Id,
                     duplicateIds,
+                    mergedNormalizedKey: group.Key,
                     mergedOccurrenceCount: members.Sum(p => p.OccurrenceCount),
                     mergedAverageAmount: mostRecent.AverageAmount,
                     mergedLastObservedAt: mostRecent.LastObservedAt,

--- a/src/Core/MyMascada.Application/Features/RecurringPatterns/Services/RecurringPatternPersistenceService.cs
+++ b/src/Core/MyMascada.Application/Features/RecurringPatterns/Services/RecurringPatternPersistenceService.cs
@@ -395,52 +395,61 @@ public class RecurringPatternPersistenceService : IRecurringPatternPersistenceSe
 
             foreach (var group in groups)
             {
-                var members = group.ToList();
+                var canonicalKey = group.Key;
 
-                if (members.Count == 1)
+                // Name similarity alone is not enough to destructively merge two persisted
+                // patterns: two legitimately-distinct merchants can have near-identical names.
+                // Split each name-group into merge clusters that additionally require compatible
+                // evidence (same exact normalized key, OR same cadence AND close amounts), so we
+                // only soft-delete + reparent rows that are genuinely the same recurring bill.
+                var clusters = PartitionByMergeEvidence(group.ToList(), p => normalizedByPattern[p]);
+
+                foreach (var cluster in clusters)
                 {
-                    // Lone row: migrate a stale stored key to the normalized form so the next
-                    // exact-key upsert updates this row instead of creating a duplicate.
-                    var only = members[0];
-                    var migratedKey = group.Key;
-                    if (!string.IsNullOrWhiteSpace(migratedKey) && only.NormalizedMerchantKey != migratedKey)
+                    if (cluster.Count == 1)
                     {
-                        await _patternRepository.UpdateNormalizedKeyAsync(userId, only.Id, migratedKey, cancellationToken);
-                        _logger.LogInformation(
-                            "Migrated normalized key for recurring pattern {PatternId} to '{NormalizedKey}'",
-                            only.Id, migratedKey);
+                        // Lone row: migrate a stale stored key to the normalized form so the next
+                        // exact-key upsert updates this row instead of creating a duplicate.
+                        var only = cluster[0];
+                        if (!string.IsNullOrWhiteSpace(canonicalKey) && only.NormalizedMerchantKey != canonicalKey)
+                        {
+                            await _patternRepository.UpdateNormalizedKeyAsync(userId, only.Id, canonicalKey, cancellationToken);
+                            _logger.LogInformation(
+                                "Migrated normalized key for recurring pattern {PatternId} to '{NormalizedKey}'",
+                                only.Id, canonicalKey);
+                        }
+                        continue;
                     }
-                    continue;
+
+                    // Choose the canonical so explicit user intent survives the merge: prefer a
+                    // Paused/Cancelled row (user actions that MergeDuplicatePatternsAsync preserves)
+                    // over Active/AtRisk, then the strongest by occurrences and confidence.
+                    var canonicalPattern = cluster
+                        .OrderByDescending(p => IsUserManagedStatus(p.Status))
+                        .ThenByDescending(p => p.OccurrenceCount)
+                        .ThenByDescending(p => p.Confidence)
+                        .First();
+
+                    var duplicateIds = cluster.Where(p => p.Id != canonicalPattern.Id).Select(p => p.Id).ToList();
+
+                    // Merge occurrence history (counts) and adopt the freshest observation/amount.
+                    var mostRecent = cluster.OrderByDescending(p => p.LastObservedAt).First();
+
+                    await _patternRepository.MergeDuplicatePatternsAsync(
+                        userId,
+                        canonicalPattern.Id,
+                        duplicateIds,
+                        mergedNormalizedKey: canonicalKey,
+                        mergedOccurrenceCount: cluster.Sum(p => p.OccurrenceCount),
+                        mergedAverageAmount: mostRecent.AverageAmount,
+                        mergedLastObservedAt: mostRecent.LastObservedAt,
+                        mergedNextExpectedDate: mostRecent.NextExpectedDate,
+                        cancellationToken);
+
+                    _logger.LogInformation(
+                        "Reconciled {DuplicateCount} duplicate recurring pattern(s) into {CanonicalId} for merchant {MerchantName}",
+                        duplicateIds.Count, canonicalPattern.Id, canonicalPattern.MerchantName);
                 }
-
-                // Choose the canonical so explicit user intent survives the merge: prefer a
-                // Paused/Cancelled row (user actions that MergeDuplicatePatternsAsync preserves)
-                // over Active/AtRisk, then the strongest by occurrences and confidence.
-                var canonicalPattern = members
-                    .OrderByDescending(p => IsUserManagedStatus(p.Status))
-                    .ThenByDescending(p => p.OccurrenceCount)
-                    .ThenByDescending(p => p.Confidence)
-                    .First();
-
-                var duplicateIds = members.Where(p => p.Id != canonicalPattern.Id).Select(p => p.Id).ToList();
-
-                // Merge occurrence history (counts) and adopt the freshest observation/amount.
-                var mostRecent = members.OrderByDescending(p => p.LastObservedAt).First();
-
-                await _patternRepository.MergeDuplicatePatternsAsync(
-                    userId,
-                    canonicalPattern.Id,
-                    duplicateIds,
-                    mergedNormalizedKey: group.Key,
-                    mergedOccurrenceCount: members.Sum(p => p.OccurrenceCount),
-                    mergedAverageAmount: mostRecent.AverageAmount,
-                    mergedLastObservedAt: mostRecent.LastObservedAt,
-                    mergedNextExpectedDate: mostRecent.NextExpectedDate,
-                    cancellationToken);
-
-                _logger.LogInformation(
-                    "Reconciled {DuplicateCount} duplicate recurring pattern(s) into {CanonicalId} for merchant {MerchantName}",
-                    duplicateIds.Count, canonicalPattern.Id, canonicalPattern.MerchantName);
             }
         }
         catch (Exception ex)
@@ -456,6 +465,84 @@ public class RecurringPatternPersistenceService : IRecurringPatternPersistenceSe
     /// </summary>
     private static bool IsUserManagedStatus(RecurringPatternStatus status)
         => status is RecurringPatternStatus.Paused or RecurringPatternStatus.Cancelled;
+
+    // Amount tolerance for treating two fuzzy-name-matched patterns as the same recurring bill.
+    private const decimal MergeAmountTolerance = 0.2m; // ±20%
+
+    /// <summary>
+    /// Splits a name-similarity group into clusters that are safe to destructively merge.
+    /// Two patterns join the same cluster only when they share the exact normalized key
+    /// (unambiguous duplicate) OR they have the same cadence AND closely-matching amounts —
+    /// so two distinct merchants with merely-similar names are never merged. Uses union-find
+    /// for transitivity within the group.
+    /// </summary>
+    private static List<List<RecurringPattern>> PartitionByMergeEvidence(
+        List<RecurringPattern> members,
+        Func<RecurringPattern, string> normalizedKeyOf)
+    {
+        if (members.Count <= 1)
+            return new List<List<RecurringPattern>> { members };
+
+        var parent = Enumerable.Range(0, members.Count).ToArray();
+
+        int Find(int x)
+        {
+            while (parent[x] != x)
+            {
+                parent[x] = parent[parent[x]];
+                x = parent[x];
+            }
+            return x;
+        }
+
+        void Union(int a, int b)
+        {
+            var rootA = Find(a);
+            var rootB = Find(b);
+            if (rootA != rootB)
+                parent[rootB] = rootA;
+        }
+
+        for (var i = 0; i < members.Count; i++)
+        {
+            for (var j = i + 1; j < members.Count; j++)
+            {
+                if (AreSameRecurringBill(members[i], members[j], normalizedKeyOf))
+                    Union(i, j);
+            }
+        }
+
+        return members
+            .Select((pattern, index) => (pattern, root: Find(index)))
+            .GroupBy(x => x.root)
+            .Select(g => g.Select(x => x.pattern).ToList())
+            .ToList();
+    }
+
+    /// <summary>
+    /// Whether two persisted patterns are confidently the same recurring bill: an exact
+    /// normalized-key match, or a fuzzy-name match backed by the same cadence and close amounts.
+    /// </summary>
+    private static bool AreSameRecurringBill(
+        RecurringPattern a,
+        RecurringPattern b,
+        Func<RecurringPattern, string> normalizedKeyOf)
+    {
+        // Identical normalized merchant key — the unambiguous duplicate case the bug is about.
+        if (string.Equals(normalizedKeyOf(a), normalizedKeyOf(b), StringComparison.Ordinal))
+            return true;
+
+        // Fuzzy name match (same name-similarity group) requires corroborating evidence.
+        var sameCadence = a.GetIntervalName() == b.GetIntervalName();
+
+        var larger = Math.Max(a.AverageAmount, b.AverageAmount);
+        var smaller = Math.Min(a.AverageAmount, b.AverageAmount);
+        var closeAmount = larger <= 0
+            ? smaller <= 0
+            : (larger - smaller) <= larger * MergeAmountTolerance;
+
+        return sameCadence && closeAmount;
+    }
 
     private RecurringPattern? DetectPattern(string merchantKey, List<Transaction> transactions, DateTime today)
     {

--- a/src/Core/MyMascada.Application/Features/RecurringPatterns/Services/RecurringPatternPersistenceService.cs
+++ b/src/Core/MyMascada.Application/Features/RecurringPatterns/Services/RecurringPatternPersistenceService.cs
@@ -1,7 +1,7 @@
-using System.Text.RegularExpressions;
 using Microsoft.Extensions.Logging;
 using MyMascada.Application.Common.Interfaces;
 using MyMascada.Application.Features.UpcomingBills.DTOs;
+using MyMascada.Domain.Common;
 using MyMascada.Domain.Entities;
 using MyMascada.Domain.Enums;
 
@@ -76,6 +76,11 @@ public class RecurringPatternPersistenceService : IRecurringPatternPersistenceSe
     /// </summary>
     public async Task<int> DetectAndPersistPatternsAsync(Guid userId, CancellationToken cancellationToken = default)
     {
+        // Self-heal: merge any already-persisted duplicate patterns for this user so existing
+        // accounts (which may already have several stale rows for the same merchant) converge
+        // to a single canonical pattern. Runs every detection pass via the background job.
+        await ReconcileDuplicatePatternsAsync(userId, cancellationToken);
+
         var today = DateTime.UtcNow.Date;
         var startDate = today.AddMonths(-LookbackMonths);
 
@@ -258,7 +263,13 @@ public class RecurringPatternPersistenceService : IRecurringPatternPersistenceSe
             };
         }
 
-        var bills = upcomingPatterns.Select(p => new UpcomingBillDto
+        // Safety net: even if duplicate pattern rows still exist for the same merchant
+        // (e.g. before the reconciliation pass has run), consolidate them here so the user
+        // never sees the same merchant more than once. Keep the soonest-due / highest-confidence
+        // pattern and prefer the most recently observed amount.
+        var consolidatedPatterns = ConsolidateByMerchant(upcomingPatterns, today);
+
+        var bills = consolidatedPatterns.Select(p => new UpcomingBillDto
         {
             PatternId = p.Id,
             MerchantName = p.MerchantName,
@@ -280,6 +291,50 @@ public class RecurringPatternPersistenceService : IRecurringPatternPersistenceSe
             TotalBillsCount = bills.Count,
             TotalExpectedAmount = bills.Sum(b => b.ExpectedAmount)
         };
+    }
+
+    /// <summary>
+    /// Collapses patterns that resolve to the same merchant (identical normalized key, or
+    /// near-duplicate via the shared similarity rule) into a single representative pattern.
+    /// The representative is the soonest-due, then highest-confidence pattern; its amount is
+    /// taken from the most recently observed pattern in the group.
+    /// </summary>
+    private static List<RecurringPattern> ConsolidateByMerchant(
+        IEnumerable<RecurringPattern> patterns,
+        DateTime today)
+    {
+        var patternList = patterns.ToList();
+        if (patternList.Count <= 1)
+            return patternList;
+
+        // Build a similarity grouping over the distinct normalized keys.
+        var keys = patternList
+            .Select(p => p.NormalizedMerchantKey ?? string.Empty)
+            .ToList();
+        var canonicalByKey = MerchantNormalizer.GroupSimilarKeys(keys);
+
+        var grouped = patternList
+            .GroupBy(p => canonicalByKey.TryGetValue(p.NormalizedMerchantKey ?? string.Empty, out var canonical)
+                ? canonical
+                : (p.NormalizedMerchantKey ?? string.Empty));
+
+        var result = new List<RecurringPattern>();
+        foreach (var group in grouped)
+        {
+            // Representative = soonest due, then highest confidence.
+            var representative = group
+                .OrderBy(p => p.GetDaysUntilDue(today))
+                .ThenByDescending(p => p.Confidence)
+                .First();
+
+            // Prefer the most recently observed amount across the duplicate rows.
+            var mostRecent = group.OrderByDescending(p => p.LastObservedAt).First();
+            representative.AverageAmount = mostRecent.AverageAmount;
+
+            result.Add(representative);
+        }
+
+        return result;
     }
 
     #region Private Helper Methods
@@ -305,37 +360,104 @@ public class RecurringPatternPersistenceService : IRecurringPatternPersistenceSe
         return MergeSimilarGroups(groups);
     }
 
-    private Dictionary<string, List<Transaction>> MergeSimilarGroups(Dictionary<string, List<Transaction>> groups)
+    private static Dictionary<string, List<Transaction>> MergeSimilarGroups(Dictionary<string, List<Transaction>> groups)
     {
+        if (groups.Count <= 1)
+            return groups;
+
+        // Transitive grouping: union-find collapses A~B~C into one group even when A is not
+        // directly similar to C. This is the key fix for the same-merchant-split-into-many bug.
+        var canonicalByKey = MerchantNormalizer.GroupSimilarKeys(groups.Keys.ToList());
+
         var mergedGroups = new Dictionary<string, List<Transaction>>();
-        var processedKeys = new HashSet<string>();
+        var componentMembers = new Dictionary<string, List<string>>();
 
-        foreach (var group in groups.OrderByDescending(g => g.Value.Count))
+        foreach (var key in groups.Keys)
         {
-            if (processedKeys.Contains(group.Key))
-                continue;
-
-            var mergedList = new List<Transaction>(group.Value);
-            processedKeys.Add(group.Key);
-
-            // Find similar groups
-            foreach (var otherGroup in groups)
+            var canonical = canonicalByKey.TryGetValue(key, out var c) ? c : key;
+            if (!componentMembers.TryGetValue(canonical, out var members))
             {
-                if (processedKeys.Contains(otherGroup.Key))
-                    continue;
-
-                var similarity = CalculateStringSimilarity(group.Key, otherGroup.Key);
-                if (similarity > 0.8m) // 80% similar = same merchant
-                {
-                    mergedList.AddRange(otherGroup.Value);
-                    processedKeys.Add(otherGroup.Key);
-                }
+                members = new List<string>();
+                componentMembers[canonical] = members;
             }
+            members.Add(key);
+        }
 
-            mergedGroups[group.Key] = mergedList;
+        foreach (var (_, members) in componentMembers)
+        {
+            // Choose the display key as the member with the most transactions (most common
+            // representation of the merchant), so the resulting pattern uses a sensible key.
+            var displayKey = members
+                .OrderByDescending(k => groups[k].Count)
+                .ThenBy(k => k, StringComparer.Ordinal)
+                .First();
+
+            var mergedList = members.SelectMany(k => groups[k]).ToList();
+            mergedGroups[displayKey] = mergedList;
         }
 
         return mergedGroups;
+    }
+
+    /// <summary>
+    /// Merges already-persisted duplicate <see cref="RecurringPattern"/> rows for a user.
+    /// Active patterns are grouped by normalized/similar merchant key; one canonical pattern
+    /// is kept (most occurrences, then highest confidence) with merged occurrence counts and
+    /// the most recent amount/next-expected-date, and the rest are soft-deleted.
+    /// </summary>
+    private async Task ReconcileDuplicatePatternsAsync(Guid userId, CancellationToken cancellationToken)
+    {
+        try
+        {
+            var activePatterns = (await _patternRepository.GetActiveAsync(userId, cancellationToken)).ToList();
+            if (activePatterns.Count <= 1)
+                return;
+
+            var canonicalByKey = MerchantNormalizer.GroupSimilarKeys(
+                activePatterns.Select(p => p.NormalizedMerchantKey ?? string.Empty).ToList());
+
+            var groups = activePatterns
+                .GroupBy(p => canonicalByKey.TryGetValue(p.NormalizedMerchantKey ?? string.Empty, out var canonical)
+                    ? canonical
+                    : (p.NormalizedMerchantKey ?? string.Empty))
+                .Where(g => g.Count() > 1)
+                .ToList();
+
+            foreach (var group in groups)
+            {
+                var members = group.ToList();
+
+                // Keep the strongest pattern: most occurrences, then highest confidence.
+                var canonicalPattern = members
+                    .OrderByDescending(p => p.OccurrenceCount)
+                    .ThenByDescending(p => p.Confidence)
+                    .First();
+
+                var duplicateIds = members.Where(p => p.Id != canonicalPattern.Id).Select(p => p.Id).ToList();
+
+                // Merge occurrence history (counts) and adopt the freshest observation/amount.
+                var mostRecent = members.OrderByDescending(p => p.LastObservedAt).First();
+
+                await _patternRepository.MergeDuplicatePatternsAsync(
+                    userId,
+                    canonicalPattern.Id,
+                    duplicateIds,
+                    mergedOccurrenceCount: members.Sum(p => p.OccurrenceCount),
+                    mergedAverageAmount: mostRecent.AverageAmount,
+                    mergedLastObservedAt: mostRecent.LastObservedAt,
+                    mergedNextExpectedDate: mostRecent.NextExpectedDate,
+                    cancellationToken);
+
+                _logger.LogInformation(
+                    "Reconciled {DuplicateCount} duplicate recurring pattern(s) into {CanonicalId} for merchant {MerchantName}",
+                    duplicateIds.Count, canonicalPattern.Id, canonicalPattern.MerchantName);
+            }
+        }
+        catch (Exception ex)
+        {
+            // Reconciliation is best-effort self-healing; never let it break detection.
+            _logger.LogError(ex, "Failed to reconcile duplicate recurring patterns for user {UserId}", userId);
+        }
     }
 
     private RecurringPattern? DetectPattern(string merchantKey, List<Transaction> transactions, DateTime today)
@@ -459,31 +581,7 @@ public class RecurringPatternPersistenceService : IRecurringPatternPersistenceSe
     }
 
     private static string NormalizeDescription(string? description)
-    {
-        if (string.IsNullOrWhiteSpace(description))
-            return string.Empty;
-
-        // Convert to lowercase and remove extra whitespace
-        var normalized = Regex.Replace(description.ToLowerInvariant().Trim(), @"\s+", " ");
-
-        // Remove common transaction prefixes/suffixes
-        normalized = Regex.Replace(normalized, @"^(purchase\s+|payment\s+|pos\s+|debit\s+|eftpos\s+)", "");
-
-        // Remove reference numbers (patterns like #123, REF:ABC123, etc.)
-        normalized = Regex.Replace(normalized, @"(#|ref:?|id:?)\s*[\w\d-]+", "");
-
-        // Remove dates (patterns like 01/15, 15-Jan, etc.)
-        normalized = Regex.Replace(normalized, @"\d{1,2}[/-]\d{1,2}([/-]\d{2,4})?", "");
-
-        // Remove time patterns
-        normalized = Regex.Replace(normalized, @"\d{1,2}:\d{2}(:\d{2})?(\s*(am|pm))?", "");
-
-        // Remove trailing numbers that might be transaction IDs
-        normalized = Regex.Replace(normalized, @"\s+\d+$", "");
-
-        // Clean up extra whitespace again
-        return Regex.Replace(normalized.Trim(), @"\s+", " ");
-    }
+        => MerchantNormalizer.Normalize(description);
 
     private static string FormatMerchantName(string? description)
     {
@@ -497,47 +595,6 @@ public class RecurringPatternPersistenceService : IRecurringPatternPersistenceSe
             return "Unknown Merchant";
 
         return System.Globalization.CultureInfo.CurrentCulture.TextInfo.ToTitleCase(normalized);
-    }
-
-    private static decimal CalculateStringSimilarity(string str1, string str2)
-    {
-        if (string.IsNullOrEmpty(str1) && string.IsNullOrEmpty(str2))
-            return 1m;
-
-        if (string.IsNullOrEmpty(str1) || string.IsNullOrEmpty(str2))
-            return 0m;
-
-        var distance = LevenshteinDistance(str1, str2);
-        var maxLength = Math.Max(str1.Length, str2.Length);
-
-        return 1m - (decimal)distance / maxLength;
-    }
-
-    private static int LevenshteinDistance(string s1, string s2)
-    {
-        if (s1.Length == 0) return s2.Length;
-        if (s2.Length == 0) return s1.Length;
-
-        var matrix = new int[s1.Length + 1, s2.Length + 1];
-
-        for (int i = 0; i <= s1.Length; i++)
-            matrix[i, 0] = i;
-
-        for (int j = 0; j <= s2.Length; j++)
-            matrix[0, j] = j;
-
-        for (int i = 1; i <= s1.Length; i++)
-        {
-            for (int j = 1; j <= s2.Length; j++)
-            {
-                var cost = (s1[i - 1] == s2[j - 1]) ? 0 : 1;
-                matrix[i, j] = Math.Min(
-                    Math.Min(matrix[i - 1, j] + 1, matrix[i, j - 1] + 1),
-                    matrix[i - 1, j - 1] + cost);
-            }
-        }
-
-        return matrix[s1.Length, s2.Length];
     }
 
     #endregion

--- a/src/Core/MyMascada.Application/Features/RecurringPatterns/Services/RecurringPatternPersistenceService.cs
+++ b/src/Core/MyMascada.Application/Features/RecurringPatterns/Services/RecurringPatternPersistenceService.cs
@@ -395,28 +395,31 @@ public class RecurringPatternPersistenceService : IRecurringPatternPersistenceSe
 
             foreach (var group in groups)
             {
-                var canonicalKey = group.Key;
-
                 // Name similarity alone is not enough to destructively merge two persisted
                 // patterns: two legitimately-distinct merchants can have near-identical names.
                 // Split each name-group into merge clusters that additionally require compatible
                 // evidence (same exact normalized key, OR same cadence AND close amounts), so we
                 // only soft-delete + reparent rows that are genuinely the same recurring bill.
-                var clusters = PartitionByMergeEvidence(group.ToList(), p => normalizedByPattern[p]);
+                var clusters = RecurringPatternGrouping.PartitionBySameBill(group.ToList(), p => normalizedByPattern[p]);
 
                 foreach (var cluster in clusters)
                 {
+                    // Derive the key from THIS cluster's members, not the wider name-similarity
+                    // group: a group can split into clusters belonging to different merchants, and
+                    // using the group key would rewrite a cluster to the wrong merchant's key.
+                    var clusterKey = ChooseClusterKey(cluster, normalizedByPattern);
+
                     if (cluster.Count == 1)
                     {
                         // Lone row: migrate a stale stored key to the normalized form so the next
                         // exact-key upsert updates this row instead of creating a duplicate.
                         var only = cluster[0];
-                        if (!string.IsNullOrWhiteSpace(canonicalKey) && only.NormalizedMerchantKey != canonicalKey)
+                        if (!string.IsNullOrWhiteSpace(clusterKey) && only.NormalizedMerchantKey != clusterKey)
                         {
-                            await _patternRepository.UpdateNormalizedKeyAsync(userId, only.Id, canonicalKey, cancellationToken);
+                            await _patternRepository.UpdateNormalizedKeyAsync(userId, only.Id, clusterKey, cancellationToken);
                             _logger.LogInformation(
                                 "Migrated normalized key for recurring pattern {PatternId} to '{NormalizedKey}'",
-                                only.Id, canonicalKey);
+                                only.Id, clusterKey);
                         }
                         continue;
                     }
@@ -439,7 +442,7 @@ public class RecurringPatternPersistenceService : IRecurringPatternPersistenceSe
                         userId,
                         canonicalPattern.Id,
                         duplicateIds,
-                        mergedNormalizedKey: canonicalKey,
+                        mergedNormalizedKey: clusterKey,
                         mergedOccurrenceCount: cluster.Sum(p => p.OccurrenceCount),
                         mergedAverageAmount: mostRecent.AverageAmount,
                         mergedLastObservedAt: mostRecent.LastObservedAt,
@@ -466,82 +469,23 @@ public class RecurringPatternPersistenceService : IRecurringPatternPersistenceSe
     private static bool IsUserManagedStatus(RecurringPatternStatus status)
         => status is RecurringPatternStatus.Paused or RecurringPatternStatus.Cancelled;
 
-    // Amount tolerance for treating two fuzzy-name-matched patterns as the same recurring bill.
-    private const decimal MergeAmountTolerance = 0.2m; // ±20%
-
     /// <summary>
-    /// Splits a name-similarity group into clusters that are safe to destructively merge.
-    /// Two patterns join the same cluster only when they share the exact normalized key
-    /// (unambiguous duplicate) OR they have the same cadence AND closely-matching amounts —
-    /// so two distinct merchants with merely-similar names are never merged. Uses union-find
-    /// for transitivity within the group.
+    /// Picks the normalized key to apply to a merge cluster: the most common normalized key among
+    /// its members (ties broken deterministically), so the cluster converges to its own merchant's
+    /// key rather than a wider name-similarity group's representative.
     /// </summary>
-    private static List<List<RecurringPattern>> PartitionByMergeEvidence(
-        List<RecurringPattern> members,
-        Func<RecurringPattern, string> normalizedKeyOf)
+    private static string ChooseClusterKey(
+        List<RecurringPattern> cluster,
+        IReadOnlyDictionary<RecurringPattern, string> normalizedByPattern)
     {
-        if (members.Count <= 1)
-            return new List<List<RecurringPattern>> { members };
-
-        var parent = Enumerable.Range(0, members.Count).ToArray();
-
-        int Find(int x)
-        {
-            while (parent[x] != x)
-            {
-                parent[x] = parent[parent[x]];
-                x = parent[x];
-            }
-            return x;
-        }
-
-        void Union(int a, int b)
-        {
-            var rootA = Find(a);
-            var rootB = Find(b);
-            if (rootA != rootB)
-                parent[rootB] = rootA;
-        }
-
-        for (var i = 0; i < members.Count; i++)
-        {
-            for (var j = i + 1; j < members.Count; j++)
-            {
-                if (AreSameRecurringBill(members[i], members[j], normalizedKeyOf))
-                    Union(i, j);
-            }
-        }
-
-        return members
-            .Select((pattern, index) => (pattern, root: Find(index)))
-            .GroupBy(x => x.root)
-            .Select(g => g.Select(x => x.pattern).ToList())
-            .ToList();
-    }
-
-    /// <summary>
-    /// Whether two persisted patterns are confidently the same recurring bill: an exact
-    /// normalized-key match, or a fuzzy-name match backed by the same cadence and close amounts.
-    /// </summary>
-    private static bool AreSameRecurringBill(
-        RecurringPattern a,
-        RecurringPattern b,
-        Func<RecurringPattern, string> normalizedKeyOf)
-    {
-        // Identical normalized merchant key — the unambiguous duplicate case the bug is about.
-        if (string.Equals(normalizedKeyOf(a), normalizedKeyOf(b), StringComparison.Ordinal))
-            return true;
-
-        // Fuzzy name match (same name-similarity group) requires corroborating evidence.
-        var sameCadence = a.GetIntervalName() == b.GetIntervalName();
-
-        var larger = Math.Max(a.AverageAmount, b.AverageAmount);
-        var smaller = Math.Min(a.AverageAmount, b.AverageAmount);
-        var closeAmount = larger <= 0
-            ? smaller <= 0
-            : (larger - smaller) <= larger * MergeAmountTolerance;
-
-        return sameCadence && closeAmount;
+        return cluster
+            .Select(p => normalizedByPattern[p])
+            .Where(k => !string.IsNullOrWhiteSpace(k))
+            .GroupBy(k => k)
+            .OrderByDescending(g => g.Count())
+            .ThenBy(g => g.Key, StringComparer.Ordinal)
+            .Select(g => g.Key)
+            .FirstOrDefault() ?? string.Empty;
     }
 
     private RecurringPattern? DetectPattern(string merchantKey, List<Transaction> transactions, DateTime today)

--- a/src/Core/MyMascada.Application/Features/RecurringPatterns/Services/RecurringPatternPersistenceService.cs
+++ b/src/Core/MyMascada.Application/Features/RecurringPatterns/Services/RecurringPatternPersistenceService.cs
@@ -400,7 +400,7 @@ public class RecurringPatternPersistenceService : IRecurringPatternPersistenceSe
                 // Split each name-group into merge clusters that additionally require compatible
                 // evidence (same exact normalized key, OR same cadence AND close amounts), so we
                 // only soft-delete + reparent rows that are genuinely the same recurring bill.
-                var clusters = RecurringPatternGrouping.PartitionBySameBill(group.ToList(), p => normalizedByPattern[p]);
+                var clusters = RecurringPatternGrouping.PartitionBySameBill(group.ToList());
 
                 foreach (var cluster in clusters)
                 {

--- a/src/Core/MyMascada.Application/Features/UpcomingBills/Services/RecurringPatternService.cs
+++ b/src/Core/MyMascada.Application/Features/UpcomingBills/Services/RecurringPatternService.cs
@@ -83,20 +83,21 @@ public class RecurringPatternService : IRecurringPatternService
 
         // Safety net: consolidate any duplicate pattern rows that resolve to the same merchant
         // so the dashboard never shows the same bill multiple times, even if stale duplicate
-        // rows still exist in the database.
-        var consolidatedPatterns = ConsolidateByMerchant(upcomingPatterns, today);
+        // rows still exist in the database. ConsolidateUpcoming is pure and does not mutate the
+        // (EF-tracked) pattern entities.
+        var consolidated = MerchantConsolidation.ConsolidateUpcoming(upcomingPatterns, today);
 
-        var bills = consolidatedPatterns.Select(p => new UpcomingBillDto
+        var bills = consolidated.Select(c => new UpcomingBillDto
         {
-            PatternId = p.Id,
-            MerchantName = p.MerchantName,
-            ExpectedAmount = Math.Round(p.AverageAmount, 2),
-            ExpectedDate = p.NextExpectedDate,
-            DaysUntilDue = p.GetDaysUntilDue(today),
-            ConfidenceScore = Math.Round(p.Confidence, 2),
-            ConfidenceLevel = p.GetConfidenceLevel(),
-            Interval = p.GetIntervalName(),
-            OccurrenceCount = p.OccurrenceCount
+            PatternId = c.Pattern.Id,
+            MerchantName = c.Pattern.MerchantName,
+            ExpectedAmount = Math.Round(c.DisplayAmount, 2),
+            ExpectedDate = c.Pattern.NextExpectedDate,
+            DaysUntilDue = c.Pattern.GetDaysUntilDue(today),
+            ConfidenceScore = Math.Round(c.Pattern.Confidence, 2),
+            ConfidenceLevel = c.Pattern.GetConfidenceLevel(),
+            Interval = c.Pattern.GetIntervalName(),
+            OccurrenceCount = c.Pattern.OccurrenceCount
         })
         .OrderBy(b => b.DaysUntilDue)
         .ThenByDescending(b => b.ConfidenceScore)
@@ -108,45 +109,6 @@ public class RecurringPatternService : IRecurringPatternService
             TotalBillsCount = bills.Count,
             TotalExpectedAmount = bills.Sum(b => b.ExpectedAmount)
         };
-    }
-
-    /// <summary>
-    /// Collapses patterns that resolve to the same merchant (identical normalized key, or
-    /// near-duplicate via the shared similarity rule) into a single representative pattern.
-    /// The representative is the soonest-due, then highest-confidence pattern; its amount is
-    /// taken from the most recently observed pattern in the group.
-    /// </summary>
-    private static List<RecurringPattern> ConsolidateByMerchant(
-        IEnumerable<RecurringPattern> patterns,
-        DateTime today)
-    {
-        var patternList = patterns.ToList();
-        if (patternList.Count <= 1)
-            return patternList;
-
-        var canonicalByKey = MerchantNormalizer.GroupSimilarKeys(
-            patternList.Select(p => p.NormalizedMerchantKey ?? string.Empty).ToList());
-
-        var grouped = patternList
-            .GroupBy(p => canonicalByKey.TryGetValue(p.NormalizedMerchantKey ?? string.Empty, out var canonical)
-                ? canonical
-                : (p.NormalizedMerchantKey ?? string.Empty));
-
-        var result = new List<RecurringPattern>();
-        foreach (var group in grouped)
-        {
-            var representative = group
-                .OrderBy(p => p.GetDaysUntilDue(today))
-                .ThenByDescending(p => p.Confidence)
-                .First();
-
-            var mostRecent = group.OrderByDescending(p => p.LastObservedAt).First();
-            representative.AverageAmount = mostRecent.AverageAmount;
-
-            result.Add(representative);
-        }
-
-        return result;
     }
 
     /// <summary>

--- a/src/Core/MyMascada.Application/Features/UpcomingBills/Services/RecurringPatternService.cs
+++ b/src/Core/MyMascada.Application/Features/UpcomingBills/Services/RecurringPatternService.cs
@@ -1,6 +1,6 @@
-using System.Text.RegularExpressions;
 using MyMascada.Application.Common.Interfaces;
 using MyMascada.Application.Features.UpcomingBills.DTOs;
+using MyMascada.Domain.Common;
 using MyMascada.Domain.Entities;
 
 namespace MyMascada.Application.Features.UpcomingBills.Services;
@@ -81,7 +81,12 @@ public class RecurringPatternService : IRecurringPatternService
             };
         }
 
-        var bills = upcomingPatterns.Select(p => new UpcomingBillDto
+        // Safety net: consolidate any duplicate pattern rows that resolve to the same merchant
+        // so the dashboard never shows the same bill multiple times, even if stale duplicate
+        // rows still exist in the database.
+        var consolidatedPatterns = ConsolidateByMerchant(upcomingPatterns, today);
+
+        var bills = consolidatedPatterns.Select(p => new UpcomingBillDto
         {
             PatternId = p.Id,
             MerchantName = p.MerchantName,
@@ -103,6 +108,45 @@ public class RecurringPatternService : IRecurringPatternService
             TotalBillsCount = bills.Count,
             TotalExpectedAmount = bills.Sum(b => b.ExpectedAmount)
         };
+    }
+
+    /// <summary>
+    /// Collapses patterns that resolve to the same merchant (identical normalized key, or
+    /// near-duplicate via the shared similarity rule) into a single representative pattern.
+    /// The representative is the soonest-due, then highest-confidence pattern; its amount is
+    /// taken from the most recently observed pattern in the group.
+    /// </summary>
+    private static List<RecurringPattern> ConsolidateByMerchant(
+        IEnumerable<RecurringPattern> patterns,
+        DateTime today)
+    {
+        var patternList = patterns.ToList();
+        if (patternList.Count <= 1)
+            return patternList;
+
+        var canonicalByKey = MerchantNormalizer.GroupSimilarKeys(
+            patternList.Select(p => p.NormalizedMerchantKey ?? string.Empty).ToList());
+
+        var grouped = patternList
+            .GroupBy(p => canonicalByKey.TryGetValue(p.NormalizedMerchantKey ?? string.Empty, out var canonical)
+                ? canonical
+                : (p.NormalizedMerchantKey ?? string.Empty));
+
+        var result = new List<RecurringPattern>();
+        foreach (var group in grouped)
+        {
+            var representative = group
+                .OrderBy(p => p.GetDaysUntilDue(today))
+                .ThenByDescending(p => p.Confidence)
+                .First();
+
+            var mostRecent = group.OrderByDescending(p => p.LastObservedAt).First();
+            representative.AverageAmount = mostRecent.AverageAmount;
+
+            result.Add(representative);
+        }
+
+        return result;
     }
 
     /// <summary>
@@ -184,34 +228,36 @@ public class RecurringPatternService : IRecurringPatternService
         return MergeSimilarGroups(groups);
     }
 
-    private Dictionary<string, List<Transaction>> MergeSimilarGroups(Dictionary<string, List<Transaction>> groups)
+    private static Dictionary<string, List<Transaction>> MergeSimilarGroups(Dictionary<string, List<Transaction>> groups)
     {
-        var mergedGroups = new Dictionary<string, List<Transaction>>();
-        var processedKeys = new HashSet<string>();
+        if (groups.Count <= 1)
+            return groups;
 
-        foreach (var group in groups.OrderByDescending(g => g.Value.Count))
+        // Transitive grouping via union-find: collapses A~B~C into one group even when A is
+        // not directly similar to C, so a single merchant never splits into multiple bills.
+        var canonicalByKey = MerchantNormalizer.GroupSimilarKeys(groups.Keys.ToList());
+
+        var componentMembers = new Dictionary<string, List<string>>();
+        foreach (var key in groups.Keys)
         {
-            if (processedKeys.Contains(group.Key))
-                continue;
-
-            var mergedList = new List<Transaction>(group.Value);
-            processedKeys.Add(group.Key);
-
-            // Find similar groups
-            foreach (var otherGroup in groups)
+            var canonical = canonicalByKey.TryGetValue(key, out var c) ? c : key;
+            if (!componentMembers.TryGetValue(canonical, out var members))
             {
-                if (processedKeys.Contains(otherGroup.Key))
-                    continue;
-
-                var similarity = CalculateStringSimilarity(group.Key, otherGroup.Key);
-                if (similarity > 0.8m) // 80% similar = same merchant
-                {
-                    mergedList.AddRange(otherGroup.Value);
-                    processedKeys.Add(otherGroup.Key);
-                }
+                members = new List<string>();
+                componentMembers[canonical] = members;
             }
+            members.Add(key);
+        }
 
-            mergedGroups[group.Key] = mergedList;
+        var mergedGroups = new Dictionary<string, List<Transaction>>();
+        foreach (var (_, members) in componentMembers)
+        {
+            var displayKey = members
+                .OrderByDescending(k => groups[k].Count)
+                .ThenBy(k => k, StringComparer.Ordinal)
+                .First();
+
+            mergedGroups[displayKey] = members.SelectMany(k => groups[k]).ToList();
         }
 
         return mergedGroups;
@@ -355,36 +401,10 @@ public class RecurringPatternService : IRecurringPatternService
         return Math.Min(1.0m, confidenceScore);
     }
 
-    private string NormalizeDescription(string? description)
-    {
-        if (string.IsNullOrWhiteSpace(description))
-            return string.Empty;
+    private static string NormalizeDescription(string? description)
+        => MerchantNormalizer.Normalize(description);
 
-        // Convert to lowercase and remove extra whitespace
-        var normalized = Regex.Replace(description.ToLowerInvariant().Trim(), @"\s+", " ");
-
-        // Remove common transaction prefixes/suffixes
-        normalized = Regex.Replace(normalized, @"^(purchase\s+|payment\s+|pos\s+|debit\s+|eftpos\s+)", "");
-
-        // Remove reference numbers (patterns like #123, REF:ABC123, etc.)
-        normalized = Regex.Replace(normalized, @"(#|ref:?|id:?)\s*[\w\d-]+", "");
-
-        // Remove dates (patterns like 01/15, 15-Jan, etc.)
-        normalized = Regex.Replace(normalized, @"\d{1,2}[/-]\d{1,2}([/-]\d{2,4})?", "");
-
-        // Remove time patterns
-        normalized = Regex.Replace(normalized, @"\d{1,2}:\d{2}(:\d{2})?(\s*(am|pm))?", "");
-
-        // Remove trailing numbers that might be transaction IDs
-        normalized = Regex.Replace(normalized, @"\s+\d+$", "");
-
-        // Clean up extra whitespace again
-        normalized = Regex.Replace(normalized.Trim(), @"\s+", " ");
-
-        return normalized;
-    }
-
-    private string FormatMerchantName(string? description)
+    private static string FormatMerchantName(string? description)
     {
         if (string.IsNullOrWhiteSpace(description))
             return "Unknown Merchant";
@@ -396,46 +416,5 @@ public class RecurringPatternService : IRecurringPatternService
             return "Unknown Merchant";
 
         return System.Globalization.CultureInfo.CurrentCulture.TextInfo.ToTitleCase(normalized);
-    }
-
-    private decimal CalculateStringSimilarity(string str1, string str2)
-    {
-        if (string.IsNullOrEmpty(str1) && string.IsNullOrEmpty(str2))
-            return 1m;
-
-        if (string.IsNullOrEmpty(str1) || string.IsNullOrEmpty(str2))
-            return 0m;
-
-        var distance = LevenshteinDistance(str1, str2);
-        var maxLength = Math.Max(str1.Length, str2.Length);
-
-        return 1m - (decimal)distance / maxLength;
-    }
-
-    private int LevenshteinDistance(string s1, string s2)
-    {
-        if (s1.Length == 0) return s2.Length;
-        if (s2.Length == 0) return s1.Length;
-
-        var matrix = new int[s1.Length + 1, s2.Length + 1];
-
-        for (int i = 0; i <= s1.Length; i++)
-            matrix[i, 0] = i;
-
-        for (int j = 0; j <= s2.Length; j++)
-            matrix[0, j] = j;
-
-        for (int i = 1; i <= s1.Length; i++)
-        {
-            for (int j = 1; j <= s2.Length; j++)
-            {
-                var cost = (s1[i - 1] == s2[j - 1]) ? 0 : 1;
-                matrix[i, j] = Math.Min(
-                    Math.Min(matrix[i - 1, j] + 1, matrix[i, j - 1] + 1),
-                    matrix[i - 1, j - 1] + cost);
-            }
-        }
-
-        return matrix[s1.Length, s2.Length];
     }
 }

--- a/src/Core/MyMascada.Domain/Common/MerchantConsolidation.cs
+++ b/src/Core/MyMascada.Domain/Common/MerchantConsolidation.cs
@@ -1,0 +1,75 @@
+using MyMascada.Domain.Entities;
+
+namespace MyMascada.Domain.Common;
+
+/// <summary>
+/// Read-path consolidation of recurring patterns that resolve to the same merchant.
+///
+/// This is a display-time safety net: even if duplicate <see cref="RecurringPattern"/> rows
+/// still exist for one merchant, the user should only ever see a single upcoming bill. It is
+/// deliberately pure — it never mutates the supplied entities (which are typically tracked by
+/// the EF Core DbContext), returning the chosen representative plus a separate display amount.
+/// </summary>
+public static class MerchantConsolidation
+{
+    /// <summary>
+    /// A consolidated upcoming bill: the representative pattern and the amount to display
+    /// (the most recently observed amount across the duplicate group).
+    /// </summary>
+    public readonly record struct ConsolidatedPattern(RecurringPattern Pattern, decimal DisplayAmount);
+
+    /// <summary>
+    /// Collapses patterns that resolve to the same merchant (identical normalized key, or
+    /// near-duplicate via the shared similarity rule) into a single representative each.
+    /// The representative is the soonest-due, then highest-confidence pattern; the display
+    /// amount is taken from the most recently observed pattern in the group.
+    /// </summary>
+    public static List<ConsolidatedPattern> ConsolidateUpcoming(
+        IEnumerable<RecurringPattern> patterns,
+        DateTime today)
+    {
+        var patternList = patterns.ToList();
+        if (patternList.Count == 0)
+            return new List<ConsolidatedPattern>();
+
+        if (patternList.Count == 1)
+        {
+            return new List<ConsolidatedPattern>
+            {
+                new(patternList[0], patternList[0].AverageAmount)
+            };
+        }
+
+        // Re-normalize stored keys before grouping so rows persisted by an older normalizer
+        // (which may still contain reference tokens or doubled words) collapse with cleaner ones.
+        var normalizedByPattern = patternList.ToDictionary(
+            p => p,
+            p => MerchantNormalizer.Normalize(p.NormalizedMerchantKey));
+
+        var canonicalByKey = MerchantNormalizer.GroupSimilarKeys(
+            normalizedByPattern.Values.ToList());
+
+        var grouped = patternList.GroupBy(p =>
+            canonicalByKey.TryGetValue(normalizedByPattern[p], out var canonical)
+                ? canonical
+                : normalizedByPattern[p]);
+
+        var result = new List<ConsolidatedPattern>();
+        foreach (var group in grouped)
+        {
+            var representative = group
+                .OrderBy(p => p.GetDaysUntilDue(today))
+                .ThenByDescending(p => p.Confidence)
+                .First();
+
+            var displayAmount = group
+                .OrderByDescending(p => p.LastObservedAt)
+                .First()
+                .AverageAmount;
+
+            result.Add(new ConsolidatedPattern(representative, displayAmount));
+        }
+
+        return result;
+    }
+}

--- a/src/Core/MyMascada.Domain/Common/MerchantConsolidation.cs
+++ b/src/Core/MyMascada.Domain/Common/MerchantConsolidation.cs
@@ -61,8 +61,7 @@ public static class MerchantConsolidation
         {
             // Only collapse rows that are confidently the same bill; keep distinct similarly-named
             // merchants as separate dashboard entries.
-            var clusters = RecurringPatternGrouping.PartitionBySameBill(
-                nameGroup.ToList(), p => normalizedByPattern[p]);
+            var clusters = RecurringPatternGrouping.PartitionBySameBill(nameGroup.ToList());
 
             foreach (var cluster in clusters)
             {

--- a/src/Core/MyMascada.Domain/Common/MerchantConsolidation.cs
+++ b/src/Core/MyMascada.Domain/Common/MerchantConsolidation.cs
@@ -19,10 +19,12 @@ public static class MerchantConsolidation
     public readonly record struct ConsolidatedPattern(RecurringPattern Pattern, decimal DisplayAmount);
 
     /// <summary>
-    /// Collapses patterns that resolve to the same merchant (identical normalized key, or
-    /// near-duplicate via the shared similarity rule) into a single representative each.
-    /// The representative is the soonest-due, then highest-confidence pattern; the display
-    /// amount is taken from the most recently observed pattern in the group.
+    /// Collapses patterns that are confidently the same recurring bill into a single representative
+    /// each. Patterns are first grouped by merchant-name similarity, then each name-group is split
+    /// by corroborating evidence (exact normalized key, or same cadence + close amount) so two
+    /// distinct merchants with similar names are NOT collapsed into one — which would hide a real
+    /// bill from the dashboard. The representative is the soonest-due, then highest-confidence
+    /// pattern; the display amount is the most recently observed amount in the cluster.
     /// </summary>
     public static List<ConsolidatedPattern> ConsolidateUpcoming(
         IEnumerable<RecurringPattern> patterns,
@@ -49,25 +51,33 @@ public static class MerchantConsolidation
         var canonicalByKey = MerchantNormalizer.GroupSimilarKeys(
             normalizedByPattern.Values.ToList());
 
-        var grouped = patternList.GroupBy(p =>
+        var nameGroups = patternList.GroupBy(p =>
             canonicalByKey.TryGetValue(normalizedByPattern[p], out var canonical)
                 ? canonical
                 : normalizedByPattern[p]);
 
         var result = new List<ConsolidatedPattern>();
-        foreach (var group in grouped)
+        foreach (var nameGroup in nameGroups)
         {
-            var representative = group
-                .OrderBy(p => p.GetDaysUntilDue(today))
-                .ThenByDescending(p => p.Confidence)
-                .First();
+            // Only collapse rows that are confidently the same bill; keep distinct similarly-named
+            // merchants as separate dashboard entries.
+            var clusters = RecurringPatternGrouping.PartitionBySameBill(
+                nameGroup.ToList(), p => normalizedByPattern[p]);
 
-            var displayAmount = group
-                .OrderByDescending(p => p.LastObservedAt)
-                .First()
-                .AverageAmount;
+            foreach (var cluster in clusters)
+            {
+                var representative = cluster
+                    .OrderBy(p => p.GetDaysUntilDue(today))
+                    .ThenByDescending(p => p.Confidence)
+                    .First();
 
-            result.Add(new ConsolidatedPattern(representative, displayAmount));
+                var displayAmount = cluster
+                    .OrderByDescending(p => p.LastObservedAt)
+                    .First()
+                    .AverageAmount;
+
+                result.Add(new ConsolidatedPattern(representative, displayAmount));
+            }
         }
 
         return result;

--- a/src/Core/MyMascada.Domain/Common/MerchantNormalizer.cs
+++ b/src/Core/MyMascada.Domain/Common/MerchantNormalizer.cs
@@ -43,8 +43,14 @@ public static class MerchantNormalizer
         // Remove common transaction prefixes.
         normalized = Regex.Replace(normalized, @"^(purchase\s+|payment\s+|pos\s+|debit\s+|eftpos\s+)", "");
 
-        // Remove explicit reference numbers (patterns like #123, REF:ABC123, ID:987654).
-        normalized = Regex.Replace(normalized, @"(#|ref:?|id:?)\s*[\w\d-]+", "");
+        // Remove explicit reference numbers (patterns like #123, REF:ABC123, ID:987654, "ref 99").
+        // Guards against corrupting ordinary merchant text:
+        //  - (?<!\w) anchors the label to a word boundary on the left (so it can't match inside
+        //    "rapid"/"video"),
+        //  - the label must be followed by a colon or whitespace separator before the value
+        //    (so "refresh"/"identity" are left intact).
+        normalized = Regex.Replace(normalized, @"(?<!\w)#\s*[\w-]+", "");
+        normalized = Regex.Replace(normalized, @"(?<!\w)(?:ref|id)(?::\s*|:?\s+)[\w-]+", "");
 
         // Remove dates (patterns like 01/15, 12-25-2024).
         normalized = Regex.Replace(normalized, @"\d{1,2}[/-]\d{1,2}([/-]\d{2,4})?", "");

--- a/src/Core/MyMascada.Domain/Common/MerchantNormalizer.cs
+++ b/src/Core/MyMascada.Domain/Common/MerchantNormalizer.cs
@@ -1,0 +1,245 @@
+using System.Text.RegularExpressions;
+
+namespace MyMascada.Domain.Common;
+
+/// <summary>
+/// Shared helpers for normalizing transaction descriptions into stable merchant keys,
+/// measuring similarity between keys, and grouping mutually-similar keys together.
+///
+/// Centralizing this logic prevents drift between the pattern-detection sites
+/// (on-demand <c>RecurringPatternService</c>, persisted <c>RecurringPatternPersistenceService</c>,
+/// and the <c>RecurringPattern</c> entity's transaction matching).
+/// </summary>
+public static class MerchantNormalizer
+{
+    // Minimum length of an embedded numeric token to be treated as a reference number.
+    // Kept at 3 so short merchant numbers (e.g. "3 Mobile") survive while bank
+    // reference runs (e.g. "3301234") are stripped.
+    private const int MinNumericTokenLength = 3;
+
+    // A token is treated as an alphanumeric reference (and stripped) when it is at least
+    // this long AND at least this fraction of its characters are digits.
+    private const int MinAlphanumericRefLength = 5;
+    private const double AlphanumericDigitRatio = 0.4;
+
+    /// <summary>
+    /// Default similarity threshold used to decide whether two normalized merchant keys
+    /// represent the same merchant (0.0 - 1.0).
+    /// </summary>
+    public const decimal DefaultSimilarityThreshold = 0.8m;
+
+    /// <summary>
+    /// Normalizes a raw transaction description into a stable merchant key
+    /// (lowercase, prefixes/dates/reference-numbers removed, whitespace collapsed).
+    /// </summary>
+    public static string Normalize(string? description)
+    {
+        if (string.IsNullOrWhiteSpace(description))
+            return string.Empty;
+
+        // Convert to lowercase and collapse whitespace.
+        var normalized = Regex.Replace(description.ToLowerInvariant().Trim(), @"\s+", " ");
+
+        // Remove common transaction prefixes.
+        normalized = Regex.Replace(normalized, @"^(purchase\s+|payment\s+|pos\s+|debit\s+|eftpos\s+)", "");
+
+        // Remove explicit reference numbers (patterns like #123, REF:ABC123, ID:987654).
+        normalized = Regex.Replace(normalized, @"(#|ref:?|id:?)\s*[\w\d-]+", "");
+
+        // Remove dates (patterns like 01/15, 12-25-2024).
+        normalized = Regex.Replace(normalized, @"\d{1,2}[/-]\d{1,2}([/-]\d{2,4})?", "");
+
+        // Remove time patterns (e.g. 14:30, 2:05pm).
+        normalized = Regex.Replace(normalized, @"\d{1,2}:\d{2}(:\d{2})?(\s*(am|pm))?", "");
+
+        // Strip embedded/standalone reference tokens that NZ (and other) bank feeds append
+        // to an otherwise-stable merchant string (e.g. "ami insurance amiinsurance 3301234").
+        // Tokenize on whitespace and drop any token that looks like a reference number.
+        var tokens = normalized
+            .Split(' ', StringSplitOptions.RemoveEmptyEntries)
+            .Where(token => !IsReferenceToken(token))
+            .ToList();
+
+        // Collapse a doubled merchant-word artifact like "ami insurance amiinsurance",
+        // where one token is the concatenation of two adjacent preceding tokens.
+        tokens = CollapseConcatenatedDuplicate(tokens);
+
+        normalized = string.Join(" ", tokens);
+
+        // Remove any trailing bare numbers left over.
+        normalized = Regex.Replace(normalized, @"\s+\d+$", "");
+
+        // Final whitespace cleanup.
+        return Regex.Replace(normalized.Trim(), @"\s+", " ");
+    }
+
+    /// <summary>
+    /// Determines whether a token should be treated as a reference number and stripped.
+    /// </summary>
+    private static bool IsReferenceToken(string token)
+    {
+        if (string.IsNullOrEmpty(token))
+            return false;
+
+        // Pure numeric run of meaningful length (e.g. "3301234").
+        if (token.Length >= MinNumericTokenLength && token.All(char.IsDigit))
+            return true;
+
+        // Long alphanumeric token that is mostly digits (e.g. "inv00123ab", "x9f8273").
+        if (token.Length >= MinAlphanumericRefLength)
+        {
+            var digitCount = token.Count(char.IsDigit);
+            if (digitCount > 0 && (double)digitCount / token.Length >= AlphanumericDigitRatio)
+                return true;
+        }
+
+        return false;
+    }
+
+    /// <summary>
+    /// Collapses a doubled merchant-word artifact where a token equals the concatenation
+    /// of the immediately preceding tokens (e.g. ["ami", "insurance", "amiinsurance"] -&gt;
+    /// ["ami", "insurance"]). Conservative: only removes a token that is an exact
+    /// concatenation of preceding adjacent tokens.
+    /// </summary>
+    private static List<string> CollapseConcatenatedDuplicate(List<string> tokens)
+    {
+        if (tokens.Count < 2)
+            return tokens;
+
+        var result = new List<string>();
+        foreach (var token in tokens)
+        {
+            var isConcatenationOfPrevious = false;
+
+            // Try to match this token against the concatenation of the trailing 2..N
+            // tokens already accepted.
+            for (var take = 2; take <= result.Count; take++)
+            {
+                var candidate = string.Concat(result.Skip(result.Count - take));
+                if (string.Equals(candidate, token, StringComparison.Ordinal))
+                {
+                    isConcatenationOfPrevious = true;
+                    break;
+                }
+            }
+
+            if (!isConcatenationOfPrevious)
+                result.Add(token);
+        }
+
+        return result;
+    }
+
+    /// <summary>
+    /// Calculates normalized Levenshtein similarity (0.0 - 1.0) between two keys.
+    /// </summary>
+    public static decimal CalculateSimilarity(string? str1, string? str2)
+    {
+        if (string.IsNullOrEmpty(str1) && string.IsNullOrEmpty(str2))
+            return 1m;
+
+        if (string.IsNullOrEmpty(str1) || string.IsNullOrEmpty(str2))
+            return 0m;
+
+        var distance = LevenshteinDistance(str1, str2);
+        var maxLength = Math.Max(str1.Length, str2.Length);
+
+        return 1m - (decimal)distance / maxLength;
+    }
+
+    /// <summary>
+    /// Groups keys into connected components where any two keys with similarity above
+    /// <paramref name="threshold"/> are considered linked. Uses union-find so the grouping
+    /// is transitive: if A~B and B~C but A is not directly similar to C, all three still
+    /// collapse into one group.
+    /// </summary>
+    /// <returns>
+    /// A mapping from each input key to its canonical group representative. Callers can
+    /// group by the representative to merge mutually-similar keys.
+    /// </returns>
+    public static Dictionary<string, string> GroupSimilarKeys(
+        IReadOnlyCollection<string> keys,
+        decimal? threshold = null)
+    {
+        var effectiveThreshold = threshold ?? DefaultSimilarityThreshold;
+        var keyList = keys.Distinct().ToList();
+
+        // Union-find parent pointers keyed by index into keyList.
+        var parent = Enumerable.Range(0, keyList.Count).ToArray();
+
+        int Find(int x)
+        {
+            while (parent[x] != x)
+            {
+                parent[x] = parent[parent[x]]; // path compression
+                x = parent[x];
+            }
+            return x;
+        }
+
+        void Union(int a, int b)
+        {
+            var rootA = Find(a);
+            var rootB = Find(b);
+            if (rootA != rootB)
+                parent[rootB] = rootA;
+        }
+
+        for (var i = 0; i < keyList.Count; i++)
+        {
+            for (var j = i + 1; j < keyList.Count; j++)
+            {
+                if (CalculateSimilarity(keyList[i], keyList[j]) > effectiveThreshold)
+                    Union(i, j);
+            }
+        }
+
+        // Map each key to the (deterministic) canonical key of its component.
+        var componentCanonical = new Dictionary<int, string>();
+        for (var i = 0; i < keyList.Count; i++)
+        {
+            var root = Find(i);
+            if (!componentCanonical.TryGetValue(root, out var current)
+                || string.CompareOrdinal(keyList[i], current) < 0)
+            {
+                componentCanonical[root] = keyList[i];
+            }
+        }
+
+        var mapping = new Dictionary<string, string>();
+        for (var i = 0; i < keyList.Count; i++)
+        {
+            mapping[keyList[i]] = componentCanonical[Find(i)];
+        }
+
+        return mapping;
+    }
+
+    private static int LevenshteinDistance(string s1, string s2)
+    {
+        if (s1.Length == 0) return s2.Length;
+        if (s2.Length == 0) return s1.Length;
+
+        var matrix = new int[s1.Length + 1, s2.Length + 1];
+
+        for (var i = 0; i <= s1.Length; i++)
+            matrix[i, 0] = i;
+
+        for (var j = 0; j <= s2.Length; j++)
+            matrix[0, j] = j;
+
+        for (var i = 1; i <= s1.Length; i++)
+        {
+            for (var j = 1; j <= s2.Length; j++)
+            {
+                var cost = (s1[i - 1] == s2[j - 1]) ? 0 : 1;
+                matrix[i, j] = Math.Min(
+                    Math.Min(matrix[i - 1, j] + 1, matrix[i, j - 1] + 1),
+                    matrix[i - 1, j - 1] + cost);
+            }
+        }
+
+        return matrix[s1.Length, s2.Length];
+    }
+}

--- a/src/Core/MyMascada.Domain/Common/RecurringPatternGrouping.cs
+++ b/src/Core/MyMascada.Domain/Common/RecurringPatternGrouping.cs
@@ -13,20 +13,22 @@ public static class RecurringPatternGrouping
     public const decimal AmountTolerance = 0.2m; // ±20%
 
     /// <summary>
-    /// Whether two patterns are confidently the same recurring bill: an exact normalized-key
-    /// match, or a fuzzy-name match (callers pre-group by name similarity) backed by the same
-    /// cadence and amounts within <see cref="AmountTolerance"/>. Name similarity alone is not
-    /// sufficient — two distinct merchants can have near-identical names.
+    /// Whether two patterns are confidently the same recurring bill. Requires BOTH:
+    ///  - a merchant match (callers pre-group by name similarity; an exact normalized-key match
+    ///    also qualifies), AND
+    ///  - corroborating evidence: the same cadence and amounts within <see cref="AmountTolerance"/>.
+    ///
+    /// The evidence check applies even to exact normalized-key matches, because the normalizer
+    /// strips numeric policy/account IDs — so two genuinely-different bills at one merchant (e.g.
+    /// two insurance policies with different amounts) can normalize to the same key and must NOT
+    /// be collapsed. Conversely, name similarity alone is never sufficient.
     /// </summary>
-    public static bool AreSameRecurringBill(
-        RecurringPattern a,
-        RecurringPattern b,
-        string normalizedKeyA,
-        string normalizedKeyB)
+    public static bool AreSameRecurringBill(RecurringPattern a, RecurringPattern b)
     {
-        if (string.Equals(normalizedKeyA, normalizedKeyB, StringComparison.Ordinal))
-            return true;
-
+        // Callers pass members of the same name-similarity group (an exact cleaned-key match is
+        // the strongest form of that). But the key alone is NOT decisive — the normalizer strips
+        // policy/account IDs, so two distinct bills at one merchant can share a key — hence
+        // corroborating cadence + amount evidence is always required.
         var sameCadence = a.GetIntervalName() == b.GetIntervalName();
 
         var larger = Math.Max(a.AverageAmount, b.AverageAmount);
@@ -42,9 +44,7 @@ public static class RecurringPatternGrouping
     /// Partitions a name-similarity group into clusters that are confidently the same recurring
     /// bill, via union-find over <see cref="AreSameRecurringBill"/> (transitive within the group).
     /// </summary>
-    public static List<List<RecurringPattern>> PartitionBySameBill(
-        List<RecurringPattern> members,
-        Func<RecurringPattern, string> normalizedKeyOf)
+    public static List<List<RecurringPattern>> PartitionBySameBill(List<RecurringPattern> members)
     {
         if (members.Count <= 1)
             return new List<List<RecurringPattern>> { members };
@@ -73,7 +73,7 @@ public static class RecurringPatternGrouping
         {
             for (var j = i + 1; j < members.Count; j++)
             {
-                if (AreSameRecurringBill(members[i], members[j], normalizedKeyOf(members[i]), normalizedKeyOf(members[j])))
+                if (AreSameRecurringBill(members[i], members[j]))
                     Union(i, j);
             }
         }

--- a/src/Core/MyMascada.Domain/Common/RecurringPatternGrouping.cs
+++ b/src/Core/MyMascada.Domain/Common/RecurringPatternGrouping.cs
@@ -1,0 +1,87 @@
+using MyMascada.Domain.Entities;
+
+namespace MyMascada.Domain.Common;
+
+/// <summary>
+/// Shared grouping rules for deciding when two persisted <see cref="RecurringPattern"/> rows are
+/// confidently the SAME recurring bill (and may therefore be consolidated/merged), used by both
+/// the read-path display consolidation and the write-path reconciliation so the two never drift.
+/// </summary>
+public static class RecurringPatternGrouping
+{
+    /// <summary>Amount tolerance for treating two fuzzy-name-matched patterns as the same bill.</summary>
+    public const decimal AmountTolerance = 0.2m; // ±20%
+
+    /// <summary>
+    /// Whether two patterns are confidently the same recurring bill: an exact normalized-key
+    /// match, or a fuzzy-name match (callers pre-group by name similarity) backed by the same
+    /// cadence and amounts within <see cref="AmountTolerance"/>. Name similarity alone is not
+    /// sufficient — two distinct merchants can have near-identical names.
+    /// </summary>
+    public static bool AreSameRecurringBill(
+        RecurringPattern a,
+        RecurringPattern b,
+        string normalizedKeyA,
+        string normalizedKeyB)
+    {
+        if (string.Equals(normalizedKeyA, normalizedKeyB, StringComparison.Ordinal))
+            return true;
+
+        var sameCadence = a.GetIntervalName() == b.GetIntervalName();
+
+        var larger = Math.Max(a.AverageAmount, b.AverageAmount);
+        var smaller = Math.Min(a.AverageAmount, b.AverageAmount);
+        var closeAmount = larger <= 0
+            ? smaller <= 0
+            : (larger - smaller) <= larger * AmountTolerance;
+
+        return sameCadence && closeAmount;
+    }
+
+    /// <summary>
+    /// Partitions a name-similarity group into clusters that are confidently the same recurring
+    /// bill, via union-find over <see cref="AreSameRecurringBill"/> (transitive within the group).
+    /// </summary>
+    public static List<List<RecurringPattern>> PartitionBySameBill(
+        List<RecurringPattern> members,
+        Func<RecurringPattern, string> normalizedKeyOf)
+    {
+        if (members.Count <= 1)
+            return new List<List<RecurringPattern>> { members };
+
+        var parent = Enumerable.Range(0, members.Count).ToArray();
+
+        int Find(int x)
+        {
+            while (parent[x] != x)
+            {
+                parent[x] = parent[parent[x]];
+                x = parent[x];
+            }
+            return x;
+        }
+
+        void Union(int a, int b)
+        {
+            var rootA = Find(a);
+            var rootB = Find(b);
+            if (rootA != rootB)
+                parent[rootB] = rootA;
+        }
+
+        for (var i = 0; i < members.Count; i++)
+        {
+            for (var j = i + 1; j < members.Count; j++)
+            {
+                if (AreSameRecurringBill(members[i], members[j], normalizedKeyOf(members[i]), normalizedKeyOf(members[j])))
+                    Union(i, j);
+            }
+        }
+
+        return members
+            .Select((pattern, index) => (pattern, root: Find(index)))
+            .GroupBy(x => x.root)
+            .Select(g => g.Select(x => x.pattern).ToList())
+            .ToList();
+    }
+}

--- a/src/Core/MyMascada.Domain/Entities/RecurringPattern.cs
+++ b/src/Core/MyMascada.Domain/Entities/RecurringPattern.cs
@@ -1,5 +1,4 @@
 using System.ComponentModel.DataAnnotations;
-using System.Text.RegularExpressions;
 using MyMascada.Domain.Common;
 using MyMascada.Domain.Enums;
 
@@ -271,73 +270,13 @@ public class RecurringPattern : BaseEntity
     }
 
     /// <summary>
-    /// Normalizes a transaction description for matching
+    /// Normalizes a transaction description for matching.
+    /// Delegates to the shared <see cref="MerchantNormalizer"/> so all pattern-detection
+    /// sites use identical normalization rules.
     /// </summary>
     public static string NormalizeDescription(string? description)
-    {
-        if (string.IsNullOrWhiteSpace(description))
-            return string.Empty;
-
-        // Convert to lowercase and remove extra whitespace
-        var normalized = Regex.Replace(description.ToLowerInvariant().Trim(), @"\s+", " ");
-
-        // Remove common transaction prefixes/suffixes
-        normalized = Regex.Replace(normalized, @"^(purchase\s+|payment\s+|pos\s+|debit\s+|eftpos\s+)", "");
-
-        // Remove reference numbers (patterns like #123, REF:ABC123, etc.)
-        normalized = Regex.Replace(normalized, @"(#|ref:?|id:?)\s*[\w\d-]+", "");
-
-        // Remove dates (patterns like 01/15, 15-Jan, etc.)
-        normalized = Regex.Replace(normalized, @"\d{1,2}[/-]\d{1,2}([/-]\d{2,4})?", "");
-
-        // Remove time patterns
-        normalized = Regex.Replace(normalized, @"\d{1,2}:\d{2}(:\d{2})?(\s*(am|pm))?", "");
-
-        // Remove trailing numbers that might be transaction IDs
-        normalized = Regex.Replace(normalized, @"\s+\d+$", "");
-
-        // Clean up extra whitespace again
-        return Regex.Replace(normalized.Trim(), @"\s+", " ");
-    }
+        => MerchantNormalizer.Normalize(description);
 
     private static decimal CalculateStringSimilarity(string str1, string str2)
-    {
-        if (string.IsNullOrEmpty(str1) && string.IsNullOrEmpty(str2))
-            return 1m;
-
-        if (string.IsNullOrEmpty(str1) || string.IsNullOrEmpty(str2))
-            return 0m;
-
-        var distance = LevenshteinDistance(str1, str2);
-        var maxLength = Math.Max(str1.Length, str2.Length);
-
-        return 1m - (decimal)distance / maxLength;
-    }
-
-    private static int LevenshteinDistance(string s1, string s2)
-    {
-        if (s1.Length == 0) return s2.Length;
-        if (s2.Length == 0) return s1.Length;
-
-        var matrix = new int[s1.Length + 1, s2.Length + 1];
-
-        for (int i = 0; i <= s1.Length; i++)
-            matrix[i, 0] = i;
-
-        for (int j = 0; j <= s2.Length; j++)
-            matrix[0, j] = j;
-
-        for (int i = 1; i <= s1.Length; i++)
-        {
-            for (int j = 1; j <= s2.Length; j++)
-            {
-                var cost = (s1[i - 1] == s2[j - 1]) ? 0 : 1;
-                matrix[i, j] = Math.Min(
-                    Math.Min(matrix[i - 1, j] + 1, matrix[i, j - 1] + 1),
-                    matrix[i - 1, j - 1] + cost);
-            }
-        }
-
-        return matrix[s1.Length, s2.Length];
-    }
+        => MerchantNormalizer.CalculateSimilarity(str1, str2);
 }

--- a/src/Core/MyMascada.Domain/Entities/RecurringPattern.cs
+++ b/src/Core/MyMascada.Domain/Entities/RecurringPattern.cs
@@ -260,7 +260,12 @@ public class RecurringPattern : BaseEntity
             return false;
 
         var normalizedDescription = NormalizeDescription(description);
-        var similarity = CalculateStringSimilarity(NormalizedMerchantKey, normalizedDescription);
+
+        // Re-normalize the stored key too: patterns persisted by an older normalizer may carry
+        // reference tokens / doubled words (e.g. "ami insurance amiinsurance") that the incoming
+        // description no longer has, which would otherwise drop the similarity below threshold.
+        var normalizedKey = NormalizeDescription(NormalizedMerchantKey);
+        var similarity = CalculateStringSimilarity(normalizedKey, normalizedDescription);
 
         // Check description similarity and amount range (±20%)
         var amountRangeMatch = Math.Abs(amount) >= AverageAmount * 0.8m

--- a/src/Infrastructure/MyMascada.Infrastructure/Repositories/RecurringPatternRepository.cs
+++ b/src/Infrastructure/MyMascada.Infrastructure/Repositories/RecurringPatternRepository.cs
@@ -232,6 +232,7 @@ public class RecurringPatternRepository : IRecurringPatternRepository
         Guid userId,
         int canonicalPatternId,
         IEnumerable<int> duplicatePatternIds,
+        string mergedNormalizedKey,
         int mergedOccurrenceCount,
         decimal mergedAverageAmount,
         DateTime mergedLastObservedAt,
@@ -272,7 +273,11 @@ public class RecurringPatternRepository : IRecurringPatternRepository
             occurrence.UpdatedAt = now;
         }
 
-        // Apply merged field values to the canonical pattern.
+        // Apply merged field values to the canonical pattern. Rewriting the normalized key to
+        // the current normalizer's output ensures the next detection pass's exact-key upsert
+        // updates this row instead of creating yet another duplicate.
+        if (!string.IsNullOrWhiteSpace(mergedNormalizedKey))
+            canonical.NormalizedMerchantKey = mergedNormalizedKey;
         canonical.OccurrenceCount = mergedOccurrenceCount;
         canonical.AverageAmount = mergedAverageAmount;
         canonical.LastObservedAt = mergedLastObservedAt;
@@ -287,6 +292,30 @@ public class RecurringPatternRepository : IRecurringPatternRepository
             duplicate.UpdatedAt = now;
         }
 
+        await _context.SaveChangesAsync(cancellationToken);
+    }
+
+    /// <summary>
+    /// Rewrites the normalized merchant key of a single pattern (migrates a stale row to the
+    /// current normalizer output). No-op if unchanged or not found.
+    /// </summary>
+    public async Task UpdateNormalizedKeyAsync(
+        Guid userId,
+        int patternId,
+        string normalizedKey,
+        CancellationToken cancellationToken = default)
+    {
+        if (string.IsNullOrWhiteSpace(normalizedKey))
+            return;
+
+        var pattern = await _context.RecurringPatterns
+            .FirstOrDefaultAsync(p => p.Id == patternId && p.UserId == userId && !p.IsDeleted, cancellationToken);
+
+        if (pattern == null || pattern.NormalizedMerchantKey == normalizedKey)
+            return;
+
+        pattern.NormalizedMerchantKey = normalizedKey;
+        pattern.UpdatedAt = DateTime.UtcNow;
         await _context.SaveChangesAsync(cancellationToken);
     }
 

--- a/src/Infrastructure/MyMascada.Infrastructure/Repositories/RecurringPatternRepository.cs
+++ b/src/Infrastructure/MyMascada.Infrastructure/Repositories/RecurringPatternRepository.cs
@@ -273,6 +273,18 @@ public class RecurringPatternRepository : IRecurringPatternRepository
             occurrence.UpdatedAt = now;
         }
 
+        // Soft-delete the duplicate patterns. The unique index on (UserId, NormalizedMerchantKey)
+        // is NOT filtered on IsDeleted, so soft-deleted rows still occupy their key slot. Before
+        // the canonical row adopts the cleaned key, vacate that slot by uniquifying every
+        // duplicate's key (a duplicate may already hold the exact clean key we are about to use).
+        foreach (var duplicate in duplicates)
+        {
+            duplicate.IsDeleted = true;
+            duplicate.DeletedAt = now;
+            duplicate.UpdatedAt = now;
+            duplicate.NormalizedMerchantKey = BuildDeletedKey(duplicate.NormalizedMerchantKey, duplicate.Id);
+        }
+
         // Apply merged field values to the canonical pattern. Rewriting the normalized key to
         // the current normalizer's output ensures the next detection pass's exact-key upsert
         // updates this row instead of creating yet another duplicate.
@@ -284,15 +296,22 @@ public class RecurringPatternRepository : IRecurringPatternRepository
         canonical.NextExpectedDate = mergedNextExpectedDate;
         canonical.UpdatedAt = now;
 
-        // Soft-delete the duplicate patterns.
-        foreach (var duplicate in duplicates)
-        {
-            duplicate.IsDeleted = true;
-            duplicate.DeletedAt = now;
-            duplicate.UpdatedAt = now;
-        }
-
         await _context.SaveChangesAsync(cancellationToken);
+    }
+
+    /// <summary>
+    /// Builds a collision-free normalized key for a soft-deleted pattern row so it no longer
+    /// occupies the unique (UserId, NormalizedMerchantKey) slot of the surviving canonical row.
+    /// Bounded to the column's 200-char limit.
+    /// </summary>
+    private static string BuildDeletedKey(string? originalKey, int patternId)
+    {
+        var suffix = $"::deleted::{patternId}";
+        var maxBaseLength = Math.Max(0, 200 - suffix.Length);
+        var baseKey = originalKey ?? string.Empty;
+        if (baseKey.Length > maxBaseLength)
+            baseKey = baseKey.Substring(0, maxBaseLength);
+        return baseKey + suffix;
     }
 
     /// <summary>
@@ -312,6 +331,17 @@ public class RecurringPatternRepository : IRecurringPatternRepository
             .FirstOrDefaultAsync(p => p.Id == patternId && p.UserId == userId && !p.IsDeleted, cancellationToken);
 
         if (pattern == null || pattern.NormalizedMerchantKey == normalizedKey)
+            return;
+
+        // The unique index on (UserId, NormalizedMerchantKey) ignores IsDeleted, so any existing
+        // row (active OR soft-deleted) holding the target key would cause a constraint violation.
+        // Skip the migration in that case; the next reconciliation pass will consolidate instead.
+        var keyTaken = await _context.RecurringPatterns
+            .AnyAsync(p => p.UserId == userId
+                           && p.Id != patternId
+                           && p.NormalizedMerchantKey == normalizedKey, cancellationToken);
+
+        if (keyTaken)
             return;
 
         pattern.NormalizedMerchantKey = normalizedKey;

--- a/src/Infrastructure/MyMascada.Infrastructure/Repositories/RecurringPatternRepository.cs
+++ b/src/Infrastructure/MyMascada.Infrastructure/Repositories/RecurringPatternRepository.cs
@@ -257,9 +257,13 @@ public class RecurringPatternRepository : IRecurringPatternRepository
 
         var now = DateTime.UtcNow;
 
+        // Only operate on duplicates that actually loaded (user-scoped, not soft-deleted), so
+        // occurrence re-parenting can never touch patterns outside the verified duplicate set.
+        var validDuplicateIds = duplicates.Select(d => d.Id).ToList();
+
         // Re-parent occurrence history from the duplicates onto the canonical pattern.
         var occurrences = await _context.RecurringOccurrences
-            .Where(o => duplicateIds.Contains(o.PatternId) && !o.IsDeleted)
+            .Where(o => validDuplicateIds.Contains(o.PatternId) && !o.IsDeleted)
             .ToListAsync(cancellationToken);
 
         foreach (var occurrence in occurrences)

--- a/src/Infrastructure/MyMascada.Infrastructure/Repositories/RecurringPatternRepository.cs
+++ b/src/Infrastructure/MyMascada.Infrastructure/Repositories/RecurringPatternRepository.cs
@@ -273,10 +273,42 @@ public class RecurringPatternRepository : IRecurringPatternRepository
             occurrence.UpdatedAt = now;
         }
 
-        // Soft-delete the duplicate patterns. The unique index on (UserId, NormalizedMerchantKey)
-        // is NOT filtered on IsDeleted, so soft-deleted rows still occupy their key slot. Before
-        // the canonical row adopts the cleaned key, vacate that slot by uniquifying every
-        // duplicate's key (a duplicate may already hold the exact clean key we are about to use).
+        // Vacate the unique (UserId, NormalizedMerchantKey) slot before the canonical row adopts
+        // the cleaned key. The index is NOT filtered on IsDeleted, while the entity has a global
+        // !IsDeleted query filter — so collisions can come from the in-group duplicates above OR
+        // from a previously soft-deleted row that already holds the cleaned key. Load every row
+        // holding the target key (IgnoreQueryFilters) and uniquify each so SaveChanges cannot hit
+        // the constraint (which would otherwise swallow the whole reconciliation).
+        var rewriteCanonicalKey = !string.IsNullOrWhiteSpace(mergedNormalizedKey)
+                                  && canonical.NormalizedMerchantKey != mergedNormalizedKey;
+
+        if (rewriteCanonicalKey)
+        {
+            // Exclude the in-group duplicates; they are uniquified in the dedicated loop below.
+            var keyHolders = await _context.RecurringPatterns
+                .IgnoreQueryFilters()
+                .Where(p => p.UserId == userId
+                            && p.Id != canonicalPatternId
+                            && !validDuplicateIds.Contains(p.Id)
+                            && p.NormalizedMerchantKey == mergedNormalizedKey)
+                .ToListAsync(cancellationToken);
+
+            foreach (var holder in keyHolders)
+            {
+                // Soft-delete any live collision too: an active row outside this group that maps
+                // to the same cleaned key is itself a duplicate of the same merchant.
+                if (!holder.IsDeleted)
+                {
+                    holder.IsDeleted = true;
+                    holder.DeletedAt = now;
+                }
+                holder.NormalizedMerchantKey = BuildDeletedKey(holder.NormalizedMerchantKey, holder.Id);
+                holder.UpdatedAt = now;
+            }
+        }
+
+        // Soft-delete the in-group duplicate patterns, uniquifying their keys so they no longer
+        // occupy any (UserId, key) slot the canonical row may take.
         foreach (var duplicate in duplicates)
         {
             duplicate.IsDeleted = true;
@@ -285,10 +317,10 @@ public class RecurringPatternRepository : IRecurringPatternRepository
             duplicate.NormalizedMerchantKey = BuildDeletedKey(duplicate.NormalizedMerchantKey, duplicate.Id);
         }
 
-        // Apply merged field values to the canonical pattern. Rewriting the normalized key to
-        // the current normalizer's output ensures the next detection pass's exact-key upsert
-        // updates this row instead of creating yet another duplicate.
-        if (!string.IsNullOrWhiteSpace(mergedNormalizedKey))
+        // Apply merged field values to the canonical pattern. Rewriting the normalized key to the
+        // current normalizer's output ensures the next detection pass's exact-key upsert updates
+        // this row instead of creating yet another duplicate.
+        if (rewriteCanonicalKey)
             canonical.NormalizedMerchantKey = mergedNormalizedKey;
         canonical.OccurrenceCount = mergedOccurrenceCount;
         canonical.AverageAmount = mergedAverageAmount;
@@ -334,9 +366,11 @@ public class RecurringPatternRepository : IRecurringPatternRepository
             return;
 
         // The unique index on (UserId, NormalizedMerchantKey) ignores IsDeleted, so any existing
-        // row (active OR soft-deleted) holding the target key would cause a constraint violation.
-        // Skip the migration in that case; the next reconciliation pass will consolidate instead.
+        // row (active OR soft-deleted — hence IgnoreQueryFilters) holding the target key would
+        // cause a constraint violation. Skip the migration in that case; the next reconciliation
+        // pass will consolidate instead.
         var keyTaken = await _context.RecurringPatterns
+            .IgnoreQueryFilters()
             .AnyAsync(p => p.UserId == userId
                            && p.Id != patternId
                            && p.NormalizedMerchantKey == normalizedKey, cancellationToken);

--- a/src/Infrastructure/MyMascada.Infrastructure/Repositories/RecurringPatternRepository.cs
+++ b/src/Infrastructure/MyMascada.Infrastructure/Repositories/RecurringPatternRepository.cs
@@ -223,6 +223,69 @@ public class RecurringPatternRepository : IRecurringPatternRepository
         }
     }
 
+    /// <summary>
+    /// Merges duplicate recurring patterns into a single canonical pattern.
+    /// Re-parents occurrence history onto the canonical pattern, applies merged field values,
+    /// then soft-deletes the duplicates. Saved as a single unit of work.
+    /// </summary>
+    public async Task MergeDuplicatePatternsAsync(
+        Guid userId,
+        int canonicalPatternId,
+        IEnumerable<int> duplicatePatternIds,
+        int mergedOccurrenceCount,
+        decimal mergedAverageAmount,
+        DateTime mergedLastObservedAt,
+        DateTime mergedNextExpectedDate,
+        CancellationToken cancellationToken = default)
+    {
+        var duplicateIds = duplicatePatternIds.Distinct().Where(id => id != canonicalPatternId).ToList();
+        if (duplicateIds.Count == 0)
+            return;
+
+        var canonical = await _context.RecurringPatterns
+            .FirstOrDefaultAsync(p => p.Id == canonicalPatternId && p.UserId == userId && !p.IsDeleted, cancellationToken);
+
+        if (canonical == null)
+            return;
+
+        var duplicates = await _context.RecurringPatterns
+            .Where(p => duplicateIds.Contains(p.Id) && p.UserId == userId && !p.IsDeleted)
+            .ToListAsync(cancellationToken);
+
+        if (duplicates.Count == 0)
+            return;
+
+        var now = DateTime.UtcNow;
+
+        // Re-parent occurrence history from the duplicates onto the canonical pattern.
+        var occurrences = await _context.RecurringOccurrences
+            .Where(o => duplicateIds.Contains(o.PatternId) && !o.IsDeleted)
+            .ToListAsync(cancellationToken);
+
+        foreach (var occurrence in occurrences)
+        {
+            occurrence.PatternId = canonicalPatternId;
+            occurrence.UpdatedAt = now;
+        }
+
+        // Apply merged field values to the canonical pattern.
+        canonical.OccurrenceCount = mergedOccurrenceCount;
+        canonical.AverageAmount = mergedAverageAmount;
+        canonical.LastObservedAt = mergedLastObservedAt;
+        canonical.NextExpectedDate = mergedNextExpectedDate;
+        canonical.UpdatedAt = now;
+
+        // Soft-delete the duplicate patterns.
+        foreach (var duplicate in duplicates)
+        {
+            duplicate.IsDeleted = true;
+            duplicate.DeletedAt = now;
+            duplicate.UpdatedAt = now;
+        }
+
+        await _context.SaveChangesAsync(cancellationToken);
+    }
+
     // Occurrence operations
 
     /// <summary>

--- a/src/Infrastructure/MyMascada.Infrastructure/Repositories/RecurringPatternRepository.cs
+++ b/src/Infrastructure/MyMascada.Infrastructure/Repositories/RecurringPatternRepository.cs
@@ -262,26 +262,32 @@ public class RecurringPatternRepository : IRecurringPatternRepository
         // occurrence re-parenting can never touch patterns outside the verified duplicate set.
         var validDuplicateIds = duplicates.Select(d => d.Id).ToList();
 
-        // Re-parent occurrence history from the duplicates onto the canonical pattern.
+        // Load the duplicates' occurrence history; re-parented onto the canonical row in phase 1a.
         var occurrences = await _context.RecurringOccurrences
             .Where(o => validDuplicateIds.Contains(o.PatternId) && !o.IsDeleted)
             .ToListAsync(cancellationToken);
 
+        var rewriteCanonicalKey = !string.IsNullOrWhiteSpace(mergedNormalizedKey)
+                                  && canonical.NormalizedMerchantKey != mergedNormalizedKey;
+
+        // The unique (UserId, NormalizedMerchantKey) index is NOT filtered on IsDeleted and is
+        // checked immediately (not deferred) by PostgreSQL. Because EF flushes all changes in one
+        // SaveChanges with no ordering guarantee relative to the unique index, the canonical row
+        // adopting the cleaned key could be written before the colliding rows vacate it, tripping
+        // the constraint mid-batch. So we run an ordered two-phase save inside a transaction:
+        //   phase 1 — re-parent occurrences, soft-delete + uniquify every colliding/duplicate row;
+        //   phase 2 — assign the cleaned key to the canonical row.
+        await using var transaction = await _context.Database.BeginTransactionAsync(cancellationToken);
+
+        // Phase 1a: re-parent occurrence history onto the canonical pattern.
         foreach (var occurrence in occurrences)
         {
             occurrence.PatternId = canonicalPatternId;
             occurrence.UpdatedAt = now;
         }
 
-        // Vacate the unique (UserId, NormalizedMerchantKey) slot before the canonical row adopts
-        // the cleaned key. The index is NOT filtered on IsDeleted, while the entity has a global
-        // !IsDeleted query filter — so collisions can come from the in-group duplicates above OR
-        // from a previously soft-deleted row that already holds the cleaned key. Load every row
-        // holding the target key (IgnoreQueryFilters) and uniquify each so SaveChanges cannot hit
-        // the constraint (which would otherwise swallow the whole reconciliation).
-        var rewriteCanonicalKey = !string.IsNullOrWhiteSpace(mergedNormalizedKey)
-                                  && canonical.NormalizedMerchantKey != mergedNormalizedKey;
-
+        // Phase 1b: vacate any other row (active or soft-deleted) already holding the cleaned key,
+        // so the canonical row can take it. Live collisions are themselves same-merchant duplicates.
         if (rewriteCanonicalKey)
         {
             // Exclude the in-group duplicates; they are uniquified in the dedicated loop below.
@@ -295,8 +301,6 @@ public class RecurringPatternRepository : IRecurringPatternRepository
 
             foreach (var holder in keyHolders)
             {
-                // Soft-delete any live collision too: an active row outside this group that maps
-                // to the same cleaned key is itself a duplicate of the same merchant.
                 if (!holder.IsDeleted)
                 {
                     holder.IsDeleted = true;
@@ -307,8 +311,8 @@ public class RecurringPatternRepository : IRecurringPatternRepository
             }
         }
 
-        // Soft-delete the in-group duplicate patterns, uniquifying their keys so they no longer
-        // occupy any (UserId, key) slot the canonical row may take.
+        // Phase 1c: soft-delete the in-group duplicate patterns, uniquifying their keys so they no
+        // longer occupy any (UserId, key) slot the canonical row may take.
         foreach (var duplicate in duplicates)
         {
             duplicate.IsDeleted = true;
@@ -317,11 +321,7 @@ public class RecurringPatternRepository : IRecurringPatternRepository
             duplicate.NormalizedMerchantKey = BuildDeletedKey(duplicate.NormalizedMerchantKey, duplicate.Id);
         }
 
-        // Apply merged field values to the canonical pattern. Rewriting the normalized key to the
-        // current normalizer's output ensures the next detection pass's exact-key upsert updates
-        // this row instead of creating yet another duplicate.
-        if (rewriteCanonicalKey)
-            canonical.NormalizedMerchantKey = mergedNormalizedKey;
+        // Merge non-key fields onto the canonical row (safe to flush alongside phase 1).
         canonical.OccurrenceCount = mergedOccurrenceCount;
         canonical.AverageAmount = mergedAverageAmount;
         canonical.LastObservedAt = mergedLastObservedAt;
@@ -329,6 +329,18 @@ public class RecurringPatternRepository : IRecurringPatternRepository
         canonical.UpdatedAt = now;
 
         await _context.SaveChangesAsync(cancellationToken);
+
+        // Phase 2: now that the slot is free, the canonical row can adopt the cleaned key. This
+        // ensures the next detection pass's exact-key upsert updates this row rather than creating
+        // a fresh duplicate.
+        if (rewriteCanonicalKey)
+        {
+            canonical.NormalizedMerchantKey = mergedNormalizedKey;
+            canonical.UpdatedAt = DateTime.UtcNow;
+            await _context.SaveChangesAsync(cancellationToken);
+        }
+
+        await transaction.CommitAsync(cancellationToken);
     }
 
     /// <summary>
@@ -385,16 +397,30 @@ public class RecurringPatternRepository : IRecurringPatternRepository
         // Only SOFT-DELETED holders remain. They must be vacated, otherwise the next detection
         // pass would upsert the clean key, GetByMerchantKeyAsync (filtered) wouldn't see the
         // soft-deleted holder, the insert would hit the unique index, and the merchant would
-        // never converge.
+        // never converge. Use an ordered two-phase save inside a transaction so the index is not
+        // tripped mid-batch (see MergeDuplicatePatternsAsync for the rationale).
+        if (keyHolders.Count == 0)
+        {
+            pattern.NormalizedMerchantKey = normalizedKey;
+            pattern.UpdatedAt = now;
+            await _context.SaveChangesAsync(cancellationToken);
+            return;
+        }
+
+        await using var transaction = await _context.Database.BeginTransactionAsync(cancellationToken);
+
         foreach (var holder in keyHolders)
         {
             holder.NormalizedMerchantKey = BuildDeletedKey(holder.NormalizedMerchantKey, holder.Id);
             holder.UpdatedAt = now;
         }
+        await _context.SaveChangesAsync(cancellationToken);
 
         pattern.NormalizedMerchantKey = normalizedKey;
-        pattern.UpdatedAt = now;
+        pattern.UpdatedAt = DateTime.UtcNow;
         await _context.SaveChangesAsync(cancellationToken);
+
+        await transaction.CommitAsync(cancellationToken);
     }
 
     // Occurrence operations

--- a/src/Infrastructure/MyMascada.Infrastructure/Repositories/RecurringPatternRepository.cs
+++ b/src/Infrastructure/MyMascada.Infrastructure/Repositories/RecurringPatternRepository.cs
@@ -365,21 +365,35 @@ public class RecurringPatternRepository : IRecurringPatternRepository
         if (pattern == null || pattern.NormalizedMerchantKey == normalizedKey)
             return;
 
-        // The unique index on (UserId, NormalizedMerchantKey) ignores IsDeleted, so any existing
-        // row (active OR soft-deleted — hence IgnoreQueryFilters) holding the target key would
-        // cause a constraint violation. Skip the migration in that case; the next reconciliation
-        // pass will consolidate instead.
-        var keyTaken = await _context.RecurringPatterns
-            .IgnoreQueryFilters()
-            .AnyAsync(p => p.UserId == userId
-                           && p.Id != patternId
-                           && p.NormalizedMerchantKey == normalizedKey, cancellationToken);
+        var now = DateTime.UtcNow;
 
-        if (keyTaken)
+        // The unique index on (UserId, NormalizedMerchantKey) ignores IsDeleted, so any other row
+        // holding the target key (active OR soft-deleted — hence IgnoreQueryFilters) would cause a
+        // constraint violation when this row adopts it.
+        var keyHolders = await _context.RecurringPatterns
+            .IgnoreQueryFilters()
+            .Where(p => p.UserId == userId
+                        && p.Id != patternId
+                        && p.NormalizedMerchantKey == normalizedKey)
+            .ToListAsync(cancellationToken);
+
+        // A LIVE other row already owns the clean key: that pattern is the legitimate owner, so
+        // leave this stale row alone and let the next reconciliation pass merge them.
+        if (keyHolders.Any(p => !p.IsDeleted))
             return;
 
+        // Only SOFT-DELETED holders remain. They must be vacated, otherwise the next detection
+        // pass would upsert the clean key, GetByMerchantKeyAsync (filtered) wouldn't see the
+        // soft-deleted holder, the insert would hit the unique index, and the merchant would
+        // never converge.
+        foreach (var holder in keyHolders)
+        {
+            holder.NormalizedMerchantKey = BuildDeletedKey(holder.NormalizedMerchantKey, holder.Id);
+            holder.UpdatedAt = now;
+        }
+
         pattern.NormalizedMerchantKey = normalizedKey;
-        pattern.UpdatedAt = DateTime.UtcNow;
+        pattern.UpdatedAt = now;
         await _context.SaveChangesAsync(cancellationToken);
     }
 

--- a/tests/MyMascada.Tests.Unit/Domain/MerchantNormalizerTests.cs
+++ b/tests/MyMascada.Tests.Unit/Domain/MerchantNormalizerTests.cs
@@ -47,6 +47,24 @@ public class MerchantNormalizerTests
         MerchantNormalizer.Normalize("3 MOBILE").Should().Be("3 mobile");
     }
 
+    [Theory]
+    [InlineData("MERCHANT #12345", "merchant")]
+    [InlineData("ACME CORP REF:ABC123", "acme corp")]
+    [InlineData("STORE ID:987654", "store")]
+    public void Normalize_ShouldStripExplicitReferencePrefixes(string input, string expected)
+    {
+        MerchantNormalizer.Normalize(input).Should().Be(expected);
+    }
+
+    [Theory]
+    [InlineData("RAPID RENTALS", "rapid rentals")]   // "id" inside "rapid" must survive
+    [InlineData("VIDEO STORE", "video store")]       // "id" inside "video" must survive
+    [InlineData("REFRESH CAFE", "refresh cafe")]     // "ref" inside "refresh" must survive
+    public void Normalize_ShouldNotStripReferenceTokensInsideWords(string input, string expected)
+    {
+        MerchantNormalizer.Normalize(input).Should().Be(expected);
+    }
+
     [Fact]
     public void Normalize_ShouldNotCollapseGenuinelyDifferentMerchants()
     {

--- a/tests/MyMascada.Tests.Unit/Domain/MerchantNormalizerTests.cs
+++ b/tests/MyMascada.Tests.Unit/Domain/MerchantNormalizerTests.cs
@@ -1,0 +1,103 @@
+using MyMascada.Domain.Common;
+
+namespace MyMascada.Tests.Unit.Domain;
+
+public class MerchantNormalizerTests
+{
+    #region Embedded reference-number stripping
+
+    [Fact]
+    public void Normalize_ShouldStripEmbeddedNumericReference_SoSameMerchantNormalizesEqual()
+    {
+        // Two NZ-style bank feed descriptions for the same merchant that differ only by an
+        // embedded reference number. These must collapse to the same normalized key.
+        var a = MerchantNormalizer.Normalize("AMI INSURANCE AMIINSURANCE 3301234");
+        var b = MerchantNormalizer.Normalize("AMI INSURANCE AMIINSURANCE 3305678");
+
+        a.Should().Be(b);
+        a.Should().Be("ami insurance");
+    }
+
+    [Theory]
+    [InlineData("AMI INSURANCE AMIINSURANCE 3301234", "ami insurance")]
+    [InlineData("SPOTIFY 9928374 SUBSCRIPTION", "spotify subscription")]
+    [InlineData("POWER CO 0012849 AUTOPAY", "power co autopay")]
+    public void Normalize_ShouldStripStandaloneNumericTokens(string input, string expected)
+    {
+        MerchantNormalizer.Normalize(input).Should().Be(expected);
+    }
+
+    [Fact]
+    public void Normalize_ShouldCollapseDoubledMerchantWordArtifact()
+    {
+        MerchantNormalizer.Normalize("AMI INSURANCE AMIINSURANCE").Should().Be("ami insurance");
+    }
+
+    [Fact]
+    public void Normalize_ShouldStripLongMostlyNumericAlphanumericToken()
+    {
+        // Reference token that is mostly digits should be removed.
+        MerchantNormalizer.Normalize("MERCHANT INV00123AB").Should().Be("merchant");
+    }
+
+    [Fact]
+    public void Normalize_ShouldKeepShortNumberThatIsPartOfBrand()
+    {
+        // A short numeric token (< 3 digits) that is part of the brand should survive.
+        MerchantNormalizer.Normalize("3 MOBILE").Should().Be("3 mobile");
+    }
+
+    [Fact]
+    public void Normalize_ShouldNotCollapseGenuinelyDifferentMerchants()
+    {
+        var netflix = MerchantNormalizer.Normalize("NETFLIX 12345");
+        var spotify = MerchantNormalizer.Normalize("SPOTIFY 67890");
+
+        netflix.Should().NotBe(spotify);
+        netflix.Should().Be("netflix");
+        spotify.Should().Be("spotify");
+    }
+
+    #endregion
+
+    #region Transitive merge (union-find connected components)
+
+    [Fact]
+    public void GroupSimilarKeys_ShouldTransitivelyMerge_WhenAandCNotDirectlySimilar()
+    {
+        // Build an explicit chain where the endpoints are NOT directly similar but each
+        // is similar to a shared middle key.
+        var keys = new[]
+        {
+            "netflixaaaa",   // A
+            "netflixaabb",   // B: 2 diff from A
+            "netflixbbbb"    // C: 2 diff from B, 4 diff from A
+        };
+
+        // A vs C differ by 4/11 chars -> ~0.64 similarity (below 0.8, not directly similar).
+        // A vs B and B vs C differ by 2/11 -> ~0.82 (above 0.8). Union-find must chain them.
+        MerchantNormalizer.CalculateSimilarity(keys[0], keys[2])
+            .Should().BeLessThan(0.8m, "endpoints are not directly similar");
+        MerchantNormalizer.CalculateSimilarity(keys[0], keys[1])
+            .Should().BeGreaterThan(0.8m);
+        MerchantNormalizer.CalculateSimilarity(keys[1], keys[2])
+            .Should().BeGreaterThan(0.8m);
+
+        var mapping = MerchantNormalizer.GroupSimilarKeys(keys);
+
+        mapping.Values.Distinct().Should().HaveCount(1,
+            "transitive merge should collapse A~B~C even though A is not similar to C");
+    }
+
+    [Fact]
+    public void GroupSimilarKeys_ShouldKeepDistinctMerchantsSeparate()
+    {
+        var keys = new[] { "netflix", "spotify", "power company" };
+
+        var mapping = MerchantNormalizer.GroupSimilarKeys(keys);
+
+        mapping.Values.Distinct().Should().HaveCount(3);
+    }
+
+    #endregion
+}

--- a/tests/MyMascada.Tests.Unit/Domain/RecurringPatternGroupingTests.cs
+++ b/tests/MyMascada.Tests.Unit/Domain/RecurringPatternGroupingTests.cs
@@ -7,17 +7,34 @@ namespace MyMascada.Tests.Unit.Domain;
 public class RecurringPatternGroupingTests
 {
     [Fact]
-    public void PartitionBySameBill_ExactKeyMatch_AlwaysClustersTogether()
+    public void PartitionBySameBill_ExactKeySameCadenceCloseAmount_Clusters()
     {
+        // The reported bug's shape: same merchant key, same cadence, near-identical amounts.
         var members = new List<RecurringPattern>
         {
             Pattern("ami insurance", intervalDays: 30, amount: 42.74m),
-            Pattern("ami insurance", intervalDays: 30, amount: 99.00m), // wildly different amount
+            Pattern("ami insurance", intervalDays: 30, amount: 42.75m),
         };
 
-        var clusters = RecurringPatternGrouping.PartitionBySameBill(members, p => p.NormalizedMerchantKey);
+        var clusters = RecurringPatternGrouping.PartitionBySameBill(members);
 
-        clusters.Should().HaveCount(1, "exact normalized-key matches are unambiguous duplicates");
+        clusters.Should().HaveCount(1);
+    }
+
+    [Fact]
+    public void PartitionBySameBill_ExactKeyButDifferentAmount_StaysSeparate()
+    {
+        // Same merchant key after the normalizer strips policy/account IDs, but clearly different
+        // bills (e.g. two insurance policies). The amount evidence must keep them separate.
+        var members = new List<RecurringPattern>
+        {
+            Pattern("ami insurance", intervalDays: 30, amount: 42.74m),
+            Pattern("ami insurance", intervalDays: 30, amount: 300.00m),
+        };
+
+        var clusters = RecurringPatternGrouping.PartitionBySameBill(members);
+
+        clusters.Should().HaveCount(2, "exact key alone is not enough once reference IDs are stripped");
     }
 
     [Fact]
@@ -29,7 +46,7 @@ public class RecurringPatternGroupingTests
             Pattern("acme service", intervalDays: 30, amount: 250.00m),
         };
 
-        var clusters = RecurringPatternGrouping.PartitionBySameBill(members, p => p.NormalizedMerchantKey);
+        var clusters = RecurringPatternGrouping.PartitionBySameBill(members);
 
         clusters.Should().HaveCount(2, "similar names alone must not collapse distinct bills");
     }
@@ -43,7 +60,7 @@ public class RecurringPatternGroupingTests
             Pattern("acme service", intervalDays: 30, amount: 110.00m), // within ±20%
         };
 
-        var clusters = RecurringPatternGrouping.PartitionBySameBill(members, p => p.NormalizedMerchantKey);
+        var clusters = RecurringPatternGrouping.PartitionBySameBill(members);
 
         clusters.Should().HaveCount(1);
     }
@@ -60,7 +77,7 @@ public class RecurringPatternGroupingTests
             Pattern("acme service", intervalDays: 7, amount: 9.00m),     // C (distinct bill)
         };
 
-        var clusters = RecurringPatternGrouping.PartitionBySameBill(members, p => p.NormalizedMerchantKey);
+        var clusters = RecurringPatternGrouping.PartitionBySameBill(members);
 
         clusters.Should().HaveCount(2);
         clusters.Should().ContainSingle(c => c.Count == 2);

--- a/tests/MyMascada.Tests.Unit/Domain/RecurringPatternGroupingTests.cs
+++ b/tests/MyMascada.Tests.Unit/Domain/RecurringPatternGroupingTests.cs
@@ -1,0 +1,85 @@
+using MyMascada.Domain.Common;
+using MyMascada.Domain.Entities;
+using MyMascada.Domain.Enums;
+
+namespace MyMascada.Tests.Unit.Domain;
+
+public class RecurringPatternGroupingTests
+{
+    [Fact]
+    public void PartitionBySameBill_ExactKeyMatch_AlwaysClustersTogether()
+    {
+        var members = new List<RecurringPattern>
+        {
+            Pattern("ami insurance", intervalDays: 30, amount: 42.74m),
+            Pattern("ami insurance", intervalDays: 30, amount: 99.00m), // wildly different amount
+        };
+
+        var clusters = RecurringPatternGrouping.PartitionBySameBill(members, p => p.NormalizedMerchantKey);
+
+        clusters.Should().HaveCount(1, "exact normalized-key matches are unambiguous duplicates");
+    }
+
+    [Fact]
+    public void PartitionBySameBill_FuzzyNameDifferentCadenceAndAmount_StaysSeparate()
+    {
+        var members = new List<RecurringPattern>
+        {
+            Pattern("acme services", intervalDays: 7, amount: 12.00m),
+            Pattern("acme service", intervalDays: 30, amount: 250.00m),
+        };
+
+        var clusters = RecurringPatternGrouping.PartitionBySameBill(members, p => p.NormalizedMerchantKey);
+
+        clusters.Should().HaveCount(2, "similar names alone must not collapse distinct bills");
+    }
+
+    [Fact]
+    public void PartitionBySameBill_FuzzyNameSameCadenceAndCloseAmount_Clusters()
+    {
+        var members = new List<RecurringPattern>
+        {
+            Pattern("acme services", intervalDays: 30, amount: 100.00m),
+            Pattern("acme service", intervalDays: 30, amount: 110.00m), // within ±20%
+        };
+
+        var clusters = RecurringPatternGrouping.PartitionBySameBill(members, p => p.NormalizedMerchantKey);
+
+        clusters.Should().HaveCount(1);
+    }
+
+    [Fact]
+    public void PartitionBySameBill_ChainAxBxC_SplitsOutDistinctMember()
+    {
+        // A and B share an exact key (same bill); C has a similar name but a very different
+        // cadence + amount, so it must NOT be pulled into the A/B cluster.
+        var members = new List<RecurringPattern>
+        {
+            Pattern("acme services", intervalDays: 30, amount: 100.00m), // A
+            Pattern("acme services", intervalDays: 30, amount: 100.00m), // B (exact key with A)
+            Pattern("acme service", intervalDays: 7, amount: 9.00m),     // C (distinct bill)
+        };
+
+        var clusters = RecurringPatternGrouping.PartitionBySameBill(members, p => p.NormalizedMerchantKey);
+
+        clusters.Should().HaveCount(2);
+        clusters.Should().ContainSingle(c => c.Count == 2);
+        clusters.Should().ContainSingle(c => c.Count == 1);
+    }
+
+    private static RecurringPattern Pattern(string key, int intervalDays, decimal amount)
+        => new()
+        {
+            Id = Random.Shared.Next(1, int.MaxValue),
+            UserId = Guid.NewGuid(),
+            MerchantName = key,
+            NormalizedMerchantKey = key,
+            IntervalDays = intervalDays,
+            AverageAmount = amount,
+            Confidence = 0.8m,
+            Status = RecurringPatternStatus.Active,
+            NextExpectedDate = DateTime.UtcNow.AddDays(3),
+            LastObservedAt = DateTime.UtcNow.AddDays(-27),
+            OccurrenceCount = 4
+        };
+}

--- a/tests/MyMascada.Tests.Unit/Domain/RecurringPatternTests.cs
+++ b/tests/MyMascada.Tests.Unit/Domain/RecurringPatternTests.cs
@@ -481,6 +481,22 @@ public class RecurringPatternTests
     }
 
     [Fact]
+    public void MatchesTransaction_WithStaleStoredKey_ShouldStillMatchCleanDescription()
+    {
+        // Arrange - pattern persisted by the old normalizer keeps a noisy key, while the
+        // incoming description normalizes to the clean form. They must still match.
+        var pattern = CreatePattern(
+            normalizedMerchantKey: "ami insurance amiinsurance 3301234",
+            averageAmount: 42.75m);
+
+        // Act
+        var result = pattern.MatchesTransaction("AMI INSURANCE AMIINSURANCE 3305678", -42.75m);
+
+        // Assert
+        result.Should().BeTrue();
+    }
+
+    [Fact]
     public void MatchesTransaction_WithEmptyDescription_ShouldReturnFalse()
     {
         // Arrange

--- a/tests/MyMascada.Tests.Unit/Services/RecurringPatternPersistenceServiceTests.cs
+++ b/tests/MyMascada.Tests.Unit/Services/RecurringPatternPersistenceServiceTests.cs
@@ -264,15 +264,15 @@ public class RecurringPatternPersistenceServiceTests
     }
 
     [Fact]
-    public async Task DetectAndPersistPatternsAsync_WithExactSameKeyButDifferentAmounts_ShouldStillMerge()
+    public async Task DetectAndPersistPatternsAsync_WithSameKeyAndCloseAmounts_ShouldMerge()
     {
-        // Arrange - identical normalized key is an unambiguous duplicate; merge regardless of the
-        // amount spread (this is the reported bug's exact shape: same merchant, varied amounts).
+        // Arrange - the reported bug's exact shape: same merchant key, same cadence, near-identical
+        // amounts. These must merge into one canonical pattern.
         var today = DateTime.UtcNow.Date;
         var patterns = new List<RecurringPattern>
         {
             CreatePattern("ami insurance", amount: 42.74m, nextDue: today.AddDays(2), confidence: 0.85m, occurrences: 5),
-            CreatePattern("ami insurance", amount: 99.00m, nextDue: today.AddDays(3), confidence: 0.80m, occurrences: 3),
+            CreatePattern("ami insurance", amount: 42.75m, nextDue: today.AddDays(3), confidence: 0.80m, occurrences: 3),
         };
 
         _patternRepository.GetByUserIdAsync(_userId, Arg.Any<bool>(), Arg.Any<CancellationToken>()).Returns(patterns);
@@ -286,6 +286,32 @@ public class RecurringPatternPersistenceServiceTests
         await _patternRepository.Received(1).MergeDuplicatePatternsAsync(
             _userId, patterns[0].Id,
             Arg.Is<IEnumerable<int>>(ids => ids.SequenceEqual(new[] { patterns[1].Id })),
+            Arg.Any<string>(), Arg.Any<int>(), Arg.Any<decimal>(), Arg.Any<DateTime>(),
+            Arg.Any<DateTime>(), Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task DetectAndPersistPatternsAsync_WithSameKeyButFarApartAmounts_ShouldNotMerge()
+    {
+        // Arrange - same normalized key (the normalizer stripped policy/account IDs) but clearly
+        // different bills (e.g. two insurance policies). The amount evidence keeps them separate.
+        var today = DateTime.UtcNow.Date;
+        var patterns = new List<RecurringPattern>
+        {
+            CreatePattern("ami insurance", amount: 42.74m, nextDue: today.AddDays(2), confidence: 0.85m, occurrences: 5),
+            CreatePattern("ami insurance", amount: 300.00m, nextDue: today.AddDays(3), confidence: 0.80m, occurrences: 3),
+        };
+
+        _patternRepository.GetByUserIdAsync(_userId, Arg.Any<bool>(), Arg.Any<CancellationToken>()).Returns(patterns);
+        _transactionRepository.GetByDateRangeAsync(_userId, Arg.Any<DateTime>(), Arg.Any<DateTime>())
+            .Returns(new List<Transaction>());
+
+        // Act
+        await _service.DetectAndPersistPatternsAsync(_userId);
+
+        // Assert
+        await _patternRepository.DidNotReceive().MergeDuplicatePatternsAsync(
+            Arg.Any<Guid>(), Arg.Any<int>(), Arg.Any<IEnumerable<int>>(),
             Arg.Any<string>(), Arg.Any<int>(), Arg.Any<decimal>(), Arg.Any<DateTime>(),
             Arg.Any<DateTime>(), Arg.Any<CancellationToken>());
     }

--- a/tests/MyMascada.Tests.Unit/Services/RecurringPatternPersistenceServiceTests.cs
+++ b/tests/MyMascada.Tests.Unit/Services/RecurringPatternPersistenceServiceTests.cs
@@ -100,6 +100,31 @@ public class RecurringPatternPersistenceServiceTests
     }
 
     [Fact]
+    public async Task GetUpcomingBillsAsync_WithSimilarNamesButDifferentCadenceAndAmount_ShouldKeepBothBills()
+    {
+        // Arrange - two distinct bills with near-identical names but unrelated cadence/amount.
+        // Display consolidation must NOT collapse them, otherwise a real bill is hidden.
+        var today = DateTime.UtcNow.Date;
+        var weekly = CreatePattern("acme services", amount: 12.00m, nextDue: today.AddDays(2),
+            confidence: 0.85m, occurrences: 6);
+        weekly.IntervalDays = 7;
+        var monthly = CreatePattern("acme service", amount: 250.00m, nextDue: today.AddDays(3),
+            confidence: 0.85m, occurrences: 6);
+        monthly.IntervalDays = 30;
+
+        _patternRepository
+            .GetUpcomingAsync(_userId, Arg.Any<DateTime>(), Arg.Any<DateTime>(), Arg.Any<CancellationToken>())
+            .Returns(new List<RecurringPattern> { weekly, monthly });
+
+        // Act
+        var result = await _service.GetUpcomingBillsAsync(_userId, daysAhead: 7);
+
+        // Assert
+        result.Bills.Should().HaveCount(2);
+        result.TotalExpectedAmount.Should().Be(262.00m);
+    }
+
+    [Fact]
     public async Task DetectAndPersistPatternsAsync_WithExistingDuplicatePatterns_ShouldMergeThem()
     {
         // Arrange - existing active patterns include three duplicates for one merchant.

--- a/tests/MyMascada.Tests.Unit/Services/RecurringPatternPersistenceServiceTests.cs
+++ b/tests/MyMascada.Tests.Unit/Services/RecurringPatternPersistenceServiceTests.cs
@@ -128,11 +128,55 @@ public class RecurringPatternPersistenceServiceTests
             canonicalPatternId: activePatterns[1].Id, // occurrences:5 -> canonical
             Arg.Is<IEnumerable<int>>(ids => ids.OrderBy(x => x).SequenceEqual(
                 new[] { activePatterns[0].Id, activePatterns[2].Id }.OrderBy(x => x))),
+            mergedNormalizedKey: "ami insurance",
             mergedOccurrenceCount: 12, // 4 + 5 + 3
             mergedAverageAmount: 42.75m, // most recent (lastObserved -1)
             Arg.Any<DateTime>(),
             Arg.Any<DateTime>(),
             Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task DetectAndPersistPatternsAsync_WithStaleNormalizedKey_ShouldMigrateLoneRowKey()
+    {
+        // Arrange - a single active pattern whose stored key was produced by the old normalizer.
+        var today = DateTime.UtcNow.Date;
+        var stale = CreatePattern("ami insurance amiinsurance 3301234", amount: 42.75m,
+            nextDue: today.AddDays(3), confidence: 0.85m, occurrences: 5);
+
+        _patternRepository.GetActiveAsync(_userId, Arg.Any<CancellationToken>())
+            .Returns(new List<RecurringPattern> { stale });
+        _transactionRepository.GetByDateRangeAsync(_userId, Arg.Any<DateTime>(), Arg.Any<DateTime>())
+            .Returns(new List<Transaction>());
+
+        // Act
+        await _service.DetectAndPersistPatternsAsync(_userId);
+
+        // Assert - the lone stale row's key is migrated to the clean normalized form so the next
+        // exact-key upsert updates it rather than creating a fresh duplicate.
+        await _patternRepository.Received(1).UpdateNormalizedKeyAsync(
+            _userId, stale.Id, "ami insurance", Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task DetectAndPersistPatternsAsync_WithAlreadyCleanLoneKey_ShouldNotMigrate()
+    {
+        // Arrange
+        var today = DateTime.UtcNow.Date;
+        var clean = CreatePattern("ami insurance", amount: 42.75m,
+            nextDue: today.AddDays(3), confidence: 0.85m, occurrences: 5);
+
+        _patternRepository.GetActiveAsync(_userId, Arg.Any<CancellationToken>())
+            .Returns(new List<RecurringPattern> { clean });
+        _transactionRepository.GetByDateRangeAsync(_userId, Arg.Any<DateTime>(), Arg.Any<DateTime>())
+            .Returns(new List<Transaction>());
+
+        // Act
+        await _service.DetectAndPersistPatternsAsync(_userId);
+
+        // Assert
+        await _patternRepository.DidNotReceive().UpdateNormalizedKeyAsync(
+            Arg.Any<Guid>(), Arg.Any<int>(), Arg.Any<string>(), Arg.Any<CancellationToken>());
     }
 
     [Fact]
@@ -156,8 +200,8 @@ public class RecurringPatternPersistenceServiceTests
         // Assert - no merge should occur for genuinely distinct merchants.
         await _patternRepository.DidNotReceive().MergeDuplicatePatternsAsync(
             Arg.Any<Guid>(), Arg.Any<int>(), Arg.Any<IEnumerable<int>>(),
-            Arg.Any<int>(), Arg.Any<decimal>(), Arg.Any<DateTime>(), Arg.Any<DateTime>(),
-            Arg.Any<CancellationToken>());
+            Arg.Any<string>(), Arg.Any<int>(), Arg.Any<decimal>(), Arg.Any<DateTime>(),
+            Arg.Any<DateTime>(), Arg.Any<CancellationToken>());
     }
 
     private RecurringPattern CreatePattern(

--- a/tests/MyMascada.Tests.Unit/Services/RecurringPatternPersistenceServiceTests.cs
+++ b/tests/MyMascada.Tests.Unit/Services/RecurringPatternPersistenceServiceTests.cs
@@ -1,0 +1,187 @@
+using Microsoft.Extensions.Logging;
+using MyMascada.Application.Common.Interfaces;
+using MyMascada.Application.Features.RecurringPatterns.Services;
+using MyMascada.Domain.Entities;
+using MyMascada.Domain.Enums;
+using NSubstitute;
+
+namespace MyMascada.Tests.Unit.Services;
+
+public class RecurringPatternPersistenceServiceTests
+{
+    private readonly IRecurringPatternRepository _patternRepository;
+    private readonly ITransactionRepository _transactionRepository;
+    private readonly RecurringPatternPersistenceService _service;
+    private readonly Guid _userId = Guid.NewGuid();
+    private int _patternIdCounter = 1;
+
+    public RecurringPatternPersistenceServiceTests()
+    {
+        _patternRepository = Substitute.For<IRecurringPatternRepository>();
+        _transactionRepository = Substitute.For<ITransactionRepository>();
+        _service = new RecurringPatternPersistenceService(
+            _patternRepository,
+            _transactionRepository,
+            Substitute.For<ILogger<RecurringPatternPersistenceService>>());
+    }
+
+    [Fact]
+    public async Task GetUpcomingBillsAsync_WithDuplicatePatternsForSameMerchant_ShouldReturnSingleBill()
+    {
+        // Arrange - three near-duplicate patterns for the same merchant (the reported bug):
+        // same normalized key, near-identical amounts. They must surface as ONE bill.
+        var today = DateTime.UtcNow.Date;
+        var patterns = new List<RecurringPattern>
+        {
+            CreatePattern("ami insurance", amount: 42.74m, nextDue: today.AddDays(2), confidence: 0.80m, occurrences: 4),
+            CreatePattern("ami insurance", amount: 42.75m, nextDue: today.AddDays(3), confidence: 0.85m, occurrences: 5),
+            CreatePattern("ami insurance", amount: 42.75m, nextDue: today.AddDays(4), confidence: 0.82m, occurrences: 3),
+        };
+
+        _patternRepository
+            .GetUpcomingAsync(_userId, Arg.Any<DateTime>(), Arg.Any<DateTime>(), Arg.Any<CancellationToken>())
+            .Returns(patterns);
+
+        // Act
+        var result = await _service.GetUpcomingBillsAsync(_userId, daysAhead: 7);
+
+        // Assert
+        result.Bills.Should().HaveCount(1, "duplicate patterns for one merchant must consolidate into a single bill");
+        result.TotalBillsCount.Should().Be(1);
+        result.Bills.Single().MerchantName.Should().Be("Ami Insurance");
+    }
+
+    [Fact]
+    public async Task GetUpcomingBillsAsync_WithDuplicatePatterns_ShouldKeepSoonestDue()
+    {
+        // Arrange
+        var today = DateTime.UtcNow.Date;
+        var patterns = new List<RecurringPattern>
+        {
+            CreatePattern("ami insurance", amount: 42.74m, nextDue: today.AddDays(5), confidence: 0.90m, occurrences: 4,
+                lastObserved: today.AddDays(-25)),
+            CreatePattern("ami insurance", amount: 42.99m, nextDue: today.AddDays(2), confidence: 0.80m, occurrences: 5,
+                lastObserved: today.AddDays(-1)),
+        };
+
+        _patternRepository
+            .GetUpcomingAsync(_userId, Arg.Any<DateTime>(), Arg.Any<DateTime>(), Arg.Any<CancellationToken>())
+            .Returns(patterns);
+
+        // Act
+        var result = await _service.GetUpcomingBillsAsync(_userId, daysAhead: 7);
+
+        // Assert - representative is the soonest-due, with the most recent amount.
+        result.Bills.Should().HaveCount(1);
+        result.Bills.Single().DaysUntilDue.Should().Be(2);
+        result.Bills.Single().ExpectedAmount.Should().Be(42.99m, "the most recently observed amount should win");
+    }
+
+    [Fact]
+    public async Task GetUpcomingBillsAsync_WithDistinctMerchants_ShouldReturnSeparateBills()
+    {
+        // Arrange
+        var today = DateTime.UtcNow.Date;
+        var patterns = new List<RecurringPattern>
+        {
+            CreatePattern("ami insurance", amount: 42.75m, nextDue: today.AddDays(2), confidence: 0.85m, occurrences: 5),
+            CreatePattern("netflix", amount: 15.99m, nextDue: today.AddDays(3), confidence: 0.90m, occurrences: 6),
+        };
+
+        _patternRepository
+            .GetUpcomingAsync(_userId, Arg.Any<DateTime>(), Arg.Any<DateTime>(), Arg.Any<CancellationToken>())
+            .Returns(patterns);
+
+        // Act
+        var result = await _service.GetUpcomingBillsAsync(_userId, daysAhead: 7);
+
+        // Assert
+        result.Bills.Should().HaveCount(2);
+    }
+
+    [Fact]
+    public async Task DetectAndPersistPatternsAsync_WithExistingDuplicatePatterns_ShouldMergeThem()
+    {
+        // Arrange - existing active patterns include three duplicates for one merchant.
+        var today = DateTime.UtcNow.Date;
+        var activePatterns = new List<RecurringPattern>
+        {
+            CreatePattern("ami insurance", amount: 42.74m, nextDue: today.AddDays(2), confidence: 0.80m, occurrences: 4,
+                lastObserved: today.AddDays(-28)),
+            CreatePattern("ami insurance", amount: 42.75m, nextDue: today.AddDays(3), confidence: 0.85m, occurrences: 5,
+                lastObserved: today.AddDays(-1)),
+            CreatePattern("ami insurance", amount: 42.75m, nextDue: today.AddDays(4), confidence: 0.82m, occurrences: 3,
+                lastObserved: today.AddDays(-30)),
+        };
+
+        _patternRepository.GetActiveAsync(_userId, Arg.Any<CancellationToken>()).Returns(activePatterns);
+        _transactionRepository.GetByDateRangeAsync(_userId, Arg.Any<DateTime>(), Arg.Any<DateTime>())
+            .Returns(new List<Transaction>());
+
+        // Act
+        await _service.DetectAndPersistPatternsAsync(_userId);
+
+        // Assert - reconciliation merges the two duplicates into the canonical (most occurrences)
+        // pattern, summing occurrence counts and adopting the freshest amount/dates.
+        await _patternRepository.Received(1).MergeDuplicatePatternsAsync(
+            _userId,
+            canonicalPatternId: activePatterns[1].Id, // occurrences:5 -> canonical
+            Arg.Is<IEnumerable<int>>(ids => ids.OrderBy(x => x).SequenceEqual(
+                new[] { activePatterns[0].Id, activePatterns[2].Id }.OrderBy(x => x))),
+            mergedOccurrenceCount: 12, // 4 + 5 + 3
+            mergedAverageAmount: 42.75m, // most recent (lastObserved -1)
+            Arg.Any<DateTime>(),
+            Arg.Any<DateTime>(),
+            Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task DetectAndPersistPatternsAsync_WithDistinctMerchants_ShouldNotMerge()
+    {
+        // Arrange
+        var today = DateTime.UtcNow.Date;
+        var activePatterns = new List<RecurringPattern>
+        {
+            CreatePattern("ami insurance", amount: 42.75m, nextDue: today.AddDays(2), confidence: 0.85m, occurrences: 5),
+            CreatePattern("netflix", amount: 15.99m, nextDue: today.AddDays(3), confidence: 0.90m, occurrences: 6),
+        };
+
+        _patternRepository.GetActiveAsync(_userId, Arg.Any<CancellationToken>()).Returns(activePatterns);
+        _transactionRepository.GetByDateRangeAsync(_userId, Arg.Any<DateTime>(), Arg.Any<DateTime>())
+            .Returns(new List<Transaction>());
+
+        // Act
+        await _service.DetectAndPersistPatternsAsync(_userId);
+
+        // Assert - no merge should occur for genuinely distinct merchants.
+        await _patternRepository.DidNotReceive().MergeDuplicatePatternsAsync(
+            Arg.Any<Guid>(), Arg.Any<int>(), Arg.Any<IEnumerable<int>>(),
+            Arg.Any<int>(), Arg.Any<decimal>(), Arg.Any<DateTime>(), Arg.Any<DateTime>(),
+            Arg.Any<CancellationToken>());
+    }
+
+    private RecurringPattern CreatePattern(
+        string normalizedKey,
+        decimal amount,
+        DateTime nextDue,
+        decimal confidence,
+        int occurrences,
+        DateTime? lastObserved = null)
+    {
+        return new RecurringPattern
+        {
+            Id = _patternIdCounter++,
+            UserId = _userId,
+            MerchantName = System.Globalization.CultureInfo.CurrentCulture.TextInfo.ToTitleCase(normalizedKey),
+            NormalizedMerchantKey = normalizedKey,
+            IntervalDays = 30,
+            AverageAmount = amount,
+            Confidence = confidence,
+            Status = RecurringPatternStatus.Active,
+            NextExpectedDate = nextDue,
+            LastObservedAt = lastObserved ?? DateTime.UtcNow.AddDays(-27),
+            OccurrenceCount = occurrences,
+            ConsecutiveMisses = 0
+        };
+    }
+}

--- a/tests/MyMascada.Tests.Unit/Services/RecurringPatternPersistenceServiceTests.cs
+++ b/tests/MyMascada.Tests.Unit/Services/RecurringPatternPersistenceServiceTests.cs
@@ -114,7 +114,7 @@ public class RecurringPatternPersistenceServiceTests
                 lastObserved: today.AddDays(-30)),
         };
 
-        _patternRepository.GetActiveAsync(_userId, Arg.Any<CancellationToken>()).Returns(activePatterns);
+        _patternRepository.GetByUserIdAsync(_userId, Arg.Any<bool>(), Arg.Any<CancellationToken>()).Returns(activePatterns);
         _transactionRepository.GetByDateRangeAsync(_userId, Arg.Any<DateTime>(), Arg.Any<DateTime>())
             .Returns(new List<Transaction>());
 
@@ -144,7 +144,7 @@ public class RecurringPatternPersistenceServiceTests
         var stale = CreatePattern("ami insurance amiinsurance 3301234", amount: 42.75m,
             nextDue: today.AddDays(3), confidence: 0.85m, occurrences: 5);
 
-        _patternRepository.GetActiveAsync(_userId, Arg.Any<CancellationToken>())
+        _patternRepository.GetByUserIdAsync(_userId, Arg.Any<bool>(), Arg.Any<CancellationToken>())
             .Returns(new List<RecurringPattern> { stale });
         _transactionRepository.GetByDateRangeAsync(_userId, Arg.Any<DateTime>(), Arg.Any<DateTime>())
             .Returns(new List<Transaction>());
@@ -166,7 +166,7 @@ public class RecurringPatternPersistenceServiceTests
         var clean = CreatePattern("ami insurance", amount: 42.75m,
             nextDue: today.AddDays(3), confidence: 0.85m, occurrences: 5);
 
-        _patternRepository.GetActiveAsync(_userId, Arg.Any<CancellationToken>())
+        _patternRepository.GetByUserIdAsync(_userId, Arg.Any<bool>(), Arg.Any<CancellationToken>())
             .Returns(new List<RecurringPattern> { clean });
         _transactionRepository.GetByDateRangeAsync(_userId, Arg.Any<DateTime>(), Arg.Any<DateTime>())
             .Returns(new List<Transaction>());
@@ -180,6 +180,36 @@ public class RecurringPatternPersistenceServiceTests
     }
 
     [Fact]
+    public async Task DetectAndPersistPatternsAsync_WithPausedAndActiveDuplicate_ShouldKeepPausedAsCanonical()
+    {
+        // Arrange - the user paused this merchant; a stale Active duplicate also exists. Merging
+        // must keep the Paused row as canonical so the bill is not silently resurrected.
+        var today = DateTime.UtcNow.Date;
+        var patterns = new List<RecurringPattern>
+        {
+            CreatePattern("ami insurance", amount: 42.75m, nextDue: today.AddDays(3), confidence: 0.95m,
+                occurrences: 8, status: RecurringPatternStatus.Active),
+            CreatePattern("ami insurance", amount: 42.75m, nextDue: today.AddDays(2), confidence: 0.70m,
+                occurrences: 3, status: RecurringPatternStatus.Paused),
+        };
+
+        _patternRepository.GetByUserIdAsync(_userId, Arg.Any<bool>(), Arg.Any<CancellationToken>()).Returns(patterns);
+        _transactionRepository.GetByDateRangeAsync(_userId, Arg.Any<DateTime>(), Arg.Any<DateTime>())
+            .Returns(new List<Transaction>());
+
+        // Act
+        await _service.DetectAndPersistPatternsAsync(_userId);
+
+        // Assert - the Paused row (patterns[1]) is canonical despite weaker occurrences/confidence.
+        await _patternRepository.Received(1).MergeDuplicatePatternsAsync(
+            _userId,
+            canonicalPatternId: patterns[1].Id,
+            Arg.Is<IEnumerable<int>>(ids => ids.SequenceEqual(new[] { patterns[0].Id })),
+            Arg.Any<string>(), Arg.Any<int>(), Arg.Any<decimal>(), Arg.Any<DateTime>(),
+            Arg.Any<DateTime>(), Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
     public async Task DetectAndPersistPatternsAsync_WithDistinctMerchants_ShouldNotMerge()
     {
         // Arrange
@@ -190,7 +220,7 @@ public class RecurringPatternPersistenceServiceTests
             CreatePattern("netflix", amount: 15.99m, nextDue: today.AddDays(3), confidence: 0.90m, occurrences: 6),
         };
 
-        _patternRepository.GetActiveAsync(_userId, Arg.Any<CancellationToken>()).Returns(activePatterns);
+        _patternRepository.GetByUserIdAsync(_userId, Arg.Any<bool>(), Arg.Any<CancellationToken>()).Returns(activePatterns);
         _transactionRepository.GetByDateRangeAsync(_userId, Arg.Any<DateTime>(), Arg.Any<DateTime>())
             .Returns(new List<Transaction>());
 
@@ -210,7 +240,8 @@ public class RecurringPatternPersistenceServiceTests
         DateTime nextDue,
         decimal confidence,
         int occurrences,
-        DateTime? lastObserved = null)
+        DateTime? lastObserved = null,
+        RecurringPatternStatus status = RecurringPatternStatus.Active)
     {
         return new RecurringPattern
         {
@@ -221,7 +252,7 @@ public class RecurringPatternPersistenceServiceTests
             IntervalDays = 30,
             AverageAmount = amount,
             Confidence = confidence,
-            Status = RecurringPatternStatus.Active,
+            Status = status,
             NextExpectedDate = nextDue,
             LastObservedAt = lastObserved ?? DateTime.UtcNow.AddDays(-27),
             OccurrenceCount = occurrences,

--- a/tests/MyMascada.Tests.Unit/Services/RecurringPatternPersistenceServiceTests.cs
+++ b/tests/MyMascada.Tests.Unit/Services/RecurringPatternPersistenceServiceTests.cs
@@ -210,6 +210,62 @@ public class RecurringPatternPersistenceServiceTests
     }
 
     [Fact]
+    public async Task DetectAndPersistPatternsAsync_WithSimilarNamesButDifferentCadenceAndAmount_ShouldNotMerge()
+    {
+        // Arrange - two patterns whose names are one edit apart (so they land in the same
+        // name-similarity group) but with unrelated cadence AND amount. They are NOT the same
+        // recurring bill and must not be destructively merged.
+        var today = DateTime.UtcNow.Date;
+        var weekly = CreatePattern("acme services", amount: 12.00m, nextDue: today.AddDays(2),
+            confidence: 0.85m, occurrences: 6);
+        weekly.IntervalDays = 7; // Weekly
+        var monthly = CreatePattern("acme service", amount: 250.00m, nextDue: today.AddDays(3),
+            confidence: 0.85m, occurrences: 6);
+        monthly.IntervalDays = 30; // Monthly, ~20x the amount
+
+        _patternRepository.GetByUserIdAsync(_userId, Arg.Any<bool>(), Arg.Any<CancellationToken>())
+            .Returns(new List<RecurringPattern> { weekly, monthly });
+        _transactionRepository.GetByDateRangeAsync(_userId, Arg.Any<DateTime>(), Arg.Any<DateTime>())
+            .Returns(new List<Transaction>());
+
+        // Act
+        await _service.DetectAndPersistPatternsAsync(_userId);
+
+        // Assert - no destructive merge for distinct bills that merely share a similar name.
+        await _patternRepository.DidNotReceive().MergeDuplicatePatternsAsync(
+            Arg.Any<Guid>(), Arg.Any<int>(), Arg.Any<IEnumerable<int>>(),
+            Arg.Any<string>(), Arg.Any<int>(), Arg.Any<decimal>(), Arg.Any<DateTime>(),
+            Arg.Any<DateTime>(), Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task DetectAndPersistPatternsAsync_WithExactSameKeyButDifferentAmounts_ShouldStillMerge()
+    {
+        // Arrange - identical normalized key is an unambiguous duplicate; merge regardless of the
+        // amount spread (this is the reported bug's exact shape: same merchant, varied amounts).
+        var today = DateTime.UtcNow.Date;
+        var patterns = new List<RecurringPattern>
+        {
+            CreatePattern("ami insurance", amount: 42.74m, nextDue: today.AddDays(2), confidence: 0.85m, occurrences: 5),
+            CreatePattern("ami insurance", amount: 99.00m, nextDue: today.AddDays(3), confidence: 0.80m, occurrences: 3),
+        };
+
+        _patternRepository.GetByUserIdAsync(_userId, Arg.Any<bool>(), Arg.Any<CancellationToken>()).Returns(patterns);
+        _transactionRepository.GetByDateRangeAsync(_userId, Arg.Any<DateTime>(), Arg.Any<DateTime>())
+            .Returns(new List<Transaction>());
+
+        // Act
+        await _service.DetectAndPersistPatternsAsync(_userId);
+
+        // Assert
+        await _patternRepository.Received(1).MergeDuplicatePatternsAsync(
+            _userId, patterns[0].Id,
+            Arg.Is<IEnumerable<int>>(ids => ids.SequenceEqual(new[] { patterns[1].Id })),
+            Arg.Any<string>(), Arg.Any<int>(), Arg.Any<decimal>(), Arg.Any<DateTime>(),
+            Arg.Any<DateTime>(), Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
     public async Task DetectAndPersistPatternsAsync_WithDistinctMerchants_ShouldNotMerge()
     {
         // Arrange

--- a/tests/MyMascada.Tests.Unit/Services/RecurringPatternPersistenceServiceTests.cs
+++ b/tests/MyMascada.Tests.Unit/Services/RecurringPatternPersistenceServiceTests.cs
@@ -172,7 +172,7 @@ public class RecurringPatternPersistenceServiceTests
         {
             Id = _patternIdCounter++,
             UserId = _userId,
-            MerchantName = System.Globalization.CultureInfo.CurrentCulture.TextInfo.ToTitleCase(normalizedKey),
+            MerchantName = System.Globalization.CultureInfo.InvariantCulture.TextInfo.ToTitleCase(normalizedKey),
             NormalizedMerchantKey = normalizedKey,
             IntervalDays = 30,
             AverageAmount = amount,


### PR DESCRIPTION
## Problem
A user reported the same recurring bill ("Ami Insurance") showing up **3 times** in the dashboard "Upcoming Bills" list, with near-identical amounts (NZ\$42.74 / 42.75 / 42.75). Root cause: recurring-pattern detection was splitting one merchant into multiple distinct patterns.

## Root causes
1. **Normalization gap** — `NormalizeDescription` only stripped reference numbers with explicit `#`/`ref:`/`id:` prefixes or pure trailing digits. Embedded bare numeric/alphanumeric reference tokens (common in NZ bank feeds, e.g. `AMI INSURANCE AMIINSURANCE 3301234`) survived, so the same merchant produced several distinct keys.
2. **Non-transitive merge** — `MergeSimilarGroups` merged only groups >80% similar to a single anchor. Groups mutually similar but not similar to the anchor never merged; the threshold was also fragile when a long embedded number is a large fraction of a short merchant string.
3. **No upcoming-bills consolidation** — `GetUpcomingBillsAsync` emitted one bill per pattern, so duplicate patterns surfaced directly as duplicate bills.
4. **No cleanup of existing duplicates** — upsert is keyed by `NormalizedMerchantKey`; stale duplicate rows already in the DB were never reconciled.

## Fixes
- **Shared `MerchantNormalizer`** (Domain/Common): strips embedded standalone numeric tokens (len ≥ 3) and long mostly-numeric alphanumeric tokens anywhere in the string, and collapses doubled merchant-word artifacts ("ami insurance amiinsurance"). All three normalization sites now delegate to it so they can't drift.
- **Transitive merge** via union-find / connected components: `A~B~C` collapse into one group even when `A` is not directly similar to `C`. Canonical key = the member with the most transactions.
- **Upcoming-bills dedup safety net** in both `GetUpcomingBills` code paths (`RecurringPatternService` and `RecurringPatternPersistenceService`): consolidate patterns resolving to the same merchant, keeping the soonest-due / highest-confidence one and the most recent amount.
- **Self-healing reconciliation**: `DetectAndPersistPatternsAsync` now merges already-persisted duplicate rows for the user each detection pass. Occurrence history is re-parented onto the canonical pattern and duplicates are soft-deleted (new `MergeDuplicatePatternsAsync` repository method).

## Tests
- `MerchantNormalizerTests` — embedded-reference stripping (`AMI INSURANCE AMIINSURANCE 3301234` and `... 3305678` normalize equal), doubled-word collapse, brand-number preservation, and transitive merge collapsing `A~B~C` where `A≁C` directly.
- `RecurringPatternPersistenceServiceTests` — `GetUpcomingBillsAsync` returns a single bill for duplicate patterns of one merchant (keeping soonest-due + most recent amount), keeps distinct merchants separate, and `DetectAndPersistPatternsAsync` invokes reconciliation for existing duplicates.
- `dotnet build` (whole solution) succeeds. Full unit suite: **1362 passed, 0 failed**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Improved recurring-pattern detection with automatic reconciliation of duplicate entries before each run.
  * Upcoming bills now consolidate duplicates/overlaps per merchant into a single entry using the most recent display values.
* **Bug Fixes**
  * Fixed cases where similar merchants were incorrectly split across multiple patterns; also ensures distinct patterns (different cadence/amount) don’t get merged.
  * Recurring pattern matching remains reliable even if stored merchant keys are older/noisier.
* **Tests**
  * Added/expanded unit tests for merchant normalization, transitive consolidation behavior, duplicate merging, and stale-key matching.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->