### PR TITLE
fix(import-analysis): guard zero DateToleranceDays to stop decimal overflow

### DIFF
--- a/src/Core/MyMascada.Application/Features/ImportReview/Services/ImportAnalysisService.cs
+++ b/src/Core/MyMascada.Application/Features/ImportReview/Services/ImportAnalysisService.cs
@@ -405,8 +405,15 @@ public class ImportAnalysisService : IImportAnalysisService
                 var isExactAmountAndDate = amountDifference == 0 && daysDifference == 0;
                 var isCloseMatch = daysDifference <= 1 && amountDifference <= 0.01m;
                 
-                // Calculate confidence based primarily on amount/date match
-                var dateConfidence = 1.0 - (daysDifference / options.DateToleranceDays);
+                // Calculate confidence based primarily on amount/date match.
+                // Guard the divisors: bank syncs use DateToleranceDays == 0 (exact match),
+                // and dividing by it yields double.NaN, which throws OverflowException when
+                // later cast to decimal ("Value was either too large or too small for a
+                // Decimal"). A zero tolerance means we only get here on an exact match, so
+                // confidence on that axis is 1.0.
+                var dateConfidence = options.DateToleranceDays == 0
+                    ? 1.0
+                    : 1.0 - (daysDifference / options.DateToleranceDays);
                 var amountConfidence = amountDifference == 0 ? 1.0 : (1.0 - (double)amountDifference / (double)options.AmountTolerance);
                 var baseConfidence = (dateConfidence * 0.5 + amountConfidence * 0.5);
                 
@@ -446,8 +453,12 @@ public class ImportAnalysisService : IImportAnalysisService
                     ? ConflictSeverity.High 
                     : ConflictSeverity.Medium;
                 
-                var confidence = amountDifference == 0 
-                    ? (decimal)(1.0 - daysDifference / options.DateToleranceDays)
+                // Same DateToleranceDays == 0 guard as above: avoid dividing by zero
+                // (double.NaN) and the subsequent OverflowException on the decimal cast.
+                var confidence = amountDifference == 0
+                    ? (decimal)(options.DateToleranceDays == 0
+                        ? 1.0
+                        : 1.0 - daysDifference / options.DateToleranceDays)
                     : 0.7m;
 
                 conflicts.Add(new ConflictInfoDto

--- a/tests/MyMascada.Tests.Unit/Features/ImportReview/ImportAnalysisServiceConflictTests.cs
+++ b/tests/MyMascada.Tests.Unit/Features/ImportReview/ImportAnalysisServiceConflictTests.cs
@@ -1,0 +1,82 @@
+using NSubstitute;
+using MyMascada.Application.Common.Interfaces;
+using MyMascada.Application.Features.ImportReview.DTOs;
+using MyMascada.Application.Features.ImportReview.Services;
+using MyMascada.Domain.Entities;
+using MyMascada.Domain.Enums;
+
+namespace MyMascada.Tests.Unit.Features.ImportReview;
+
+public class ImportAnalysisServiceConflictTests
+{
+    private readonly ITransactionRepository _transactionRepository = Substitute.For<ITransactionRepository>();
+    private readonly IApplicationLogger<ImportAnalysisService> _logger = Substitute.For<IApplicationLogger<ImportAnalysisService>>();
+
+    private ImportAnalysisService CreateService() => new(_transactionRepository, _logger);
+
+    /// <summary>
+    /// Regression for the bank-sync crash "Value was either too large or too small for a
+    /// Decimal". Bank syncs run with DateToleranceDays = 0 (exact date match). When an
+    /// incoming candidate exactly matches an existing transaction on date and amount, the
+    /// confidence calculation divided daysDifference by DateToleranceDays == 0, producing
+    /// double.NaN, which threw OverflowException when cast to decimal. The analysis must
+    /// complete and flag the duplicate instead of throwing.
+    /// </summary>
+    [Fact]
+    public async Task AnalyzeImportAsync_ExactDateAndAmountMatch_WithZeroDateTolerance_DoesNotThrowAndFlagsDuplicate()
+    {
+        var accountId = 7;
+        var userId = Guid.NewGuid();
+        var date = new DateTime(2026, 07, 10, 0, 0, 0, DateTimeKind.Utc);
+
+        // Existing expense of -42.50 on the same day, with a different external id so the
+        // exact-external-id short-circuit does not apply and we reach the date/amount branch.
+        var existing = new Transaction
+        {
+            Id = 100,
+            AccountId = accountId,
+            Amount = -42.50m,
+            Description = "Existing coffee",
+            TransactionDate = date,
+            Source = TransactionSource.Manual,
+            Status = TransactionStatus.Cleared,
+            ExternalId = null
+        };
+
+        _transactionRepository
+            .GetTransactionsByDateRangeAsync(accountId, Arg.Any<DateTime>(), Arg.Any<DateTime>(), userId)
+            .Returns(new List<Transaction> { existing });
+
+        var candidate = new ImportCandidateDto
+        {
+            TempId = "c1",
+            Amount = 42.50m,           // normalized to -42.50 for an expense
+            Date = date,
+            Description = "Coffee",
+            Type = TransactionType.Expense,
+            ExternalReferenceId = "akahu-tx-abc" // differs from existing.ExternalId (null)
+        };
+
+        var request = new AnalyzeImportRequest
+        {
+            Source = "akahu",
+            AccountId = accountId,
+            UserId = userId,
+            Candidates = new List<ImportCandidateDto> { candidate },
+            Options = new ImportAnalysisOptions
+            {
+                DateToleranceDays = 0, // exact match, as the bank-sync path configures
+                AmountTolerance = 0m
+            }
+        };
+
+        var act = async () => await CreateService().AnalyzeImportAsync(request);
+
+        var result = await act.Should().NotThrowAsync();
+
+        var reviewItem = result.Subject.ReviewItems.Should().ContainSingle().Subject;
+        var conflict = reviewItem.Conflicts.Should().ContainSingle().Subject;
+        conflict.Type.Should().Be(ConflictType.PotentialDuplicate);
+        conflict.ConfidenceScore.Should().BeInRange(0m, 1m, "confidence must be a real number, not NaN/overflow");
+    }
+}


### PR DESCRIPTION
## Problem

A bank sync failed in production with:

> Sync failed: Value was either too large or too small for a Decimal.

One linked Akahu account synced fine; another failed every time.

## Root cause

Not an oversized amount — a `(decimal)NaN` cast. Bank syncs run duplicate detection with `DateToleranceDays = 0` (exact date match). In `ImportAnalysisService.DetectConflictsAsync`, when an incoming transaction exactly matches an existing one on **date and amount**:

```csharp
var dateConfidence = 1.0 - (daysDifference / options.DateToleranceDays); // ÷ 0 → double.NaN
...
var confidence = (decimal)(baseConfidence * 0.8 + similarity * 0.2);     // (decimal)NaN → OverflowException
```

`daysDifference / 0` is `NaN`, and casting `NaN` to `decimal` throws `System.OverflowException` with exactly that message. The exception propagates to `BankSyncService`, which reports `Sync failed: {message}`.

The **amount** axis immediately below was already guarded (`amountDifference == 0 ? 1.0 : ...`); the **date** axis never got the same guard. The account that failed had a transaction whose date+amount coincided with an existing (e.g. manually-entered) transaction — exactly the branch that divides by zero.

## Fix

Guard `DateToleranceDays == 0` in both the potential-duplicate and transfer-conflict branches. A zero tolerance is only reached on an exact date match, so date confidence is `1.0`.

Added a regression test (`ImportAnalysisServiceConflictTests`) that reproduces the exact-match + zero-tolerance path and asserts the analysis completes with a valid (non-NaN) confidence instead of throwing.

## Testing

- `dotnet test --filter ImportAnalysisServiceConflictTests` — passes
- Diagnosis confirmed against production logs (`BankSyncService: Bank sync failed for connection 11`, `System.OverflowException ... at System.Decimal.op_Explicit(Double value) ... ImportAnalysisService.cs:line 409`)

Backend-only change, no screenshots.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed import reviews with zero-day date tolerance that could previously fail during duplicate or transfer conflict analysis.
  * Exact date and amount matches are now correctly flagged as potential duplicates with valid confidence scores.

* **Tests**
  * Added coverage to verify zero-tolerance conflict analysis completes successfully and reports accurate results.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->