### PR TITLE
docs(claude-md): fix local setup commands that don't work as written

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -12,16 +12,30 @@ A personal finance management application with AI-powered transaction categoriza
 
 ### Start Infrastructure
 ```bash
-docker compose -f docker-compose.dev.yml up -d
+docker compose up -d postgres redis
 ```
-Starts PostgreSQL (port 5432) and Redis (port 6379).
+Starts PostgreSQL (port 5432) and Redis (port 6379). Requires `DB_PASSWORD` in `.env`.
+
+> Naming only these two services is deliberate — a bare `docker compose up -d` would
+> also start the api/frontend/caddy containers and fight the locally-run ones below.
+>
+> If something else already owns port 5432 (e.g. a Postgres installed via Homebrew),
+> the container will not be the database you connect to. Check with
+> `lsof -nP -iTCP:5432 -sTCP:LISTEN` before assuming the container is in use.
 
 ### Start Backend
 ```bash
-cd src/WebAPI
-dotnet run
+dotnet run --project src/WebAPI/MyMascada.WebAPI
 ```
 Backend runs on `http://localhost:5126`. Applies EF migrations automatically on startup.
+
+> The project lives at `src/WebAPI/MyMascada.WebAPI`, so `cd src/WebAPI && dotnet run`
+> fails with "Couldn't find a project to run".
+>
+> Run it via the launch profile (as above). Passing `--no-launch-profile` drops the
+> `http://localhost:5126` binding and the Development environment, so it tries port
+> 5000 and the container-only Data Protection key path `/app` — both of which fail
+> locally.
 
 ### Start Frontend
 ```bash


### PR DESCRIPTION
Both commands in **Local Development Setup** fail exactly as documented. I hit both while verifying #339.

| Documented | Problem | Fixed to |
|---|---|---|
| `docker compose -f docker-compose.dev.yml up -d` | That file doesn't exist — the repo only has `docker-compose.yml` | `docker compose up -d postgres redis` |
| `cd src/WebAPI && dotnet run` | Project is nested at `src/WebAPI/MyMascada.WebAPI` → *"Couldn't find a project to run"* | `dotnet run --project src/WebAPI/MyMascada.WebAPI` |

Naming `postgres redis` explicitly is deliberate: a bare `docker compose up -d` would also start the `api`/`frontend`/`caddy` containers and fight the locally-run ones the guide then tells you to start.

Also documented two traps that cost me time:

- **A Homebrew Postgres on 5432 silently shadows the container.** The compose Postgres starts fine and looks healthy, but the app connects to the native one — so you can apply a migration and then find the table "missing" in the container. Added a `lsof` check.
- **`--no-launch-profile` breaks local runs.** It drops the `http://localhost:5126` binding *and* the Development environment, so the app tries port 5000 and the container-only Data Protection key path `/app`, and dies with `IOException: Read-only file system: '/app'`.

## Testing

Both corrected commands verified end to end: infra comes up, backend serves `HTTP 200` on `http://localhost:5126/health`.

Docs only — no code, no screenshots needed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated local development instructions for starting PostgreSQL, Redis, and the backend.
  * Added guidance for configuring `DB_PASSWORD` and verifying PostgreSQL port ownership.
  * Clarified backend project location, startup commands, port behavior, migrations, and Data Protection key paths.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->