### PR TITLE
fix(cors): allow X-Admin-Key header so the admin panel can call the API

### DIFF
--- a/src/WebAPI/MyMascada.WebAPI/Extensions/CorsServiceExtensions.cs
+++ b/src/WebAPI/MyMascada.WebAPI/Extensions/CorsServiceExtensions.cs
@@ -37,7 +37,7 @@ public static class CorsServiceExtensions
 
                 policy.WithOrigins(allOrigins)
                       .WithMethods("GET", "POST", "PUT", "DELETE", "PATCH", "OPTIONS")
-                      .WithHeaders("Content-Type", "Authorization", "Accept", "X-Requested-With")
+                      .WithHeaders("Content-Type", "Authorization", "Accept", "X-Requested-With", "X-Admin-Key")
                       .AllowCredentials()
                       .SetPreflightMaxAge(TimeSpan.FromMinutes(10))
                       .WithExposedHeaders("Authorization", "Content-Type", "Accept", "Origin", "Access-Control-Allow-Origin");


### PR DESCRIPTION
## Symptom

The production admin panel (served from an allowed origin, talking to `https://api.mymascada.com/api/latest`) is completely broken by a CORS preflight failure. Every admin request fails in the browser with:

> Request header field X-Admin-Key is not allowed by Access-Control-Allow-Headers.

This breaks the **Waitlist**, **Invitations**, and **User Features** admin tabs. (`curl` works because it does not enforce CORS — this is browser-only.)

## Root cause

Admin endpoints require a custom `X-Admin-Key` request header (see `src/WebAPI/MyMascada.WebAPI/Filters/AdminApiKeyAttribute.cs`). The `AllowFrontend` CORS policy in `CorsServiceExtensions.cs` listed allowed headers as:

```
.WithHeaders("Content-Type", "Authorization", "Accept", "X-Requested-With")
```

`X-Admin-Key` was missing, so the browser blocked every admin request at the preflight stage. The origin itself was already allowed — the failure is specifically about the missing header.

## Fix

Add `X-Admin-Key` to the allowed-headers list. No other changes (origins, methods, exposed headers, credentials are all untouched).

## Testing

- `dotnet build` on the WebAPI project → 0 errors.
- Backend-only CORS config change; no UI changes, so no screenshots.

🤖 Generated with [Claude Code](https://claude.com/claude-code)